### PR TITLE
fix(rpiv-pi): let web researcher load extension tools

### DIFF
--- a/packages/rpiv-pi/agents/web-search-researcher.md
+++ b/packages/rpiv-pi/agents/web-search-researcher.md
@@ -2,7 +2,6 @@
 name: web-search-researcher
 description: Do you find yourself desiring information that you don't quite feel well-trained (confident) on? Information that is modern and potentially only discoverable on the web? Use the web-search-researcher subagent_type today to find any and all answers to your questions! It will research deeply to figure out and attempt to answer your questions! If you aren't immediately satisfied you can get your money back! (Not really - but you can re-run web-search-researcher with an altered prompt in the event you're not satisfied the first time)
 tools: web_search, web_fetch, read, grep, find, ls
-isolated: true
 ---
 
 You are an expert web research specialist focused on finding accurate, relevant information from web sources. Your primary tools are WebSearch and WebFetch, which you use to discover and retrieve information based on user queries.


### PR DESCRIPTION
## Summary
- Fixes web-search-researcher disabling extension-provided web tools by removing isolated: true.
- Applies to existing rpiv-web-tools users too.
- Keeps PR minimal and independent from pi-web-access support.

## Testing
- npm test --workspace packages/rpiv-pi (blocked: vitest: command not found)