### PR TITLE
Localize ask_user_question non-interactive error

### DIFF
--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -13,6 +13,7 @@ import {
 } from "./tool/types.js";
 import { validateQuestionnaire } from "./tool/validate-questionnaire.js";
 import type { WrappingSelectItem } from "./view/components/wrapping-select.js";
+import { initI18n, t } from "./i18n.js";
 
 const ERROR_NO_UI = "Error: UI not available (running in non-interactive mode)";
 
@@ -30,6 +31,8 @@ export function buildItemsForQuestion(question: QuestionData): WrappingSelectIte
 }
 
 export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
+	initI18n(pi);
+
 	pi.registerTool({
 		name: "ask_user_question",
 		label: "Ask User Question",
@@ -63,7 +66,7 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const typed = params as unknown as QuestionParams;
-			if (!ctx.hasUI) return buildToolResult(ERROR_NO_UI, { answers: [], cancelled: true, error: "no_ui" });
+			if (!ctx.hasUI) return buildToolResult(t("ask.error.noUi", ERROR_NO_UI), { answers: [], cancelled: true, error: "no_ui" });
 
 			const validation = validateQuestionnaire(typed);
 			if (!validation.ok) {

--- a/packages/rpiv-ask-user-question/i18n.ts
+++ b/packages/rpiv-ask-user-question/i18n.ts
@@ -1,0 +1,42 @@
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+	es: {
+		"ask.error.noUi": "Error: la interfaz no está disponible (modo no interactivo)",
+	},
+	fr: {
+		"ask.error.noUi": "Erreur : l’interface n’est pas disponible (mode non interactif)",
+	},
+	"pt-BR": {
+		"ask.error.noUi": "Erro: UI indisponível (executando em modo não interativo)",
+	},
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: { events?: { emit?: (event: string, payload: unknown) => void } }): void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", {
+		namespace: "rpiv-ask-user-question",
+		defaultLocale: "en",
+		locales: translations,
+	});
+	pi.events?.emit?.("pi-core/i18n/requestApi", {
+		onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+			const locale = api.getLocale?.();
+			if (isLocale(locale)) currentLocale = locale;
+			api.onLocaleChange?.((next) => {
+				if (isLocale(next)) currentLocale = next;
+			});
+		},
+	});
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+	const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+	return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+	return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/packages/rpiv-ask-user-question/package.json
+++ b/packages/rpiv-ask-user-question/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "ask-user-question.ts",
+    "i18n.ts",
     "index.ts",
     "LICENSE",
     "README.md",


### PR DESCRIPTION
This is a smaller follow-up after I retracted the earlier over-broad localization PR. I kept this one limited to the non-interactive/no-UI failure path only.\n\nWhat changed:\n- adds a tiny local i18n helper with English fallback\n- localizes only the ask_user_question no-UI error text\n- registers an optional pi-core i18n bundle when available\n- includes es, fr, and pt-BR strings\n\nWhat did not change:\n- no required dependency\n- English remains the default/fallback\n- question schema, option labels, result envelope, UI behavior, and validation stay untouched\n\nValidation:\n- passed: npm pack --dry-run in packages/rpiv-ask-user-question\n- partial: targeted package test run passed 384/385 tests\n- blocked/existing: ship-manifest test fails on Windows path separators for existing nested files; tarball dry-run confirms files are included\n\nIf useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.