### PR TITLE
Hide completed todos on next agent turn

### DIFF
--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Overlay UX: completed todo items now stay visible until the next agent response starts, then disappear from later overlay renders. Replay-driven lifecycle events (`session_start`, `session_compact`, `session_tree`) reset that per-overlay display memory so replayed completed items can be shown once again.
+
 ## [1.1.4] - 2026-05-03
 
 ### Added

--- a/packages/rpiv-todo/README.md
+++ b/packages/rpiv-todo/README.md
@@ -17,7 +17,7 @@ Give the model a todo list it can keep across long sessions. `rpiv-todo` adds th
 
 ## Features
 
-- **Live overlay above the editor** - see the model's plan at all times; auto-hides when empty.
+- **Live overlay above the editor** - see the model's plan at all times; completed items stay visible until the next agent response starts, then fall away; auto-hides when empty.
 - **Survives `/reload` and compaction** - tasks replay from the conversation branch, not disk.
 - **Status states** - pending, in_progress, completed, plus a deleted tombstone for audit.
 - **Dependency tracking** - `blockedBy` with cycle detection, so the model can sequence work.
@@ -111,9 +111,11 @@ Returns:
 
 ## Overlay
 
-The aboveEditor widget auto-renders whenever any non-deleted tasks exist.
-12-line collapse threshold; completed tasks drop first on overflow, pending
-tasks truncate last. Auto-hides when the list is empty.
+The aboveEditor widget auto-renders whenever any overlay-visible tasks exist.
+Completed tasks stay visible after completion until the next agent response
+starts, then disappear from later overlay renders. 12-line collapse
+threshold; completed tasks still drop first on overflow, pending tasks
+truncate last. Auto-hides when the list is empty.
 
 ## Localization
 

--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -81,17 +81,20 @@ export default function (pi: ExtensionAPI) {
 		if (ctx.hasUI) {
 			todoOverlay ??= new TodoOverlay();
 			todoOverlay.setUICtx(ctx.ui);
+			todoOverlay.resetCompletedDisplayState();
 			todoOverlay.update();
 		}
 	});
 
 	pi.on("session_compact", async (_event, ctx) => {
 		replaceState(replayFromBranch(ctx));
+		todoOverlay?.resetCompletedDisplayState();
 		todoOverlay?.update();
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
 		replaceState(replayFromBranch(ctx));
+		todoOverlay?.resetCompletedDisplayState();
 		todoOverlay?.update();
 	});
 
@@ -105,5 +108,9 @@ export default function (pi: ExtensionAPI) {
 	pi.on("tool_execution_end", async (event) => {
 		if (event.toolName !== TOOL_NAME || event.isError) return;
 		todoOverlay?.update();
+	});
+
+	pi.on("agent_start", async () => {
+		todoOverlay?.hideCompletedTasksFromPreviousTurn();
 	});
 }

--- a/packages/rpiv-todo/todo-overlay.lifecycle.test.ts
+++ b/packages/rpiv-todo/todo-overlay.lifecycle.test.ts
@@ -190,6 +190,34 @@ describe("TodoOverlay — lifecycle", () => {
 		expect(typeof setWidget.mock.calls[1][1]).toBe("function");
 	});
 
+	it("resetCompletedDisplayState() lets replayed completed tasks be shown once again", async () => {
+		const { captured } = registerTool();
+		await seed(captured, [
+			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "completed" },
+		]);
+		const overlay = new TodoOverlay();
+		const ui = makeCtx();
+		overlay.setUICtx(ui);
+		overlay.update();
+		const setWidget = ui.setWidget as ReturnType<typeof vi.fn>;
+		const factory = setWidget.mock.calls[0][1] as (
+			tui: { requestRender: () => void },
+			theme: typeof identityTheme,
+		) => { render: (w: number) => string[]; invalidate: () => void };
+		const widget = factory({ requestRender: vi.fn() }, identityTheme);
+		expect(widget.render(200).join("\n")).toContain("done");
+		overlay.hideCompletedTasksFromPreviousTurn();
+		expect(widget.render(200)).toEqual([]);
+		overlay.resetCompletedDisplayState();
+		expect(widget.render(200).join("\n")).toContain("done");
+	});
+
+	it("hideCompletedTasksFromPreviousTurn() is a no-op when nothing is pending hide", () => {
+		const overlay = new TodoOverlay();
+		expect(() => overlay.hideCompletedTasksFromPreviousTurn()).not.toThrow();
+	});
+
 	it("all-deleted todos count as empty (no widget)", async () => {
 		const { captured } = registerTool();
 		const tool = await seed(captured, [{ action: "create", subject: "a" }]);

--- a/packages/rpiv-todo/todo-overlay.render.test.ts
+++ b/packages/rpiv-todo/todo-overlay.render.test.ts
@@ -29,7 +29,7 @@ async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }
 		theme: typeof identityTheme,
 	) => { render: (w: number) => string[]; invalidate: () => void };
 	const widget = factory({ requestRender: vi.fn() }, identityTheme);
