### PR TITLE
fix(rpiv-pi): honor PI_CODING_AGENT_DIR for settings

### DIFF
--- a/packages/rpiv-pi/CHANGELOG.md
+++ b/packages/rpiv-pi/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Sibling package detection and `/rpiv-setup` legacy pruning now honor
+  `PI_CODING_AGENT_DIR` instead of always reading `~/.pi/agent/settings.json`.
+
 ## [1.12.0] - 2026-05-21
 
 ## [1.11.0] - 2026-05-20

--- a/packages/rpiv-pi/extensions/rpiv-core/package-checks.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/package-checks.test.ts
@@ -3,12 +3,12 @@ import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { findMissingSiblings } from "./package-checks.js";
 import { SIBLINGS } from "./siblings.js";
-
-const SETTINGS_PATH = join(process.env.HOME!, ".pi", "agent", "settings.json");
+import { getPiAgentSettingsPath } from "./utils.js";
 
 function writeSettings(contents: unknown) {
-	mkdirSync(dirname(SETTINGS_PATH), { recursive: true });
-	writeFileSync(SETTINGS_PATH, JSON.stringify(contents), "utf-8");
+	const settingsPath = getPiAgentSettingsPath();
+	mkdirSync(dirname(settingsPath), { recursive: true });
+	writeFileSync(settingsPath, JSON.stringify(contents), "utf-8");
 }
 
 describe("findMissingSiblings", () => {
@@ -17,8 +17,9 @@ describe("findMissingSiblings", () => {
 	});
 
 	it("returns all 7 siblings when JSON is invalid", () => {
-		mkdirSync(dirname(SETTINGS_PATH), { recursive: true });
-		writeFileSync(SETTINGS_PATH, "{not json", "utf-8");
+		const settingsPath = getPiAgentSettingsPath();
+		mkdirSync(dirname(settingsPath), { recursive: true });
+		writeFileSync(settingsPath, "{not json", "utf-8");
 		expect(findMissingSiblings()).toHaveLength(SIBLINGS.length);
 	});
 
@@ -51,6 +52,14 @@ describe("findMissingSiblings", () => {
 	});
 
 	it("returns [] when all 7 siblings are installed", () => {
+		writeSettings({
+			packages: SIBLINGS.map((s) => s.pkg.replace(/^npm:/, "")),
+		});
+		expect(findMissingSiblings()).toEqual([]);
+	});
+
+	it("reads settings from PI_CODING_AGENT_DIR when configured", () => {
+		process.env.PI_CODING_AGENT_DIR = join(process.env.HOME!, ".config", "pi", "agent");
 		writeSettings({
 			packages: SIBLINGS.map((s) => s.pkg.replace(/^npm:/, "")),
 		});

--- a/packages/rpiv-pi/extensions/rpiv-core/package-checks.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/package-checks.ts
@@ -1,5 +1,5 @@
 /**
- * Detect which SIBLINGS are installed by reading ~/.pi/agent/settings.json.
+ * Detect which SIBLINGS are installed by reading the active Pi settings file.
  * Pure utility — no ExtensionAPI.
  */
 
@@ -8,7 +8,7 @@ import { readPiAgentSettings } from "./utils.js";
 
 /**
  * Return the SIBLINGS not currently installed.
- * Reads ~/.pi/agent/settings.json once per call — callers that need both the
+ * Reads the active Pi settings file once per call — callers that need both the
  * full snapshot and the missing subset should call this once and filter.
  */
 export function findMissingSiblings(): SiblingPlugin[] {

--- a/packages/rpiv-pi/extensions/rpiv-core/prune-legacy-siblings.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/prune-legacy-siblings.test.ts
@@ -2,16 +2,24 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { findLegacySiblings, pruneLegacySiblings } from "./prune-legacy-siblings.js";
+import { getPiAgentSettingsPath } from "./utils.js";
 
-const SETTINGS_PATH = join(process.env.HOME!, ".pi", "agent", "settings.json");
+function writeSettingsRaw(raw: string): void {
+	const settingsPath = getPiAgentSettingsPath();
+	mkdirSync(dirname(settingsPath), { recursive: true });
+	writeFileSync(settingsPath, raw, "utf-8");
+}
 
 function writeSettings(contents: unknown): void {
-	mkdirSync(dirname(SETTINGS_PATH), { recursive: true });
-	writeFileSync(SETTINGS_PATH, JSON.stringify(contents), "utf-8");
+	writeSettingsRaw(JSON.stringify(contents));
+}
+
+function readSettingsRaw(): string {
+	return readFileSync(getPiAgentSettingsPath(), "utf-8");
 }
 
 function readSettings(): unknown {
-	return JSON.parse(readFileSync(SETTINGS_PATH, "utf-8"));
+	return JSON.parse(readSettingsRaw());
 }
 
 describe("pruneLegacySiblings", () => {
@@ -20,10 +28,9 @@ describe("pruneLegacySiblings", () => {
 	});
 
 	it("invalid JSON → pruned: [], file byte-exact unchanged", () => {
-		mkdirSync(dirname(SETTINGS_PATH), { recursive: true });
-		writeFileSync(SETTINGS_PATH, "{not json", "utf-8");
+		writeSettingsRaw("{not json");
 		expect(pruneLegacySiblings()).toEqual({ pruned: [] });
-		expect(readFileSync(SETTINGS_PATH, "utf-8")).toBe("{not json");
+		expect(readSettingsRaw()).toBe("{not json");
 	});
 
 	it("non-object top-level (array) → pruned: [], file unchanged", () => {
@@ -47,9 +54,9 @@ describe("pruneLegacySiblings", () => {
 		writeSettings({
 			packages: ["npm:pi-perplexity", "npm:@juicesharp/rpiv-todo", "npm:@tintinweb/pi-subagents"],
 		});
-		const before = readFileSync(SETTINGS_PATH, "utf-8");
+		const before = readSettingsRaw();
 		expect(pruneLegacySiblings()).toEqual({ pruned: [] });
-		expect(readFileSync(SETTINGS_PATH, "utf-8")).toBe(before);
+		expect(readSettingsRaw()).toBe(before);
 	});
 
 	it("legacy-only: removes pi-subagents (nicobailon fork), preserves other top-level keys", () => {
@@ -93,6 +100,15 @@ describe("pruneLegacySiblings", () => {
 		});
 	});
 
+	it("prunes settings from PI_CODING_AGENT_DIR when configured", () => {
+		process.env.PI_CODING_AGENT_DIR = join(process.env.HOME!, ".config", "pi", "agent");
+		writeSettings({
+			packages: ["npm:pi-subagents"],
+		});
+		expect(pruneLegacySiblings().pruned).toEqual(["npm:pi-subagents"]);
+		expect(readSettings()).toEqual({ packages: [] });
+	});
+
 	it("idempotent: second call after prune is a no-op", () => {
 		writeSettings({
 			packages: ["npm:pi-subagents"],
@@ -115,8 +131,7 @@ describe("findLegacySiblings (read-only scan)", () => {
 	});
 
 	it("invalid JSON → []", () => {
-		mkdirSync(dirname(SETTINGS_PATH), { recursive: true });
-		writeFileSync(SETTINGS_PATH, "{not json", "utf-8");
+		writeSettingsRaw("{not json");
 		expect(findLegacySiblings()).toEqual([]);
 	});
 
@@ -147,16 +162,22 @@ describe("findLegacySiblings (read-only scan)", () => {
 			defaultProvider: "zai",
 			packages: ["npm:pi-subagents", "npm:@juicesharp/rpiv-todo"],
 		});
-		const before = readFileSync(SETTINGS_PATH, "utf-8");
+		const before = readSettingsRaw();
 		expect(findLegacySiblings()).toEqual(["npm:pi-subagents"]);
-		expect(readFileSync(SETTINGS_PATH, "utf-8")).toBe(before);
+		expect(readSettingsRaw()).toBe(before);
+	});
+
+	it("reads settings from PI_CODING_AGENT_DIR when configured", () => {
+		process.env.PI_CODING_AGENT_DIR = join(process.env.HOME!, ".config", "pi", "agent");
+		writeSettings({ packages: ["npm:pi-subagents"] });
+		expect(findLegacySiblings()).toEqual(["npm:pi-subagents"]);
 	});
 
 	it("idempotent: repeat call returns the same list and does not mutate", () => {
 		writeSettings({ packages: ["npm:pi-subagents"] });
-		const before = readFileSync(SETTINGS_PATH, "utf-8");
+		const before = readSettingsRaw();
 		expect(findLegacySiblings()).toEqual(["npm:pi-subagents"]);
 		expect(findLegacySiblings()).toEqual(["npm:pi-subagents"]);
-		expect(readFileSync(SETTINGS_PATH, "utf-8")).toBe(before);
+		expect(readSettingsRaw()).toBe(before);
 	});
 });

--- a/packages/rpiv-pi/extensions/rpiv-core/prune-legacy-siblings.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/prune-legacy-siblings.ts
@@ -1,6 +1,6 @@
 /**
  * Detect + remove deprecated sibling package entries from
- * ~/.pi/agent/settings.json.
+ * the active Pi agent settings file.
  *
  * Split into two phases so /rpiv-setup can preview pending changes in the
  * confirmation dialog and apply the mutation only after the user agrees:
@@ -23,7 +23,7 @@
 
 import { writeFileSync } from "node:fs";
 import { LEGACY_SIBLINGS } from "./siblings.js";
-import { PI_AGENT_SETTINGS, readPiAgentSettings } from "./utils.js";
+import { getPiAgentSettingsPath, readPiAgentSettings } from "./utils.js";
 
 export interface PruneLegacySiblingsResult {
 	/** settings.json `packages[]` entries that were removed (empty = no-op). */
@@ -65,7 +65,7 @@ export function pruneLegacySiblings(): PruneLegacySiblingsResult {
 
 	parsed.settings.packages = kept;
 	try {
-		writeFileSync(PI_AGENT_SETTINGS, `${JSON.stringify(parsed.settings, null, 2)}\n`, "utf-8");
+		writeFileSync(getPiAgentSettingsPath(), `${JSON.stringify(parsed.settings, null, 2)}\n`, "utf-8");
 	} catch {
 		return { pruned: [] };
 	}

--- a/packages/rpiv-pi/extensions/rpiv-core/setup-command.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/setup-command.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -83,6 +84,18 @@ describe("/rpiv-setup — pre-confirm read-only contract", () => {
 		const confirmCall = (ctx.ui.confirm as ReturnType<typeof vi.fn>).mock.calls[0]!;
 		expect(confirmCall[1]).toContain("Remove from");
 		expect(confirmCall[1]).toContain("npm:pi-subagents");
+	});
+
+	it("shows the PI_CODING_AGENT_DIR settings path in the confirmation body", async () => {
+		process.env.PI_CODING_AGENT_DIR = join(process.env.HOME!, ".config", "pi", "agent");
+		vi.mocked(findMissingSiblings).mockReturnValue([]);
+		vi.mocked(findLegacySiblings).mockReturnValue(["npm:pi-subagents"]);
+		const { pi, captured } = createMockPi();
+		registerSetupCommand(pi);
+		const ctx = createMockCtx({ hasUI: true });
+		await captured.commands.get("rpiv-setup")?.handler("", ctx as never);
+		const confirmCall = (ctx.ui.confirm as ReturnType<typeof vi.fn>).mock.calls[0]!;
+		expect(confirmCall[1]).toContain(join(process.env.HOME!, ".config", "pi", "agent", "settings.json"));
 	});
 
 	it("includes pending installs in the confirmation body", async () => {

--- a/packages/rpiv-pi/extensions/rpiv-core/setup-command.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/setup-command.ts
@@ -1,5 +1,5 @@
 /**
- * /rpiv-setup — installs any SIBLINGS not present in ~/.pi/agent/settings.json
+ * /rpiv-setup — installs any SIBLINGS not present in the active Pi settings file
  * and prunes deprecated entries (e.g. the unscoped `npm:pi-subagents` from
  * the rpiv-pi 0.12.x → 0.14.0 line). Both mutations are previewed in the
  * confirmation dialog and only executed after the user agrees.
@@ -13,7 +13,7 @@ import { findMissingSiblings } from "./package-checks.js";
 import { spawnPiInstall } from "./pi-installer.js";
 import { findLegacySiblings, pruneLegacySiblings } from "./prune-legacy-siblings.js";
 import type { SiblingPlugin } from "./siblings.js";
-import { toErrorMessage } from "./utils.js";
+import { getPiAgentSettingsPath, toErrorMessage } from "./utils.js";
 
 const INSTALL_TIMEOUT_MS = 120_000;
 const STDERR_SNIPPET_CHARS = 300;
@@ -43,12 +43,13 @@ function buildConfirmBody(missing: SiblingPlugin[], legacyEntries: string[]): st
 		for (const m of missing) lines.push(`  • ${m.pkg}  (required — provides ${m.provides})`);
 		lines.push("");
 	}
+	const settingsPath = getPiAgentSettingsPath();
 	if (legacyEntries.length > 0) {
-		lines.push("Remove from `~/.pi/agent/settings.json` (deprecated):");
+		lines.push(`Remove from \`${settingsPath}\` (deprecated):`);
 		for (const entry of legacyEntries) lines.push(`  • ${entry}`);
 		lines.push("");
 	}
-	lines.push("Your `~/.pi/agent/settings.json` will be updated. Proceed?");
+	lines.push(`Your \`${settingsPath}\` will be updated. Proceed?`);
 	return lines.join("\n");
 }
 

--- a/packages/rpiv-pi/extensions/rpiv-core/siblings.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/siblings.ts
@@ -6,14 +6,14 @@
  * /rpiv-setup installer (setup-command.ts). Add a sibling here and every
  * consumer picks it up automatically.
  *
- * Detection is filesystem-based via a regex over ~/.pi/agent/settings.json
+ * Detection is filesystem-based via a regex over the active Pi settings file
  * — no runtime import of sibling packages (keeps rpiv-core pure-orchestrator).
  */
 
 export interface SiblingPlugin {
 	/** Install spec passed to `pi install`. Prefixed with `npm:` for Pi's installer. */
 	readonly pkg: string;
-	/** Case-insensitive regex that matches the package in ~/.pi/agent/settings.json. */
+	/** Case-insensitive regex that matches the package in settings.json. */
 	readonly matches: RegExp;
 	/** What the sibling provides — shown in /rpiv-setup confirmation and reports. */
 	readonly provides: string;
@@ -59,7 +59,7 @@ export const SIBLINGS: readonly SiblingPlugin[] = [
 
 /**
  * Deprecated sibling packages that `/rpiv-setup` actively prunes from
- * ~/.pi/agent/settings.json (so upgraders don't end up with superseded
+ * the active Pi settings file (so upgraders don't end up with superseded
  * libraries loaded alongside their replacements). Single source of truth
  * for `prune-legacy-siblings.ts`.
  */

--- a/packages/rpiv-pi/extensions/rpiv-core/utils.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/utils.test.ts
@@ -1,15 +1,21 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { isPlainObject, PI_AGENT_SETTINGS, readPiAgentSettings, toErrorMessage } from "./utils.js";
+import {
+	getPiAgentSettingsPath,
+	isPlainObject,
+	PI_AGENT_SETTINGS,
+	readPiAgentSettings,
+	toErrorMessage,
+} from "./utils.js";
 
-function writeSettingsRaw(raw: string): void {
-	mkdirSync(dirname(PI_AGENT_SETTINGS), { recursive: true });
-	writeFileSync(PI_AGENT_SETTINGS, raw, "utf-8");
+function writeSettingsRaw(raw: string, path = getPiAgentSettingsPath()): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, raw, "utf-8");
 }
 
-function writeSettings(contents: unknown): void {
-	writeSettingsRaw(JSON.stringify(contents));
+function writeSettings(contents: unknown, path = getPiAgentSettingsPath()): void {
+	writeSettingsRaw(JSON.stringify(contents), path);
 }
 
 describe("isPlainObject", () => {
@@ -65,6 +71,17 @@ describe("toErrorMessage", () => {
 	});
 });
 
+describe("getPiAgentSettingsPath", () => {
+	it("uses ~/.pi/agent/settings.json when PI_CODING_AGENT_DIR is unset", () => {
+		expect(getPiAgentSettingsPath()).toBe(PI_AGENT_SETTINGS);
+	});
+
+	it("uses PI_CODING_AGENT_DIR/settings.json when configured", () => {
+		process.env.PI_CODING_AGENT_DIR = join(process.env.HOME!, ".config", "pi", "agent");
+		expect(getPiAgentSettingsPath()).toBe(join(process.env.HOME!, ".config", "pi", "agent", "settings.json"));
+	});
+});
+
 describe("readPiAgentSettings", () => {
 	it("returns undefined when the settings file is missing", () => {
 		rmSync(PI_AGENT_SETTINGS, { force: true });
@@ -103,6 +120,12 @@ describe("readPiAgentSettings", () => {
 			defaultProvider: "zai",
 			packages: ["npm:pi-perplexity", "npm:@juicesharp/rpiv-todo"],
 		});
+	});
+
+	it("reads from PI_CODING_AGENT_DIR/settings.json when configured", () => {
+		process.env.PI_CODING_AGENT_DIR = join(process.env.HOME!, ".config", "pi", "agent");
+		writeSettings({ packages: ["npm:@juicesharp/rpiv-todo"] });
+		expect(readPiAgentSettings()?.packages).toEqual(["npm:@juicesharp/rpiv-todo"]);
 	});
 
 	it("preserves non-string entries inside packages (caller responsibility to filter)", () => {

--- a/packages/rpiv-pi/extensions/rpiv-core/utils.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/utils.ts
@@ -12,8 +12,14 @@ import { join } from "node:path";
 // PI Agent Settings path
 // ---------------------------------------------------------------------------
 
-/** Path to the Pi agent settings file. Shared by package-checks and prune-legacy-siblings. */
+/** Default Pi agent settings path when PI_CODING_AGENT_DIR is not configured. */
 export const PI_AGENT_SETTINGS = join(homedir(), ".pi", "agent", "settings.json");
+
+/** Resolve the active Pi agent settings file, honoring Pi's configurable agent dir. */
+export function getPiAgentSettingsPath(): string {
+	const configuredAgentDir = process.env.PI_CODING_AGENT_DIR;
+	return join(configuredAgentDir || join(homedir(), ".pi", "agent"), "settings.json");
+}
 
 // ---------------------------------------------------------------------------
 // Type guards
@@ -48,15 +54,16 @@ interface PiAgentSettingsResult {
 }
 
 /**
- * Read and parse ~/.pi/agent/settings.json.
+ * Read and parse the active Pi agent settings file.
  * Returns undefined if the file is missing, has invalid JSON, or is not a plain object
  * with a packages array. Fail-soft — never throws.
  */
 export function readPiAgentSettings(): PiAgentSettingsResult | undefined {
-	if (!existsSync(PI_AGENT_SETTINGS)) return undefined;
+	const settingsPath = getPiAgentSettingsPath();
+	if (!existsSync(settingsPath)) return undefined;
 	let parsed: unknown;
 	try {
-		parsed = JSON.parse(readFileSync(PI_AGENT_SETTINGS, "utf-8"));
+		parsed = JSON.parse(readFileSync(settingsPath, "utf-8"));
 	} catch {
 		return undefined;
 	}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -6,6 +6,7 @@ import { beforeEach, vi } from "vitest";
 const TEST_HOME = mkdtempSync(join(tmpdir(), "rpiv-test-home-"));
 process.env.HOME = TEST_HOME;
 process.env.USERPROFILE = TEST_HOME;
+delete process.env.PI_CODING_AGENT_DIR;
 
 vi.mock("@earendil-works/pi-ai", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@earendil-works/pi-ai")>();
@@ -43,6 +44,8 @@ const VOICE_SYMBOL = Symbol.for("rpiv-voice");
 // hookTimeout is therefore raised in vitest.config.ts. The cost is paid once
 // per worker; subsequent tests reuse the module cache and beforeEach is fast.
 beforeEach(async () => {
+	delete process.env.PI_CODING_AGENT_DIR;
+
 	const todo = await import("../packages/rpiv-todo/todo.js");
 	todo.__resetState();
 
@@ -78,6 +81,7 @@ beforeEach(async () => {
 	delete (globalThis as Record<symbol, unknown>)[VOICE_SYMBOL];
 
 	const piAgentSettings = join(process.env.HOME!, ".pi", "agent", "settings.json");
+	const xdgPiAgentDir = join(process.env.HOME!, ".config", "pi", "agent");
 	const advisorConfig = join(process.env.HOME!, ".config", "rpiv-advisor", "advisor.json");
 	const i18nConfig = join(process.env.HOME!, ".config", "rpiv-i18n", "locale.json");
 	const voiceConfig = join(process.env.HOME!, ".config", "rpiv-voice", "voice.json");
@@ -86,6 +90,7 @@ beforeEach(async () => {
 	const askUserQuestionConfig = join(process.env.HOME!, ".config", "rpiv-ask-user-question", "config.json");
 	const webToolsConfig = join(process.env.HOME!, ".config", "rpiv-web-tools", "config.json");
 	rmSync(piAgentSettings, { force: true });
+	rmSync(xdgPiAgentDir, { recursive: true, force: true });
 	rmSync(advisorConfig, { force: true });
 	rmSync(i18nConfig, { force: true });
 	rmSync(voiceConfig, { force: true });


### PR DESCRIPTION
## Summary

TIny change, but something I noticed during testing. Unsure if you want to support this, but figured I'd open a PR.                                                                                                                                       
                                                                                                                                                    
   - Honor `PI_CODING_AGENT_DIR` when resolving rpiv-pi's active `settings.json`                                                                    
   - Update sibling package detection and legacy pruning to use that active path                                                                    
   - Show the active settings path in `/rpiv-setup` confirmation text                                                                               
   - Add regression coverage for XDG-style Pi agent directories                                                                                     
                                                                                                                                                    
   ## Testing                                                                                                                                       
                                                                                                                                                    
   - `npx vitest run packages/rpiv-pi/extensions/rpiv-core/{utils,package-checks,prune-legacy-siblings,setup-command}.test.ts`                      
   - `npx biome check <touched ts files>`                                                                                                           
   - `npx tsc --noEmit -p tsconfig.base.json`                                                                                                       
   - `git diff --check`                                                                                                                             
   - Push hook: `npm run coverage` passed, 119 files and 1797 tests  