### PR TITLE
fix(advisor): honor compacted session context

### DIFF
--- a/packages/rpiv-advisor/advisor.execute.test.ts
+++ b/packages/rpiv-advisor/advisor.execute.test.ts
@@ -16,7 +16,16 @@ vi.mock("@earendil-works/pi-ai", async (importOriginal) => {
 	};
 });
 
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+	return {
+		...actual,
+		buildSessionContext: vi.fn(),
+	};
+});
+
 import { completeSimple } from "@earendil-works/pi-ai";
+import { buildSessionContext } from "@earendil-works/pi-coding-agent";
 import { registerAdvisorTool, setAdvisorModel } from "./advisor.js";
 
 function resp(input: { text?: string; stopReason?: "done" | "aborted" | "error" | "toolUse"; errorMessage?: string }) {
@@ -31,6 +40,16 @@ function resp(input: { text?: string; stopReason?: "done" | "aborted" | "error" 
 
 beforeEach(() => {
 	vi.mocked(completeSimple).mockReset();
+	vi.mocked(buildSessionContext).mockImplementation(
+		(entries) =>
+			({
+				messages: ((entries ?? []) as { type?: string; message?: unknown }[])
+					.filter((e) => e?.type === "message")
+					.map((e) => (e as { message: unknown }).message),
+				thinkingLevel: "off",
+				model: null,
+			}) as ReturnType<typeof buildSessionContext>,
+	);
 });
 
 describe("executeAdvisor — 4 StopReason branches", () => {
@@ -45,6 +64,43 @@ describe("executeAdvisor — 4 StopReason branches", () => {
 		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
 		expect(r?.content[0]).toMatchObject({ type: "text", text: "advice" });
 		expect(r?.details).toMatchObject({ advisorModel: "a:m" });
+	});
+
+	it("uses compacted session context instead of raw branch messages", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		vi.mocked(completeSimple).mockResolvedValueOnce(resp({ text: "advice" }) as never);
+		vi.mocked(buildSessionContext).mockReturnValueOnce({
+			messages: [
+				{
+					role: "compactionSummary",
+					summary: "COMPACTED SUMMARY OF EARLIER WORK",
+					tokensBefore: 12345,
+					timestamp: Date.now(),
+				},
+				makeUserMessage("kept user message"),
+				makeAssistantMessage({ text: "post-compaction assistant" }),
+			],
+			thinkingLevel: "off",
+			model: null,
+		} as ReturnType<typeof buildSessionContext>);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx({
+			branch: buildSessionEntries([
+				makeUserMessage("OLD RAW PRE-COMPACTION DETAIL"),
+				makeAssistantMessage({ text: "old raw assistant detail" }),
+			]),
+		});
+
+		await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+
+		const payload = vi.mocked(completeSimple).mock.calls[0]?.[1] as { messages?: unknown[] };
+		const serialized = JSON.stringify(payload.messages);
+		expect(serialized).toContain("COMPACTED SUMMARY OF EARLIER WORK");
+		expect(serialized).toContain("kept user message");
+		expect(serialized).toContain("post-compaction assistant");
+		expect(serialized).not.toContain("OLD RAW PRE-COMPACTION DETAIL");
+		expect(serialized).not.toContain("old raw assistant detail");
 	});
 
 	it("aborted stopReason returns cancel envelope", async () => {

--- a/packages/rpiv-advisor/advisor.ts
+++ b/packages/rpiv-advisor/advisor.ts
@@ -22,10 +22,10 @@ import { completeSimple, getSupportedThinkingLevels, type Message, type Thinking
 import {
 	type AgentToolResult,
 	type AgentToolUpdateCallback,
+	buildSessionContext,
 	convertToLlm,
 	type ExtensionAPI,
 	type ExtensionContext,
-	type SessionEntry,
 	type ToolInfo,
 } from "@earendil-works/pi-coding-agent";
 import type { SelectItem } from "@earendil-works/pi-tui";
@@ -377,14 +377,16 @@ async function executeAdvisor(
 	}
 
 	// Live-read every call — advisor runs mid-turn so any message_end snapshot
-	// is always one turn stale. convertToLlm is pass-through for user/assistant/
-	// toolResult (messages.js:111-114), so element refs are stable across calls
-	// via the session store — content-stable output without a snapshot layer.
-	const branch = ctx.sessionManager.getBranch();
-	const agentMessages = branch
-		.filter((e): e is SessionEntry & { type: "message" } => e.type === "message")
-		.map((e) => e.message);
-	const branchMessages = ensureUserTailForAdvisor(stripInflightAdvisorCall(convertToLlm(agentMessages)));
+	// is always one turn stale. buildSessionContext() preserves Pi's resolved
+	// LLM context, including compaction summaries and branch summaries, instead
+	// of replaying raw pre-compaction branch messages. convertToLlm is
+	// pass-through for user/assistant/toolResult (messages.js:111-114), so
+	// element refs are stable across calls via the session store.
+	const { messages: sessionMessages } = buildSessionContext(
+		ctx.sessionManager.getEntries(),
+		ctx.sessionManager.getLeafId(),
+	);
+	const branchMessages = ensureUserTailForAdvisor(stripInflightAdvisorCall(convertToLlm(sessionMessages)));
 	const inventoryMessage = getInventoryMessage(pi.getAllTools());
 	const messages: Message[] = inventoryMessage ? [inventoryMessage, ...branchMessages] : branchMessages;
 

--- a/packages/test-utils/pi.ts
+++ b/packages/test-utils/pi.ts
@@ -96,6 +96,8 @@ export function createMockUI(overrides: Partial<ExtensionUIContext> = {}): MockU
 export function createMockSessionManager(branch: SessionEntry[] = []) {
 	return {
 		getBranch: vi.fn(() => branch),
+		getEntries: vi.fn(() => branch),
+		getLeafId: vi.fn(() => (branch.length ? branch[branch.length - 1].id : null)),
 		getSessionFile: vi.fn(() => "/tmp/test-session.jsonl"),
 		getSessionId: vi.fn(() => "test-session"),
 	};


### PR DESCRIPTION
## Summary
- build advisor payload from Pi's resolved session context instead of raw branch message entries
- preserve inventory prepending, in-flight advisor call stripping, and user-tail normalization
- add regression coverage for compacted sessions so advisor sees the compaction summary rather than fully summarized raw history

## Tests
- npm run check
- npx vitest run packages/rpiv-advisor