### PR TITLE
fix(rpiv-ask-user-question): drop ambiguous "This" guideline (#6)

### DIFF
--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -58,7 +58,7 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 			`Use ask_user_question whenever the user's request is underspecified and you cannot proceed without concrete decisions — you can ask up to ${MAX_QUESTIONS} questions per invocation.`,
 			`Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer ("Type something." row is appended automatically to single-select questions) or pick "Chat about this" to abandon the questionnaire.`,
 			`Set multiSelect: true when multiple answers are valid; this suppresses the "Type something." row. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. NOTE: any non-empty preview on a single-select question ALSO suppresses the "Type something." row (no room in the side-by-side layout); "Chat about this" remains the escape hatch. If you recommend a specific option, make it the first option and append "(Recommended)" to its label.`,
-			"This replaces the AskUserQuestion tool from Claude Code. Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
+			"Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
 		],
 		parameters: QuestionParamsSchema,
 

--- a/packages/rpiv-todo/todo.register.test.ts
+++ b/packages/rpiv-todo/todo.register.test.ts
@@ -32,7 +32,7 @@ describe("registerTodoTool — registration shape", () => {
 		const tool = captured.tools.get("todo")!;
 		expect(tool.name).toBe("todo");
 		expect(tool.label).toBe("Todo");
-		expect(tool.promptSnippet).toContain("Claude-Code-style");
+		expect(tool.promptSnippet).toContain("task list");
 		expect(Array.isArray(tool.promptGuidelines)).toBe(true);
 		expect((tool.promptGuidelines as string[]).length).toBeGreaterThan(0);
 	});

--- a/packages/rpiv-todo/todo.ts
+++ b/packages/rpiv-todo/todo.ts
@@ -67,7 +67,7 @@ export function registerTodoTool(pi: ExtensionAPI): void {
 		label: TOOL_LABEL,
 		description:
 			"Manage a task list for tracking multi-step progress. Actions: create (new task), update (change status/fields/dependencies), list (all tasks, optionally filtered by status), get (single task details), delete (tombstone), clear (reset all). Status: pending → in_progress → completed, plus deleted tombstone. Use this to plan and track multi-step work like research, design, and implementation.",
-		promptSnippet: "Manage a Claude-Code-style task list to track multi-step progress",
+		promptSnippet: "Manage a task list to track multi-step progress",
 		promptGuidelines: [
 			"Use `todo` for complex work with 3+ steps, when the user gives you a list of tasks, or immediately after receiving new instructions to capture requirements. Skip it for single trivial tasks and purely conversational requests.",
 			"When starting any task, mark it in_progress BEFORE beginning work. Mark it completed IMMEDIATELY when done — never batch completions. Exactly one task should be in_progress at a time.",


### PR DESCRIPTION
## Summary
- Drop the ambiguous `"This"`-led prompt guideline in `rpiv-ask-user-question` per [Pi extension docs](https://pi.dev/docs/latest/extensions#pi-registertool-definition) — the LLM cannot resolve which tool the pronoun refers to once guidelines are spliced into the system prompt away from any tool context.
- Remove the `"replaces the AskUserQuestion tool from Claude Code"` clause entirely while we're here — irrelevant lineage that only spends prompt-cache bytes.
- Drive-by: drop `"Claude-Code-style"` from the `rpiv-todo` `promptSnippet` for the same reason. Test updated to match.

## Why
Reported in #6. Audited the other extensions (`rpiv-advisor`, `rpiv-todo`, `rpiv-web-tools`) — only `rpiv-ask-user-question` had a `"This"`-led guideline.

## Test plan
- [x] `npm test` — all 1022 tests pass
- [x] `tsc --noEmit -p tsconfig.base.json` clean
- [x] `biome check` clean

Closes #6