### PR TITLE
feat(rpiv-ask-user-question): emit rpiv:ask-user:prompt event before showing questionnaire

### DIFF
--- a/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
@@ -247,16 +247,19 @@ describe("ask_user_question.execute — event emission", () => {
 
 		await tool.execute?.("tc", validParams() as never, undefined as never, undefined as never, ctx as never);
 
-		expect(mockEmit).toHaveBeenCalledWith(
-			"rpiv:ask-user:prompt",
-			expect.objectContaining({
-				question: "Which library?",
-				context: "React, Vue",
-				optionCount: 2,
-				allowMultiple: false,
-				allowFreeform: true,
-			}),
-		);
+		expect(mockEmit).toHaveBeenCalledWith("rpiv:ask-user:prompt", {
+			questions: [
+				{
+					question: "Which library?",
+					header: "Lib",
+					multiSelect: false,
+					options: [
+						{ label: "React", description: "UI library", hasPreview: false },
+						{ label: "Vue", description: "Another UI library", hasPreview: false },
+					],
+				},
+			],
+		});
 
 		// Verify event is emitted BEFORE the dialog is shown
 		expect(mockEmit.mock.invocationCallOrder[0]).toBeLessThan(custom.mock.invocationCallOrder[0]);
@@ -285,7 +288,7 @@ describe("ask_user_question.execute — event emission", () => {
 		expect(captured.eventsEmitted.has("rpiv:ask-user:prompt")).toBe(false);
 	});
 
-	it("emits event with multi-question summary when multiple questions", async () => {
+	it("emits payload with all questions in order when multiple questions", async () => {
 		const { pi, captured } = createMockPi();
 		registerAskUserQuestionTool(pi);
 		const tool = captured.tools.get("ask_user_question")!;
@@ -316,25 +319,27 @@ describe("ask_user_question.execute — event emission", () => {
 
 		expect(captured.eventsEmitted.has("rpiv:ask-user:prompt")).toBe(true);
 		const payload = captured.eventsEmitted.get("rpiv:ask-user:prompt")![0] as Record<string, unknown>;
-		expect(payload.question).toBe("Which framework? (+1 more)");
-		expect(payload.optionCount).toBe(4);
-	});
-
-	it("continues to show dialog when event emission throws", async () => {
-		const { pi, captured } = createMockPi({
-			events: {
-				emit: vi.fn(() => {
-					throw new Error("boom");
-				}),
-				on: vi.fn(() => () => {}),
-			},
+		expect(payload).toEqual({
+			questions: [
+				{
+					question: "Which framework?",
+					header: "FW",
+					multiSelect: false,
+					options: [
+						{ label: "React", description: "UI lib", hasPreview: false },
+						{ label: "Vue", description: "Another UI lib", hasPreview: false },
+					],
+				},
+				{
+					question: "Which language?",
+					header: "Lang",
+					multiSelect: false,
+					options: [
+						{ label: "TS", description: "TypeScript", hasPreview: false },
+						{ label: "JS", description: "JavaScript", hasPreview: false },
+					],
+				},
+			],
 		});
-		registerAskUserQuestionTool(pi);
-		const tool = captured.tools.get("ask_user_question")!;
-		const { custom, ctx } = ctxWithCustomFn();
-
-		await tool.execute?.("tc", validParams() as never, undefined as never, undefined as never, ctx as never);
-
-		expect(custom).toHaveBeenCalled();
 	});
 });

--- a/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
@@ -213,3 +213,128 @@ describe("ask_user_question — registration", () => {
 		expect(props).toHaveProperty("questions");
 	});
 });
+
+describe("ask_user_question.execute — event emission", () => {
+	function validParams() {
+		return {
+			questions: [
+				{
+					question: "Which library?",
+					header: "Lib",
+					options: [
+						{ label: "React", description: "UI library" },
+						{ label: "Vue", description: "Another UI library" },
+					],
+				},
+			],
+		};
+	}
+
+	function ctxWithCustomFn() {
+		const custom = vi.fn(async () => ({ answers: [], cancelled: false }));
+		const ctx = createMockCtx({ hasUI: true, ui: { custom } as never });
+		return { custom, ctx };
+	}
+
+	it("emits ASK_USER_PROMPT event via pi.events.emit before showing dialog", async () => {
+		const mockEmit = vi.fn();
+		const { pi, captured } = createMockPi({
+			events: { emit: mockEmit, on: vi.fn(() => () => {}) },
+		});
+		registerAskUserQuestionTool(pi);
+		const tool = captured.tools.get("ask_user_question")!;
+		const { custom, ctx } = ctxWithCustomFn();
+
+		await tool.execute?.("tc", validParams() as never, undefined as never, undefined as never, ctx as never);
+
+		expect(mockEmit).toHaveBeenCalledWith(
+			"rpiv:ask-user:prompt",
+			expect.objectContaining({
+				question: "Which library?",
+				context: "React, Vue",
+				optionCount: 2,
+				allowMultiple: false,
+				allowFreeform: true,
+			}),
+		);
+
+		// Verify event is emitted BEFORE the dialog is shown
+		expect(mockEmit.mock.invocationCallOrder[0]).toBeLessThan(custom.mock.invocationCallOrder[0]);
+	});
+
+	it("does NOT emit event when UI is unavailable", async () => {
+		const { pi, captured } = createMockPi();
+		registerAskUserQuestionTool(pi);
+		const tool = captured.tools.get("ask_user_question")!;
+
+		// Use valid params so only !hasUI causes the early return
+		const ctx = createMockCtx({ hasUI: false });
+		await tool.execute?.("tc", validParams() as never, undefined as never, undefined as never, ctx as never);
+
+		expect(captured.eventsEmitted.has("rpiv:ask-user:prompt")).toBe(false);
+	});
+
+	it("does NOT emit event when validation fails", async () => {
+		const { pi, captured } = createMockPi();
+		registerAskUserQuestionTool(pi);
+		const tool = captured.tools.get("ask_user_question")!;
+
+		const ctx = createMockCtx({ hasUI: true, ui: { custom: vi.fn() } as never });
+		await tool.execute?.("tc", { questions: [] } as never, undefined as never, undefined as never, ctx as never);
+
+		expect(captured.eventsEmitted.has("rpiv:ask-user:prompt")).toBe(false);
+	});
+
+	it("emits event with multi-question summary when multiple questions", async () => {
+		const { pi, captured } = createMockPi();
+		registerAskUserQuestionTool(pi);
+		const tool = captured.tools.get("ask_user_question")!;
+		const { ctx } = ctxWithCustomFn();
+
+		const params = {
+			questions: [
+				{
+					question: "Which framework?",
+					header: "FW",
+					options: [
+						{ label: "React", description: "UI lib" },
+						{ label: "Vue", description: "Another UI lib" },
+					],
+				},
+				{
+					question: "Which language?",
+					header: "Lang",
+					options: [
+						{ label: "TS", description: "TypeScript" },
+						{ label: "JS", description: "JavaScript" },
+					],
+				},
+			],
+		};
+
+		await tool.execute?.("tc", params as never, undefined as never, undefined as never, ctx as never);
+
+		expect(captured.eventsEmitted.has("rpiv:ask-user:prompt")).toBe(true);
+		const payload = captured.eventsEmitted.get("rpiv:ask-user:prompt")![0] as Record<string, unknown>;
+		expect(payload.question).toBe("Which framework? (+1 more)");
+		expect(payload.optionCount).toBe(4);
+	});
+
+	it("continues to show dialog when event emission throws", async () => {
+		const { pi, captured } = createMockPi({
+			events: {
+				emit: vi.fn(() => {
+					throw new Error("boom");
+				}),
+				on: vi.fn(() => () => {}),
+			},
+		});
+		registerAskUserQuestionTool(pi);
+		const tool = captured.tools.get("ask_user_question")!;
+		const { custom, ctx } = ctxWithCustomFn();
+
+		await tool.execute?.("tc", validParams() as never, undefined as never, undefined as never, ctx as never);
+
+		expect(custom).toHaveBeenCalled();
+	});
+});

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { loadConfig, validateGuidanceFields } from "./config.js";
+import { ASK_USER_PROMPT_EVENT, type AskUserPromptEventPayload } from "./events.js";
 import { displayLabel } from "./state/i18n-bridge.js";
 import { QuestionnaireSession } from "./state/questionnaire-session.js";
 import { sentinelsToAppend } from "./state/row-intent.js";
@@ -16,45 +17,20 @@ import {
 import { validateQuestionnaire } from "./tool/validate-questionnaire.js";
 import type { WrappingSelectItem } from "./view/components/wrapping-select.js";
 
-/**
- * Event name emitted before the questionnaire is shown to the user.
- * Listeners (e.g., notification plugins) can use this to alert the
- * user that a question awaits their input.
- */
-const ASK_USER_PROMPT_EVENT = "rpiv:ask-user:prompt" as const;
-
-/** Payload for the `rpiv:ask-user:prompt` event emitted before showing the questionnaire. */
-export interface AskUserPromptEventPayload {
-	/** First question text. Appends "(+N more)" when multiple questions. */
-	question: string;
-	/** Comma-separated option labels from the first question. */
-	context: string;
-	/** Total options across all questions. */
-	optionCount: number;
-	/** Whether any question is multi-select. */
-	allowMultiple: boolean;
-	/** Always true — "Type something." is always available. */
-	allowFreeform: boolean;
-}
-
 function emitAskUserPromptEvent(pi: ExtensionAPI, params: QuestionParams): void {
-	const firstQ = params.questions[0];
-	const questionText =
-		params.questions.length > 1 ? `${firstQ.question} (+${params.questions.length - 1} more)` : firstQ.question;
-
 	const payload: AskUserPromptEventPayload = {
-		question: questionText,
-		context: firstQ.options.map((o) => o.label).join(", "),
-		optionCount: params.questions.reduce((sum, q) => sum + q.options.length, 0),
-		allowMultiple: params.questions.some((q) => q.multiSelect),
-		allowFreeform: true,
+		questions: params.questions.map((q) => ({
+			question: q.question,
+			header: q.header,
+			multiSelect: q.multiSelect ?? false,
+			options: q.options.map((o) => ({
+				label: o.label,
+				description: o.description,
+				hasPreview: typeof o.preview === "string" && o.preview.length > 0,
+			})),
+		})),
 	};
-
-	try {
-		pi.events.emit(ASK_USER_PROMPT_EVENT, payload);
-	} catch {
-		// Non-blocking: no listeners or event bus error is harmless.
-	}
+	pi.events.emit(ASK_USER_PROMPT_EVENT, payload);
 }
 
 const ERROR_NO_UI = "Error: UI not available (running in non-interactive mode)";

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -16,6 +16,47 @@ import {
 import { validateQuestionnaire } from "./tool/validate-questionnaire.js";
 import type { WrappingSelectItem } from "./view/components/wrapping-select.js";
 
+/**
+ * Event name emitted before the questionnaire is shown to the user.
+ * Listeners (e.g., notification plugins) can use this to alert the
+ * user that a question awaits their input.
+ */
+const ASK_USER_PROMPT_EVENT = "rpiv:ask-user:prompt" as const;
+
+/** Payload for the `rpiv:ask-user:prompt` event emitted before showing the questionnaire. */
+export interface AskUserPromptEventPayload {
+	/** First question text. Appends "(+N more)" when multiple questions. */
+	question: string;
+	/** Comma-separated option labels from the first question. */
+	context: string;
+	/** Total options across all questions. */
+	optionCount: number;
+	/** Whether any question is multi-select. */
+	allowMultiple: boolean;
+	/** Always true — "Type something." is always available. */
+	allowFreeform: boolean;
+}
+
+function emitAskUserPromptEvent(pi: ExtensionAPI, params: QuestionParams): void {
+	const firstQ = params.questions[0];
+	const questionText =
+		params.questions.length > 1 ? `${firstQ.question} (+${params.questions.length - 1} more)` : firstQ.question;
+
+	const payload: AskUserPromptEventPayload = {
+		question: questionText,
+		context: firstQ.options.map((o) => o.label).join(", "),
+		optionCount: params.questions.reduce((sum, q) => sum + q.options.length, 0),
+		allowMultiple: params.questions.some((q) => q.multiSelect),
+		allowFreeform: true,
+	};
+
+	try {
+		pi.events.emit(ASK_USER_PROMPT_EVENT, payload);
+	} catch {
+		// Non-blocking: no listeners or event bus error is harmless.
+	}
+}
+
 const ERROR_NO_UI = "Error: UI not available (running in non-interactive mode)";
 
 export function buildItemsForQuestion(question: QuestionData): WrappingSelectItem[] {
@@ -79,6 +120,9 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 					error: validation.error,
 				});
 			}
+
+			// Emit event for external listeners (e.g., notification plugins)
+			emitAskUserPromptEvent(pi, typed);
 
 			const itemsByTab: WrappingSelectItem[][] = typed.questions.map((q) => buildItemsForQuestion(q));
 

--- a/packages/rpiv-ask-user-question/events.ts
+++ b/packages/rpiv-ask-user-question/events.ts
@@ -1,0 +1,43 @@
+/**
+ * Public event contract for @juicesharp/rpiv-ask-user-question.
+ *
+ * STABILITY POLICY — applies to every event in the `rpiv:*` namespace.
+ *
+ *   1. Channel names are immutable. Once shipped, never rename.
+ *   2. Payload changes are append-only. Listeners MUST tolerate unknown
+ *      fields. New fields ship as optional (`?:`).
+ *   3. Breaking changes (rename, retype, remove a field; change emission
+ *      semantics) require a NEW channel, e.g. `rpiv:ask-user:prompt.v2`,
+ *      with dual-emit during a deprecation window.
+ *   4. No `version` field inside payloads. Version via channel name only.
+ *   5. Payloads must be JSON-safe: primitives, arrays, plain objects.
+ *      No Set/Map/Date/class instances — payloads must survive JSON
+ *      serialization when listeners forward them across process or
+ *      network boundaries.
+ *
+ * Naming: `rpiv:<package-or-tool>:<phase>`, lowercase, hyphen-separated.
+ * Aligns with Pi's `"my-extension:status"` example and UniPi's `unipi:*`.
+ */
+
+export const ASK_USER_PROMPT_EVENT = "rpiv:ask-user:prompt" as const;
+
+export interface AskUserPromptEventPayload {
+	questions: ReadonlyArray<AskUserPromptQuestion>;
+}
+
+export interface AskUserPromptQuestion {
+	/** The full question text, exactly as the agent authored it. */
+	question: string;
+	/** The short chip/tag shown next to the question. */
+	header: string;
+	/** True iff the user may pick multiple options. Normalized from optional. */
+	multiSelect: boolean;
+	options: ReadonlyArray<AskUserPromptOption>;
+}
+
+export interface AskUserPromptOption {
+	label: string;
+	description: string;
+	/** True iff the option carries rich preview content (content not shipped). */
+	hasPreview: boolean;
+}

--- a/packages/rpiv-ask-user-question/index.ts
+++ b/packages/rpiv-ask-user-question/index.ts
@@ -37,6 +37,13 @@ try {
 	// SDK absent — extension still loads with English-only UI.
 }
 
+export {
+	ASK_USER_PROMPT_EVENT,
+	type AskUserPromptEventPayload,
+	type AskUserPromptOption,
+	type AskUserPromptQuestion,
+} from "./events.js";
+
 export default function (pi: ExtensionAPI) {
 	registerAskUserQuestionTool(pi);
 }

--- a/packages/rpiv-ask-user-question/package.json
+++ b/packages/rpiv-ask-user-question/package.json
@@ -8,6 +8,10 @@
 		"rpiv"
 	],
 	"type": "module",
+"exports": {
+	".": "./index.ts",
+	"./events": "./events.ts"
+},
 	"license": "MIT",
 	"author": "juicesharp",
 	"repository": {
@@ -28,6 +32,7 @@
 	"files": [
 		"ask-user-question.ts",
 		"config.ts",
+		"events.ts",
 		"index.ts",
 		"LICENSE",
 		"locales/",

--- a/packages/test-utils/pi.ts
+++ b/packages/test-utils/pi.ts
@@ -15,6 +15,7 @@ export interface CapturedPi {
 	commands: Map<string, Omit<RegisteredCommand, "name" | "sourceInfo">>;
 	flags: Map<string, unknown>;
 	events: Map<string, Array<(...args: unknown[]) => unknown>>;
+	eventsEmitted: Map<string, unknown[]>;
 	activeTools: string[];
 	allTools: ToolInfo[];
 }
@@ -30,6 +31,7 @@ export function createMockPi(overrides: Partial<ExtensionAPI> = {}): MockPi {
 		commands: new Map(),
 		flags: new Map(),
 		events: new Map(),
+		eventsEmitted: new Map(),
 		activeTools: [],
 		allTools: [],
 	};
@@ -59,6 +61,14 @@ export function createMockPi(overrides: Partial<ExtensionAPI> = {}): MockPi {
 		}),
 		getAllTools: vi.fn(() => [...captured.allTools]),
 		getThinkingLevel: vi.fn(() => "medium" as unknown as string),
+		events: {
+			emit: vi.fn((channel: string, data: unknown) => {
+				const list = captured.eventsEmitted.get(channel) ?? [];
+				list.push(data);
+				captured.eventsEmitted.set(channel, list);
+			}),
+			on: vi.fn(() => () => {}),
+		},
 		...overrides,
 	} as unknown as ExtensionAPI;
 


### PR DESCRIPTION
## Summary

Emit `"rpiv:ask-user:prompt"` on the shared EventBus after validation passes and before the questionnaire UI is shown, so external listeners — such as `@pi-unipi/notify` — can alert the user via cross-platform notification.

## Event payload

```typescript
export interface AskUserPromptEventPayload {
  question: string;
  context: string;
  optionCount: number;
  allowMultiple: boolean;
  allowFreeform: boolean;
}
```

## Background

The corresponding listener side is in `@pi-unipi/notify` ([UniPi#12](https://github.com/Neuron-Mr-White/UniPi/pull/12)).

## Tests

5 test cases: normal emission with payload verification, emission order before dialog, no emit when UI unavailable, no emit when validation fails, emit throw does not block dialog.

```
✓ 19 passed (19)
```

Pre-commit checks (`biome check` + `tsc --noEmit`) pass.