### PR TITLE
fix: truncate inline input row to terminal width

### DIFF
--- a/packages/rpiv-ask-user-question/wrapping-select.test.ts
+++ b/packages/rpiv-ask-user-question/wrapping-select.test.ts
@@ -105,6 +105,62 @@ describe("WrappingSelect.render — inline input when isOther + focused", () => 
 		const lines = s.render(narrowWidth);
 		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(narrowWidth);
 	});
+
+	// rowPrefix "❯ 1. " = 5 cols, +16 chars input, +1 col cursor = 22 cols → 2 over.
+	// Reproduces the user-reported "overflows by a column or two" symptom that crashed pi.
+	it("clips when input pushes the row just past width (off-by-one boundary)", () => {
+		const s = new WrappingSelect([{ label: "pick", isOther: true }], 1, identityTheme);
+		s.setSelectedIndex(0);
+		s.setFocused(true);
+		s.appendInput("a".repeat(16));
+		const width = 20;
+		const lines = s.render(width);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(width);
+	});
+
+	it("clips inline input row when input is much longer than width", () => {
+		const s = new WrappingSelect([{ label: "pick", isOther: true }], 1, identityTheme);
+		s.setSelectedIndex(0);
+		s.setFocused(true);
+		s.appendInput("x".repeat(200));
+		const width = 10;
+		const lines = s.render(width);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(width);
+	});
+
+	// Each 😀 is 2 cols wide, so unclipped overflow scales with grapheme width.
+	it("clips inline input row containing wide (emoji) characters", () => {
+		const s = new WrappingSelect([{ label: "pick", isOther: true }], 1, identityTheme);
+		s.setSelectedIndex(0);
+		s.setFocused(true);
+		s.appendInput("😀".repeat(30));
+		const width = 20;
+		const lines = s.render(width);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(width);
+	});
+
+	// totalItemsForNumbering=1000 → numberWidth=4 → rowPrefix "❯    1. " = 8 cols.
+	// Pins down that truncation uses full `width`, not just post-prefix contentWidth.
+	it("clips inline input row when number column inflates the prefix", () => {
+		const s = new WrappingSelect([{ label: "pick", isOther: true }], 1, identityTheme, {
+			totalItemsForNumbering: 1000,
+		});
+		s.setSelectedIndex(0);
+		s.setFocused(true);
+		s.appendInput("hello world");
+		const width = 12;
+		const lines = s.render(width);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(width);
+	});
+
+	it("renders inline input row within width when input is empty", () => {
+		const s = new WrappingSelect([{ label: "pick", isOther: true }], 1, identityTheme);
+		s.setSelectedIndex(0);
+		s.setFocused(true);
+		const width = 12;
+		const lines = s.render(width);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(width);
+	});
 });
 
 describe("WrappingSelect.render — number column padding", () => {

--- a/packages/rpiv-ask-user-question/wrapping-select.test.ts
+++ b/packages/rpiv-ask-user-question/wrapping-select.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from "@mariozechner/pi-tui";
 import { describe, expect, it } from "vitest";
 import { WrappingSelect, type WrappingSelectTheme } from "./wrapping-select.js";
 
@@ -93,6 +94,16 @@ describe("WrappingSelect.render — inline input when isOther + focused", () => 
 		const lines = s.render(40);
 		expect(lines[0]).toContain("pick");
 		expect(lines[0]).not.toContain("▌");
+	});
+
+	it("truncates inline input row to terminal width", () => {
+		const s = new WrappingSelect([{ label: "pick", isOther: true }], 1, identityTheme);
+		s.setSelectedIndex(0);
+		s.setFocused(true);
+		s.appendInput("this is a really long input that exceeds the width");
+		const narrowWidth = 20;
+		const lines = s.render(narrowWidth);
+		expect(visibleWidth(lines[0])).toBeLessThanOrEqual(narrowWidth);
 	});
 });
 

--- a/packages/rpiv-ask-user-question/wrapping-select.ts
+++ b/packages/rpiv-ask-user-question/wrapping-select.ts
@@ -1,5 +1,5 @@
 import type { Component } from "@mariozechner/pi-tui";
-import { visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 
 export interface WrappingSelectItem {
 	label: string;
@@ -127,7 +127,7 @@ export class WrappingSelect implements Component {
 		const contentWidth = Math.max(WrappingSelect.MIN_CONTENT_WIDTH, width - visibleWidth(rowPrefix));
 
 		if (this.shouldRenderAsInlineInput(item, isActive)) {
-			return [this.renderInlineInputRow(rowPrefix)];
+			return [this.renderInlineInputRow(rowPrefix, width)];
 		}
 
 		return [
@@ -147,8 +147,9 @@ export class WrappingSelect implements Component {
 		return !!item.isOther && isActive;
 	}
 
-	private renderInlineInputRow(rowPrefix: string): string {
-		return this.theme.selectedText(`${rowPrefix}${this.inputBuffer}${WrappingSelect.INPUT_CURSOR}`);
+	private renderInlineInputRow(rowPrefix: string, width: number): string {
+		const raw = `${rowPrefix}${this.inputBuffer}${WrappingSelect.INPUT_CURSOR}`;
+		return truncateToWidth(this.theme.selectedText(raw), width, "");
 	}
 
 	private renderLabelBlock(


### PR DESCRIPTION
I was getting crashes on Arch using Ghostty and pi 0.70.2. 
Turns out the "Other" free-text input in the ask_user_question selector doesn't clip long lines to the terminal width the
 other option types (labels, descriptions) do, but this one was missing. 
If you typed enough text into that input on a narrow terminal, the line would overflow by a column or two and
 pi's safety check would kill the session. The fix is to truncate that line the same way the others already do.

The test is optional, you can skip it if it's obnoxious. Cheers and thanks for making the extension.