### PR TITLE
fix(rpiv-args): load cross-harness skill dirs

### DIFF
--- a/packages/rpiv-args/args.test.ts
+++ b/packages/rpiv-args/args.test.ts
@@ -1,5 +1,5 @@
 /* biome-ignore-all lint/suspicious/noTemplateCurlyInString: tests contain literal "${...}" substitution tokens */
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { InputEvent } from "@earendil-works/pi-coding-agent";
@@ -16,6 +16,7 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
 
 import { type BeforeAgentStartEvent, loadSkills } from "@earendil-works/pi-coding-agent";
 import {
+	collectDefaultSkillPaths,
 	handleBeforeAgentStart,
 	handleInput,
 	invalidateSkillIndex,
@@ -132,6 +133,29 @@ describe("substituteArgs", () => {
 	});
 });
 
+describe("collectDefaultSkillPaths", () => {
+	it("includes Pi and cross-harness .agents skill dirs in precedence order", () => {
+		const repoDir = join(tmpDir, "repo");
+		const nestedDir = join(repoDir, "packages", "app");
+		const agentDir = join(tmpDir, "agent");
+		const nestedAgentsSkills = join(nestedDir, ".agents", "skills");
+		const repoAgentsSkills = join(repoDir, ".agents", "skills");
+		const userPiSkills = join(agentDir, "skills");
+		mkdirSync(join(repoDir, ".git"), { recursive: true });
+		mkdirSync(nestedAgentsSkills, { recursive: true });
+		mkdirSync(repoAgentsSkills, { recursive: true });
+		mkdirSync(userPiSkills, { recursive: true });
+
+		const paths = collectDefaultSkillPaths(nestedDir, agentDir);
+
+		expect(paths).toContain(nestedAgentsSkills);
+		expect(paths).toContain(repoAgentsSkills);
+		expect(paths).toContain(userPiSkills);
+		expect(paths.indexOf(nestedAgentsSkills)).toBeLessThan(paths.indexOf(repoAgentsSkills));
+		expect(paths.indexOf(repoAgentsSkills)).toBeLessThan(paths.indexOf(userPiSkills));
+	});
+});
+
 describe("invalidateSkillIndex — lazy memoisation", () => {
 	it("builds index once across multiple handleInput calls", () => {
 		const entries = writeSkillsDir(tmpDir, [{ name: "foo", body: "hello" }]);
@@ -148,8 +172,8 @@ describe("invalidateSkillIndex — lazy memoisation", () => {
 			expect.objectContaining({
 				cwd: expect.any(String),
 				agentDir: expect.any(String),
-				skillPaths: [],
-				includeDefaults: true,
+				skillPaths: expect.any(Array),
+				includeDefaults: false,
 			}),
 		);
 		const opts = vi.mocked(loadSkills).mock.calls[0]![0];

--- a/packages/rpiv-args/args.ts
+++ b/packages/rpiv-args/args.ts
@@ -24,7 +24,9 @@
  * template literal below.
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import {
 	type BeforeAgentStartEvent,
 	type BeforeAgentStartEventResult,
@@ -124,13 +126,62 @@ export function invalidateSkillIndex(): void {
 	skillIndex = null;
 }
 
-/** Build the name→path index by asking Pi for its currently-loaded skills. */
+function findGitRepoRoot(startDir: string): string | null {
+	let dir = resolve(startDir);
+	while (true) {
+		if (existsSync(join(dir, ".git"))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function collectAncestorAgentsSkillDirs(startDir: string): string[] {
+	const skillDirs: string[] = [];
+	const gitRepoRoot = findGitRepoRoot(startDir);
+	let dir = resolve(startDir);
+	while (true) {
+		skillDirs.push(join(dir, ".agents", "skills"));
+		if (gitRepoRoot && dir === gitRepoRoot) break;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return skillDirs;
+}
+
+function addExistingPath(paths: string[], seen: Set<string>, path: string): void {
+	const resolved = resolve(path);
+	if (!existsSync(resolved) || seen.has(resolved)) return;
+	seen.add(resolved);
+	paths.push(resolved);
+}
+
+/** Collect Pi's default skill locations in collision-precedence order. */
+export function collectDefaultSkillPaths(cwd: string, agentDir: string): string[] {
+	const paths: string[] = [];
+	const seen = new Set<string>();
+	const userAgentsSkillsDir = join(homedir(), ".agents", "skills");
+
+	addExistingPath(paths, seen, join(resolve(cwd), ".pi", "skills"));
+	for (const dir of collectAncestorAgentsSkillDirs(cwd)) {
+		if (resolve(dir) !== resolve(userAgentsSkillsDir)) addExistingPath(paths, seen, dir);
+	}
+	addExistingPath(paths, seen, join(agentDir, "skills"));
+	addExistingPath(paths, seen, userAgentsSkillsDir);
+
+	return paths;
+}
+
+/** Build the name→path index by asking Pi for its default skill locations. */
 function buildSkillIndex(): Map<string, SkillIndexEntry> {
+	const cwd = process.cwd();
+	const agentDir = getAgentDir();
 	const { skills } = loadSkills({
-		cwd: process.cwd(),
-		agentDir: getAgentDir(),
-		skillPaths: [],
-		includeDefaults: true,
+		cwd,
+		agentDir,
+		skillPaths: collectDefaultSkillPaths(cwd, agentDir),
+		includeDefaults: false,
 	});
 	const index = new Map<string, SkillIndexEntry>();
 	for (const s of skills as Skill[]) {


### PR DESCRIPTION
## Summary
- include Pi's `.agents/skills` auto-discovery locations when rpiv-args builds its skill index
- preserve collision precedence by checking project `.pi`, ancestor `.agents`, user `.pi`, then user `.agents` paths
- add coverage for nested `.agents/skills` discovery order

## Why
Pi 0.74 discovers skills from `~/.agents/skills` and ancestor `.agents/skills` directories, but rpiv-args was calling `loadSkills()` with only Pi defaults. Skills visible to Pi from cross-harness `.agents/skills` directories were therefore expanded by native Pi as raw trailing args, leaving `$1` / `$ARGUMENTS` placeholders unsubstituted.

## Verification
- `npm run check`
- `npm test`
- push hook: `npm run coverage`

## Note
This switches to an explicit path list so the index matches Pi's current skill discovery order. With that list in place, `includeDefaults: false` avoids loading the older default set a second time.

