### PR TITLE
feat: add Chinese (zh) localization support

### DIFF
--- a/packages/rpiv-ask-user-question/index.ts
+++ b/packages/rpiv-ask-user-question/index.ts
@@ -56,6 +56,7 @@ try {
 		pt: loadLocale("pt"),
 		"pt-BR": loadLocale("pt-BR"),
 		ru: loadLocale("ru"),
+		zh: loadLocale("zh"),
 		uk: loadLocale("uk"),
 	});
 } catch {

--- a/packages/rpiv-ask-user-question/locales/zh.json
+++ b/packages/rpiv-ask-user-question/locales/zh.json
@@ -1,0 +1,25 @@
+{
+  "sentinel.other": "输入内容",
+  "sentinel.chat": "聊聊这个",
+  "sentinel.next": "下一个",
+
+  "submit.label": "提交答案",
+  "submit.cancel": "取消",
+
+  "hint.enter": "回车选择",
+  "hint.navigate": "↑/↓ 导航",
+  "hint.toggle": "空格切换",
+  "hint.notes": "按 n 添加备注",
+  "hint.tab": "Tab 切换问题",
+  "hint.cancel": "Esc 取消",
+
+  "review.heading": "检查你的答案",
+  "review.ready": "准备提交答案了吗？",
+  "review.incomplete": "⚠ 提交前请先回答以下问题：",
+
+  "preview.no_preview": "暂无预览",
+  "preview.notes_affordance": "备注：按 n 添加",
+
+  "chat.summary": "用户想聊聊这个话题",
+  "notes.header": "备注："
+}

--- a/packages/rpiv-i18n/i18n.ts
+++ b/packages/rpiv-i18n/i18n.ts
@@ -67,6 +67,7 @@ export const SUPPORTED_LOCALES: readonly { code: string; label: string }[] = [
 	{ code: "pt-BR", label: "Português (Brasil)" },
 	{ code: "ru", label: "Русский" },
 	{ code: "uk", label: "Українська" },
+	{ code: "zh", label: "中文" },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Add Chinese (Simplified) localization for rpiv-ask-user-question and register it in the i18n SDK.

## Changes
- Added `locales/zh.json` with 18 Chinese UI strings
- Registered Chinese locale in `packages/rpiv-ask-user-question/index.ts`
- Added Chinese to `SUPPORTED_LOCALES` in `packages/rpiv-i18n/i18n.ts`

## Motivation
Chinese is widely used but not yet supported. This addition allows Chinese-speaking users to use Pi Agent with a localized interface.

## Testing
- Verified all 18 translation keys match the English schema
- JSON syntax validated

| Key | English | Chinese |
|-----|---------|---------|
| sentinel.other | Type something. | 输入内容 |
| sentinel.chat | Chat about this | 聊聊这个 |
| submit.label | Submit answers | 提交答案 |
| ... | ... | ... |