-	return { widget, tool, ui };
+	return { widget, tool, ui, overlay };
 }
 
 beforeEach(() => {
@@ -109,14 +109,17 @@ describe("TodoOverlay — per-task formatting", () => {
 		expect(line).toContain("(Doing it)");
 	});
 
-	it("completed task uses '✓' glyph", async () => {
-		const { widget } = await setup([
+	it("completed task stays visible until the next agent turn starts", async () => {
+		const { widget, overlay } = await setup([
 			{ action: "create", subject: "done" },
 			{ action: "update", id: 1, status: "completed" },
 		]);
-		const line = widget.render(200)[1];
-		expect(line).toContain("✓");
-		expect(line).toContain("done");
+		const firstRender = widget.render(200);
+		expect(firstRender[1]).toContain("✓");
+		expect(firstRender[1]).toContain("done");
+		expect(widget.render(200)[1]).toContain("done");
+		overlay.hideCompletedTasksFromPreviousTurn();
+		expect(widget.render(200)).toEqual([]);
 	});
 });
 
@@ -212,6 +215,24 @@ describe("TodoOverlay — width truncation", () => {
 			{ action: "create", subject: "a very long subject that would overflow a narrow column" },
 		]);
 		expect(() => widget.render(20)).not.toThrow();
+	});
+
+	it("drops completed tasks from counts after the next agent turn starts", async () => {
+		const { widget, overlay } = await setup([
+			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "completed" },
+			{ action: "create", subject: "next" },
+		]);
+		expect(widget.render(200).join("\n")).toContain("Todos (1/2)");
+		const secondRender = widget.render(200).join("\n");
+		expect(secondRender).toContain("Todos (1/2)");
+		expect(secondRender).toContain("next");
+		expect(secondRender).toContain("done");
+		overlay.hideCompletedTasksFromPreviousTurn();
+		const hiddenRender = widget.render(200).join("\n");
+		expect(hiddenRender).toContain("Todos (0/1)");
+		expect(hiddenRender).toContain("next");
+		expect(hiddenRender).not.toContain("done");
 	});
 
 	it("re-renders reflect live state changes without re-registering", async () => {

--- a/packages/rpiv-todo/todo-overlay.render.test.ts
+++ b/packages/rpiv-todo/todo-overlay.render.test.ts
@@ -196,6 +196,26 @@ describe("TodoOverlay — overflow collapse", () => {
 		expect(summary).toContain("2 pending");
 	});
 
+	it("hides overflowed completed tasks on the next agent turn too", async () => {
+		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
+		for (let i = 1; i <= 11; i++) actions.push({ action: "create", subject: `p${i}` });
+		for (let i = 12; i <= 16; i++) {
+			actions.push({ action: "create", subject: `c${i}` });
+			actions.push({ action: "update", id: i, status: "completed" });
+		}
+		const { widget, overlay } = await setup(actions);
+		const beforeNextTurn = widget.render(200).join("\n");
+		expect(beforeNextTurn).toContain("Todos (5/16)");
+		expect(beforeNextTurn).toContain("+6 more");
+		expect(beforeNextTurn).toContain("5 completed");
+		overlay.hideCompletedTasksFromPreviousTurn();
+		const afterNextTurn = widget.render(200).join("\n");
+		expect(afterNextTurn).toContain("Todos (0/11)");
+		expect(afterNextTurn).toContain("p11");
+		expect(afterNextTurn).not.toContain("+1 more");
+		expect(afterNextTurn).not.toContain("completed");
+	});
+
 	it("does not engage overflow at exactly 11 visible tasks", async () => {
 		// 11 tasks → all fit in 12 lines (heading + 11). No summary row.
 		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];

--- a/packages/rpiv-todo/todo-overlay.ts
+++ b/packages/rpiv-todo/todo-overlay.ts
@@ -5,7 +5,7 @@
  * registration in widgetContainerAbove, register-once + requestRender()
  * refresh, 12-line collapse-not-scroll, auto-hide when empty.
  *
- * Reads live state via `getTodos()` at render time — NEVER `replayFromBranch`
+ * Reads live state via `getState()` at render time — NEVER `replayFromBranch`
  * from `tool_execution_end` (branch is stale; `message_end` runs after).
  */
 
@@ -139,7 +139,7 @@ export class TodoOverlay {
 			lines.push(truncate(`${theme.fg("dim", "├─")} ${formatOverlayTaskLine(task, theme, showIds)}`));
 		}
 
-		const newlyDisplayedCompletedTaskIds = layout.visible
+		const newlyDisplayedCompletedTaskIds = overlayTasks
 			.filter(
 				(task) =>
 					task.status === "completed" &&

--- a/packages/rpiv-todo/todo-overlay.ts
+++ b/packages/rpiv-todo/todo-overlay.ts
@@ -12,14 +12,8 @@
 import type { ExtensionUIContext, Theme } from "@mariozechner/pi-coding-agent";
 import { type TUI, truncateToWidth } from "@mariozechner/pi-tui";
 import { formatStatusLabel, t } from "./state/i18n-bridge.js";
-import {
-	selectHasActive,
-	selectOverlayLayout,
-	selectShowTaskIds,
-	selectTodoCounts,
-	selectVisibleTasks,
-} from "./state/selectors.js";
-import { getTodos } from "./state/store.js";
+import { selectHasActive, selectOverlayLayout, selectShowTaskIds, selectTodoCounts } from "./state/selectors.js";
+import { getState } from "./state/store.js";
 import { formatOverlayTaskLine } from "./view/format.js";
 
 const WIDGET_KEY = "rpiv-todos";
@@ -33,6 +27,9 @@ export class TodoOverlay {
 	private uiCtx: ExtensionUIContext | undefined;
 	private widgetRegistered = false;
 	private tui: TUI | undefined;
+	private completedTaskIdsPendingHide = new Set<number>();
+	private hiddenCompletedTaskIds = new Set<number>();
+	private lastNextId: number | undefined;
 
 	setUICtx(ctx: ExtensionUIContext): void {
 		// Identity-compare so repeat session_start handlers are idempotent;
@@ -46,8 +43,8 @@ export class TodoOverlay {
 
 	update(): void {
 		if (!this.uiCtx) return;
-		const snapshot = { tasks: [...getTodos()], nextId: 0 };
-		const visible = selectVisibleTasks(snapshot);
+		const snapshot = this.getSnapshot();
+		const visible = this.selectOverlayTasks(snapshot);
 
 		if (visible.length === 0) {
 			if (this.widgetRegistered) {
@@ -79,15 +76,57 @@ export class TodoOverlay {
 		}
 	}
 
-	private renderWidget(theme: Theme, width: number): string[] {
-		const snapshot = { tasks: [...getTodos()], nextId: 0 };
-		const all = selectVisibleTasks(snapshot);
-		if (all.length === 0) return [];
+	resetCompletedDisplayState(): void {
+		this.completedTaskIdsPendingHide.clear();
+		this.hiddenCompletedTaskIds.clear();
+		this.lastNextId = undefined;
+	}
 
+	hideCompletedTasksFromPreviousTurn(): void {
+		if (this.completedTaskIdsPendingHide.size === 0) return;
+		for (const taskId of this.completedTaskIdsPendingHide) {
+			this.hiddenCompletedTaskIds.add(taskId);
+		}
+		this.completedTaskIdsPendingHide.clear();
+		this.tui?.requestRender();
+	}
+
+	private getSnapshot() {
+		const state = getState();
+		if (this.lastNextId !== undefined && state.nextId < this.lastNextId) {
+			this.resetCompletedDisplayState();
+		}
+		this.lastNextId = state.nextId;
+		const completedTaskIds = new Set(
+			state.tasks.filter((task) => task.status === "completed").map((task) => task.id),
+		);
+		for (const taskId of this.completedTaskIdsPendingHide) {
+			if (!completedTaskIds.has(taskId)) this.completedTaskIdsPendingHide.delete(taskId);
+		}
+		for (const taskId of this.hiddenCompletedTaskIds) {
+			if (!completedTaskIds.has(taskId)) this.hiddenCompletedTaskIds.delete(taskId);
+		}
+		return { tasks: [...state.tasks], nextId: state.nextId };
+	}
+
+	private selectOverlayTasks(snapshot: ReturnType<TodoOverlay["getSnapshot"]>) {
+		return snapshot.tasks.filter((task) => task.status !== "deleted" && !this.shouldHideCompletedTask(task));
+	}
+
+	private shouldHideCompletedTask(task: ReturnType<TodoOverlay["getSnapshot"]>["tasks"][number]): boolean {
+		return task.status === "completed" && this.hiddenCompletedTaskIds.has(task.id);
+	}
+
+	private renderWidget(theme: Theme, width: number): string[] {
+		const snapshot = this.getSnapshot();
+		const overlayTasks = this.selectOverlayTasks(snapshot);
+		if (overlayTasks.length === 0) return [];
+
+		const overlayState = { tasks: overlayTasks, nextId: snapshot.nextId };
 		const truncate = (line: string): string => truncateToWidth(line, width, "…");
-		const counts = selectTodoCounts(snapshot);
-		const hasActive = selectHasActive(snapshot);
-		const showIds = selectShowTaskIds(snapshot);
+		const counts = selectTodoCounts(overlayState);
+		const hasActive = selectHasActive(overlayState);
+		const showIds = selectShowTaskIds(overlayState);
 
 		const headingColor = hasActive ? "accent" : "dim";
 		const headingIcon = hasActive ? "●" : "○";
@@ -95,9 +134,21 @@ export class TodoOverlay {
 		const heading = truncate(`${theme.fg(headingColor, headingIcon)} ${theme.fg(headingColor, headingText)}`);
 
 		const lines: string[] = [heading];
-		const layout = selectOverlayLayout(snapshot, MAX_WIDGET_LINES - 1);
+		const layout = selectOverlayLayout(overlayState, MAX_WIDGET_LINES - 1);
 		for (const task of layout.visible) {
 			lines.push(truncate(`${theme.fg("dim", "├─")} ${formatOverlayTaskLine(task, theme, showIds)}`));
+		}
+
+		const newlyDisplayedCompletedTaskIds = layout.visible
+			.filter(
+				(task) =>
+					task.status === "completed" &&
+					!this.completedTaskIdsPendingHide.has(task.id) &&
+					!this.hiddenCompletedTaskIds.has(task.id),
+			)
+			.map((task) => task.id);
+		for (const taskId of newlyDisplayedCompletedTaskIds) {
+			this.completedTaskIdsPendingHide.add(taskId);
 		}
 
 		if (layout.hiddenCompleted === 0 && layout.truncatedTail === 0) {
@@ -122,5 +173,6 @@ export class TodoOverlay {
 		this.widgetRegistered = false;
 		this.tui = undefined;
 		this.uiCtx = undefined;
+		this.resetCompletedDisplayState();
 	}
 }


### PR DESCRIPTION
## Summary
- keep completed todo items visible through the remainder of the current assistant turn
- hide those completed items when the next agent turn starts, instead of keeping them sticky forever
- document the overlay behavior and cover it with render/lifecycle tests

## Why
Issue #8 asks for completed todo items to stop consuming screen space and cognitive load after the user has had a chance to see them. The important nuance is timing: completed items should still be visible after the assistant marks them complete, so the user can see them while reading the assistant's response and composing the next message. They should disappear only when control passes back to the agent on the next turn.

## Implementation
- keep the canonical todo state unchanged; this is UI behavior, not task-domain state
- track overlay-local ephemeral state in `packages/rpiv-todo/todo-overlay.ts`
  - completed task ids pending hide
  - hidden completed task ids
- hide completed items on `agent_start` in `packages/rpiv-todo/index.ts`
- reset the overlay-local display memory on replay-driven lifecycle events (`session_start`, `session_compact`, `session_tree`)
- update tests to verify:
  - completed items stay visible after completion
  - completed items disappear on the next agent turn
  - replay/reset paths make replayed completed items visible once again

## Validation
- `npm test -- packages/rpiv-todo`

## Intuition

### Completed todo items stay visible until the next agent response starts
<img width="792" height="414" alt="image" src="https://github.com/user-attachments/assets/6e3e0b51-63fd-4ba2-a351-846c08cd750d" />

### ...then disappear from later overlay renders
<img width="1259" height="251" alt="image" src="https://github.com/user-attachments/assets/26f96088-7f94-40bf-8dc8-38a09774bf53" />

