### PR TITLE
feat(rpiv-goal): add session-scoped goal extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,8 @@ thoughts/
 *.swo
 *~
 
-# Agent metadata (Claude Code local session state)
+# Agent metadata (local session state)
+.agents/
 .claude/
 
 # Package specific

--- a/README.md
+++ b/README.md
@@ -4,29 +4,107 @@
 [![codecov](https://codecov.io/gh/juicesharp/rpiv-mono/branch/main/graph/badge.svg?v=2)](https://codecov.io/gh/juicesharp/rpiv-mono)
 [![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/juicesharp/rpiv-mono/badges/tests.json)](https://github.com/juicesharp/rpiv-mono/actions/workflows/ci.yml)
 
-Nine npm packages: one pipeline (rpiv-pi) and the sibling extensions it composes. Kept in one repo so orchestration and tool surfaces evolve together and ship in lockstep.
+Thirteen npm packages: one pipeline (rpiv-pi) and the sibling extensions it
+composes. Kept in one repo so orchestration and tool surfaces evolve together
+and ship in lockstep.
 
-The pipeline needs most of them. **rpiv-args** expands shell-style `$1` and `$ARGUMENTS` placeholders inside skills, **rpiv-ask-user-question** lets the model put a structured questionnaire to the user instead of guessing, **rpiv-todo** keeps a live task overlay that survives `/reload` and compaction, **rpiv-advisor** escalates to a stronger reviewer model before the agent acts, **rpiv-web-tools** gives the model web search and fetch with pluggable providers, and **rpiv-workflow** chains skills into typed multi-stage pipelines (audited JSONL state, predicate routing, per-stage output validation) and ships the `/wf` command Pi calls to run them. A couple exist because I wanted them inside Pi: **rpiv-btw** is a side-conversation pattern I got used to in Claude Code, and **rpiv-warp** integrates Pi with Warp terminal's notification system, because that's where I actually run Pi. **rpiv-i18n** is the one that came from users: it started as localization for ask-user-question and grew into a small SDK. **rpiv-telemetry** wires Pi into MLflow — auto-instruments lifecycle events and sub-agent activity so runs are inspectable after the fact.
+The pipeline needs most of them. **rpiv-args** expands shell-style `$1` and
+`$ARGUMENTS` placeholders inside skills, **rpiv-ask-user-question** lets the
+model put a structured questionnaire to the user instead of guessing,
+**rpiv-todo** keeps a live task overlay that survives `/reload` and compaction,
+**rpiv-advisor** escalates to a stronger reviewer model before the agent acts,
+**rpiv-web-tools** gives the model web search and fetch with pluggable
+providers, and **rpiv-workflow** chains skills into typed multi-stage pipelines
+(audited JSONL state, predicate routing, per-stage output validation) and ships
+the `/wf` command Pi calls to run them. A couple exist because I wanted them
+inside Pi: **rpiv-btw** is a side-conversation pattern I got used to in Claude
+Code, **rpiv-goal** keeps a session-scoped objective alive until explicit
+completion, and **rpiv-warp** integrates Pi with Warp terminal's notification
+system, because that's where I actually run Pi. **rpiv-i18n** is the one that
+came from users: it started as localization for ask-user-question and grew into
+a small SDK. **rpiv-telemetry** wires Pi into MLflow — auto-instruments
+lifecycle events and sub-agent activity so runs are inspectable after the fact.
 
 > [!TIP]
-> **For the full pipeline narrative, the subagent map, and install instructions, visit [rpiv-pi.com](https://rpiv-pi.com).**
+> **For the full pipeline narrative, the subagent map, and install instructions,
+> visit [rpiv-pi.com](https://rpiv-pi.com).**
 
 ## Roadmap
 
-The realization shaping AI-assisted development right now is that LLMs produce correct code, not aligned code. The output compiles and passes tests, but it isn't enterprise-grade in the way human engineers produce: fitting the codebase's existing patterns, respecting conventions that aren't written down anywhere, making the boring choices mature systems rely on, staying reviewable and extensible by the next person who touches it. Closing that gap takes a driver: an experienced engineer who carries the context the model can't have, who frames the task correctly upfront, who steers architecture, who pushes back when output drifts. Without that active driver, the codebase fills with locally-correct, globally-misaligned diffs that look fine in PR review and erode the team's confidence over time.
+The realization shaping AI-assisted development right now is that LLMs produce
+correct code, not aligned code. The output compiles and passes tests, but it
+isn't enterprise-grade in the way human engineers produce: fitting the
+codebase's existing patterns, respecting conventions that aren't written down
+anywhere, making the boring choices mature systems rely on, staying reviewable
+and extensible by the next person who touches it. Closing that gap takes a
+driver: an experienced engineer who carries the context the model can't have,
+who frames the task correctly upfront, who steers architecture, who pushes back
+when output drifts. Without that active driver, the codebase fills with
+locally-correct, globally-misaligned diffs that look fine in PR review and erode
+the team's confidence over time.
 
-Misaligned code isn't zero-value, it's negative-value: it compiles, it ships, then it taxes every engineer who reads that file afterward and costs the next refactor a half-day of reasoning about near-duplicates that shouldn't exist. Worse, it quietly subtracts from the architecture's coherence in a way no PR review catches. Misaligned-diff throughput is alignment-debt throughput. The cost of a driver-in-the-loop pipeline is latency, paid up front and visible on a dashboard; the cost of skipping it is alignment debt, paid later, by someone else, and rarely traced back to the diff that caused it.
+Misaligned code isn't zero-value, it's negative-value: it compiles, it ships,
+then it taxes every engineer who reads that file afterward and costs the next
+refactor a half-day of reasoning about near-duplicates that shouldn't exist.
+Worse, it quietly subtracts from the architecture's coherence in a way no PR
+review catches. Misaligned-diff throughput is alignment-debt throughput. The
+cost of a driver-in-the-loop pipeline is latency, paid up front and visible on a
+dashboard; the cost of skipping it is alignment debt, paid later, by someone
+else, and rarely traced back to the diff that caused it.
 
-rpiv-pi exists to keep the driver meaningfully in the loop while the work moves at LLM speed. The pipeline asks the right questions at the right moments (ask-user-question), surfaces architectural decisions where they matter, and structures human involvement as participation rather than approval. The bet isn't that models will plateau. They'll keep getting better. The bet is that the structural conditions for fully autonomous coding (institutional knowledge availability, connector maturity, correctness and latency at enterprise scale) are a decade-scale problem absent a real breakthrough. For that whole interval, the realistic operating model is a driver in the loop. rpiv-pi is the engine for that loop: it writes and verifies code under expert supervision. A real enterprise harness, the layer that connects an engine like this to ticketing, CI, and an organization's institutional context, is a separate piece of work and not what this project is today. At Codemasters, we're about to start exploring how an engine like rpiv-pi could fit as part of a broader multi-chain experiment. Whether any of that surfaces back here is open.
+rpiv-pi exists to keep the driver meaningfully in the loop while the work moves
+at LLM speed. The pipeline asks the right questions at the right moments
+(ask-user-question), surfaces architectural decisions where they matter, and
+structures human involvement as participation rather than approval. The bet
+isn't that models will plateau. They'll keep getting better. The bet is that the
+structural conditions for fully autonomous coding (institutional knowledge
+availability, connector maturity, correctness and latency at enterprise scale)
+are a decade-scale problem absent a real breakthrough. For that whole interval,
+the realistic operating model is a driver in the loop. rpiv-pi is the engine for
+that loop: it writes and verifies code under expert supervision. A real
+enterprise harness, the layer that connects an engine like this to ticketing,
+CI, and an organization's institutional context, is a separate piece of work and
+not what this project is today. At Codemasters, we're about to start exploring
+how an engine like rpiv-pi could fit as part of a broader multi-chain
+experiment. Whether any of that surfaces back here is open.
 
-In parallel, the pipeline is already viable on affordable open-weight models today (GLM-5.1, Kimi K2.5, MiMo-V2-Pro), and produces genuinely good results in practice. Output isn't yet at parity with frontier on the same task: more mistakes than I'd want, longer runs than I'd want. Closing that residual gap is the next set of work below. I'm assessing this as a CTO leading AI adoption at a mid-size company with no frontier-lab budget, where the cost difference matters: as of May 2026, GLM-5.1 lists at roughly a third of Claude Sonnet 4.6's output token price, and around a fifth of Opus 4.7's.
+In parallel, the pipeline is already viable on affordable open-weight models
+today (GLM-5.1, Kimi K2.5, MiMo-V2-Pro), and produces genuinely good results in
+practice. Output isn't yet at parity with frontier on the same task: more
+mistakes than I'd want, longer runs than I'd want. Closing that residual gap is
+the next set of work below. I'm assessing this as a CTO leading AI adoption at a
+mid-size company with no frontier-lab budget, where the cost difference matters:
+as of May 2026, GLM-5.1 lists at roughly a third of Claude Sonnet 4.6's output
+token price, and around a fifth of Opus 4.7's.
 
-- **Verification under affordable-model runs.** The failure mode I see today on GLM/Kimi/MiMo isn't loud breakage; it's self-validation blindness, and it has two roots, not one. Same model is the obvious one: affordable-model work passes affordable-model verifiers, and only escalation to a frontier judge (currently Opus 4.7, May 2026) reliably catches the residual issues. The less obvious one is same context: a verifier that inherits the author's chat anchors on the same framings, ratifies instead of attacks, and writes tests that encode the author's mental model rather than probe it. Frontier escalation defeats the cost argument; isolation doesn't. The next round of work is experimenting with verification setups that lean on fresh-context isolation first and frontier escalation only where it earns its keep.
-- **Delegation strategy.** The pipeline's runtime cost is a function of how work is delegated across skills and subagents: what runs in parallel, what serially, which model handles which step, where verification fires. Some of the slowness on affordable-model runs is infrastructure-side and outside scope. The part that's tractable is finding the delegation pattern that minimizes total run cost without sacrificing output quality. This is an open optimization question, not a planned feature; the next round of work is experimenting with combinations and measuring what actually trades off against what.
+- **Verification under affordable-model runs.** The failure mode I see today on
+  GLM/Kimi/MiMo isn't loud breakage; it's self-validation blindness, and it has
+  two roots, not one. Same model is the obvious one: affordable-model work
+  passes affordable-model verifiers, and only escalation to a frontier judge
+  (currently Opus 4.7, May 2026) reliably catches the residual issues. The less
+  obvious one is same context: a verifier that inherits the author's chat
+  anchors on the same framings, ratifies instead of attacks, and writes tests
+  that encode the author's mental model rather than probe it. Frontier
+  escalation defeats the cost argument; isolation doesn't. The next round of
+  work is experimenting with verification setups that lean on fresh-context
+  isolation first and frontier escalation only where it earns its keep.
+- **Delegation strategy.** The pipeline's runtime cost is a function of how work
+  is delegated across skills and subagents: what runs in parallel, what
+  serially, which model handles which step, where verification fires. Some of
+  the slowness on affordable-model runs is infrastructure-side and outside
+  scope. The part that's tractable is finding the delegation pattern that
+  minimizes total run cost without sacrificing output quality. This is an open
+  optimization question, not a planned feature; the next round of work is
+  experimenting with combinations and measuring what actually trades off against
+  what.
 
 ## Who built this
 
-Sergii Guslystyi. Software Architect and CTO at Codemasters International. Two decades building software, currently leading AI-first development adoption inside the company. rpiv-mono is a personal initiative, on my own time, where I prototype the patterns I'm working through professionally and put them in public for anyone to use, fork, or push back on.
+Sergii Guslystyi. Software Architect and CTO at Codemasters International. Two
+decades building software, currently leading AI-first development adoption
+inside the company. rpiv-mono is a personal initiative, on my own time, where I
+prototype the patterns I'm working through professionally and put them in public
+for anyone to use, fork, or push back on.
 
 Find me on X: [@juicesharp](https://x.com/juicesharp).
 
@@ -36,16 +114,26 @@ npm workspaces monorepo. Clone, `npm install` at the root, that's it.
 
 A few choices worth naming up front:
 
-- No build step. Packages publish raw `.ts`; Pi loads TypeScript directly. No `dist/`, no per-package tsconfig.
-- One Vitest runner at the root walks every package. No per-package vitest configs.
-- Lockstep versions. All nine packages share one version, enforced by `sync-versions.js`.
-- Releases are local-only by design. `node scripts/release.mjs <patch|minor|major|x.y.z>` cuts a release; no CI publish workflow.
-- Husky gates the work. `pre-commit` runs Biome and `tsc --noEmit` (fast); `pre-push` runs the full test suite with coverage thresholds. Tests don't block commits, they block pushes.
-- Single shared config across the workspace: one `biome.json`, one `tsconfig.base.json`, one `vitest.config.ts`.
+- No build step. Packages publish raw `.ts`; Pi loads TypeScript directly. No
+  `dist/`, no per-package tsconfig.
+- One Vitest runner at the root walks every package. No per-package vitest
+  configs.
+- Lockstep versions. All packages share one version, enforced by
+  `sync-versions.js`.
+- Releases are local-only by design.
+  `node scripts/release.mjs <patch|minor|major|x.y.z>` cuts a release; no CI
+  publish workflow.
+- Husky gates the work. `pre-commit` runs Biome and `tsc --noEmit` (fast);
+  `pre-push` runs the full test suite with coverage thresholds. Tests don't
+  block commits, they block pushes.
+- Single shared config across the workspace: one `biome.json`, one
+  `tsconfig.base.json`, one `vitest.config.ts`.
 
 ### Contributions
 
-Issues are welcome. PRs too, but please open an issue first if the change isn't trivial. The project has a definite shape and direction, and a quick conversation up front saves both of us a round-trip.
+Issues are welcome. PRs too, but please open an issue first if the change isn't
+trivial. The project has a definite shape and direction, and a quick
+conversation up front saves both of us a round-trip.
 
 ## Status and expectations
 
@@ -53,7 +141,8 @@ Started April 2026. MIT licensed.
 
 Single maintainer (me); Claude Code is a co-author on most commits.
 
-Actively maintained as a personal project. Issues triaged on best effort. Cadence may slow when the day job runs hot.
+Actively maintained as a personal project. Issues triaged on best effort.
+Cadence may slow when the day job runs hot.
 
 ## Pointers
 
@@ -63,19 +152,23 @@ Actively maintained as a personal project. Issues triaged on best effort. Cadenc
 
 ### Packages
 
-Almost every package can be installed directly from npm on its own. `/rpiv-setup` (shipped by `rpiv-pi`) only auto-installs the siblings the pipeline depends on; the rest are opt-in via `pi install npm:@juicesharp/rpiv-<name>`.
+Almost every package can be installed directly from npm on its own.
+`/rpiv-setup` (shipped by `rpiv-pi`) only auto-installs the siblings the
+pipeline depends on; the rest are opt-in via
+`pi install npm:@juicesharp/rpiv-<name>`.
 
-| Package | Role | Standalone install | Auto with `rpiv-pi` | npm |
-| --- | --- | :---: | :---: | --- |
-| `rpiv-pi` | Pipeline (skills + subagents) | ✓ | — | [`@juicesharp/rpiv-pi`](https://www.npmjs.com/package/@juicesharp/rpiv-pi) |
-| `rpiv-args` | `$1` / `$ARGUMENTS` placeholders in skills | ✓ | ✓ | [`@juicesharp/rpiv-args`](https://www.npmjs.com/package/@juicesharp/rpiv-args) |
-| `rpiv-ask-user-question` | Structured questionnaire to the user | ✓ | ✓ | [`@juicesharp/rpiv-ask-user-question`](https://www.npmjs.com/package/@juicesharp/rpiv-ask-user-question) |
-| `rpiv-todo` | Live task overlay surviving `/reload` | ✓ | ✓ | [`@juicesharp/rpiv-todo`](https://www.npmjs.com/package/@juicesharp/rpiv-todo) |
-| `rpiv-advisor` | Escalate to a stronger reviewer model | ✓ | ✓ | [`@juicesharp/rpiv-advisor`](https://www.npmjs.com/package/@juicesharp/rpiv-advisor) |
-| `rpiv-web-tools` | Web search + fetch with pluggable providers | ✓ | ✓ | [`@juicesharp/rpiv-web-tools`](https://www.npmjs.com/package/@juicesharp/rpiv-web-tools) |
-| `rpiv-i18n` | Localization SDK for sibling extensions | ✓ | ✓ | [`@juicesharp/rpiv-i18n`](https://www.npmjs.com/package/@juicesharp/rpiv-i18n) |
-| `rpiv-workflow` | `/wf` runner — chain skills into typed multi-stage pipelines | ✓ | ✓ | [`@juicesharp/rpiv-workflow`](https://www.npmjs.com/package/@juicesharp/rpiv-workflow) |
-| `rpiv-btw` | `/btw` side-conversation slash command | ✓ | — | [`@juicesharp/rpiv-btw`](https://www.npmjs.com/package/@juicesharp/rpiv-btw) |
-| `rpiv-voice` | Local voice dictation (`/v` overlay, on-device Whisper) | ✓ | — | [`@juicesharp/rpiv-voice`](https://www.npmjs.com/package/@juicesharp/rpiv-voice) |
-| `rpiv-telemetry` | MLflow observability — auto-instruments lifecycle + sub-agent activity | ✓ | — | [`@juicesharp/rpiv-telemetry`](https://www.npmjs.com/package/@juicesharp/rpiv-telemetry) |
-| `rpiv-warp` | Warp terminal notification integration | ✓ | — | [`@juicesharp/rpiv-warp`](https://www.npmjs.com/package/@juicesharp/rpiv-warp) |
+| Package                  | Role                                                                   | Standalone install | Auto with `rpiv-pi` | npm                                                                                                      |
+| ------------------------ | ---------------------------------------------------------------------- | :----------------: | :-----------------: | -------------------------------------------------------------------------------------------------------- |
+| `rpiv-pi`                | Pipeline (skills + subagents)                                          |         ✓          |          —          | [`@juicesharp/rpiv-pi`](https://www.npmjs.com/package/@juicesharp/rpiv-pi)                               |
+| `rpiv-args`              | `$1` / `$ARGUMENTS` placeholders in skills                             |         ✓          |          ✓          | [`@juicesharp/rpiv-args`](https://www.npmjs.com/package/@juicesharp/rpiv-args)                           |
+| `rpiv-ask-user-question` | Structured questionnaire to the user                                   |         ✓          |          ✓          | [`@juicesharp/rpiv-ask-user-question`](https://www.npmjs.com/package/@juicesharp/rpiv-ask-user-question) |
+| `rpiv-todo`              | Live task overlay surviving `/reload`                                  |         ✓          |          ✓          | [`@juicesharp/rpiv-todo`](https://www.npmjs.com/package/@juicesharp/rpiv-todo)                           |
+| `rpiv-goal`              | Session objective that keeps going until explicit completion           |         ✓          |          —          | [`@solforged/rpiv-goal`](https://www.npmjs.com/package/@solforged/rpiv-goal)                             |
+| `rpiv-advisor`           | Escalate to a stronger reviewer model                                  |         ✓          |          ✓          | [`@juicesharp/rpiv-advisor`](https://www.npmjs.com/package/@juicesharp/rpiv-advisor)                     |
+| `rpiv-web-tools`         | Web search + fetch with pluggable providers                            |         ✓          |          ✓          | [`@juicesharp/rpiv-web-tools`](https://www.npmjs.com/package/@juicesharp/rpiv-web-tools)                 |
+| `rpiv-i18n`              | Localization SDK for sibling extensions                                |         ✓          |          ✓          | [`@juicesharp/rpiv-i18n`](https://www.npmjs.com/package/@juicesharp/rpiv-i18n)                           |
+| `rpiv-workflow`          | `/wf` runner — chain skills into typed multi-stage pipelines           |         ✓          |          ✓          | [`@juicesharp/rpiv-workflow`](https://www.npmjs.com/package/@juicesharp/rpiv-workflow)                   |
+| `rpiv-btw`               | `/btw` side-conversation slash command                                 |         ✓          |          —          | [`@juicesharp/rpiv-btw`](https://www.npmjs.com/package/@juicesharp/rpiv-btw)                             |
+| `rpiv-voice`             | Local voice dictation (`/v` overlay, on-device Whisper)                |         ✓          |          —          | [`@juicesharp/rpiv-voice`](https://www.npmjs.com/package/@juicesharp/rpiv-voice)                         |
+| `rpiv-telemetry`         | MLflow observability — auto-instruments lifecycle + sub-agent activity |         ✓          |          —          | [`@juicesharp/rpiv-telemetry`](https://www.npmjs.com/package/@juicesharp/rpiv-telemetry)                 |
+| `rpiv-warp`              | Warp terminal notification integration                                 |         ✓          |          —          | [`@juicesharp/rpiv-warp`](https://www.npmjs.com/package/@juicesharp/rpiv-warp)                           |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4002,6 +4002,10 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@solforged/rpiv-goal": {
+			"resolved": "packages/rpiv-goal",
+			"link": true
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -11004,6 +11008,15 @@
 			"version": "1.15.0",
 			"license": "MIT",
 			"peerDependencies": {
+				"typebox": "*"
+			}
+		},
+		"packages/rpiv-goal": {
+			"name": "@solforged/rpiv-goal",
+			"version": "1.15.0",
+			"license": "MIT",
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
 				"typebox": "*"
 			}
 		},

--- a/packages/rpiv-goal/CHANGELOG.md
+++ b/packages/rpiv-goal/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to `@solforged/rpiv-goal` are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning:
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial opt-in `/goal` extension with session-scoped objective persistence,
+  guarded auto-continuation, and `goal_complete` termination.

--- a/packages/rpiv-goal/LICENSE
+++ b/packages/rpiv-goal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 juicesharp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/rpiv-goal/README.md
+++ b/packages/rpiv-goal/README.md
@@ -1,0 +1,78 @@
+# rpiv-goal
+
+`@solforged/rpiv-goal` is a small Pi extension for one session-scoped objective.
+It keeps the agent under an active `/goal` until the agent calls
+`goal_complete`, the user pauses or clears it, the run is interrupted, or a
+guard stops continuation.
+
+It is intentionally narrower than a task list or workflow runner: goal owns the
+objective, `rpiv-todo` owns decomposition, and `rpiv-workflow` owns phased
+pipelines.
+
+## Install
+
+```bash
+pi install npm:@solforged/rpiv-goal
+```
+
+Try locally from this repository:
+
+```bash
+pi -e ./packages/rpiv-goal
+```
+
+## Commands
+
+```text
+/goal
+/goal implement the missing validation and verify it
+/goal --tokens 100k fix the failing test
+/goal status
+/goal edit ship the smaller fix first
+/goal pause
+/goal resume
+/goal clear
+```
+
+- `/goal <objective>` starts goal mode. Replacing an unfinished goal asks for
+  confirmation.
+- `/goal --tokens 100k <objective>` adds a token budget.
+- `/goal edit <objective>` changes the objective without resetting usage.
+- `/goal pause` stops prompt injection and auto-continuation.
+- `/goal resume` restarts a paused or budget-limited goal.
+- `/goal clear` removes the current goal from the session.
+
+## Completion
+
+The extension registers one agent tool:
+
+```json
+{
+  "summary": "What changed.",
+  "evidence": "Tests, files, command output, or other proof."
+}
+```
+
+`goal_complete` terminates the turn. The prompt tells the agent to call it only
+after every explicit requirement is satisfied and verified.
+
+## Guards
+
+- State is stored in Pi session custom entries, not project files.
+- Active goals are replayed on reload, compaction, and session tree navigation.
+- Continuation prompts are skipped when messages are pending.
+- Aborted or errored assistant turns pause the goal.
+- Empty turns pause the goal instead of looping forever.
+- A hard continuation limit prevents runaway sessions.
+
+## Package shape
+
+```json
+{
+  "pi": {
+    "extensions": ["./index.ts"]
+  }
+}
+```
+
+The package publishes raw TypeScript like the rest of `rpiv-mono`.

--- a/packages/rpiv-goal/index.register.test.ts
+++ b/packages/rpiv-goal/index.register.test.ts
@@ -1,0 +1,189 @@
+import { createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import goalExtension, { __resetGoalRuntime } from "./index.js";
+import { extractContinuationMarker } from "./prompt.js";
+import { STATE_ENTRY, TOOL_NAME, WIDGET_KEY } from "./state.js";
+
+function setup() {
+	const appendEntry = vi.fn();
+	const { pi, captured } = createMockPi({ appendEntry: appendEntry as never });
+	goalExtension(pi);
+	const ctx = createMockCtx({ hasUI: true });
+	(ctx as unknown as { hasPendingMessages: () => boolean }).hasPendingMessages = vi.fn(() => false);
+	return { pi, captured, ctx, appendEntry };
+}
+
+function command(captured: ReturnType<typeof setup>["captured"]) {
+	const cmd = captured.commands.get("goal");
+	if (!cmd) throw new Error("goal command not registered");
+	return cmd;
+}
+
+function tool(captured: ReturnType<typeof setup>["captured"]) {
+	const registered = captured.tools.get(TOOL_NAME);
+	if (!registered) throw new Error("goal_complete tool not registered");
+	return registered;
+}
+
+function event(captured: ReturnType<typeof setup>["captured"], name: string) {
+	const handler = captured.events.get(name)?.[0];
+	if (!handler) throw new Error(`${name} handler not registered`);
+	return handler as (event: Record<string, unknown>, ctx: unknown) => Promise<unknown> | unknown;
+}
+
+function sendSpy(pi: ReturnType<typeof setup>["pi"]) {
+	return pi.sendUserMessage as unknown as ReturnType<typeof vi.fn>;
+}
+
+beforeEach(() => {
+	__resetGoalRuntime();
+});
+
+describe("rpiv-goal registration", () => {
+	it("registers one /goal command and the goal_complete tool", () => {
+		const { captured } = setup();
+		expect(captured.commands.has("goal")).toBe(true);
+		expect(captured.tools.get(TOOL_NAME)?.label).toBe("Goal Complete");
+		expect(JSON.stringify(captured.tools.get(TOOL_NAME)?.parameters)).toContain("evidence");
+	});
+});
+
+describe("/goal command", () => {
+	it("starts a goal, persists it, updates UI, and sends the start prompt", async () => {
+		const { pi, captured, ctx, appendEntry } = setup();
+		await command(captured).handler("--tokens 100k fix failing tests", ctx as never);
+
+		expect(appendEntry).toHaveBeenCalledWith(STATE_ENTRY, {
+			goal: expect.objectContaining({
+				objective: "fix failing tests",
+				status: "active",
+				tokenBudget: 100_000,
+			}),
+		});
+		expect(ctx.ui.setWidget).toHaveBeenCalledWith(WIDGET_KEY, expect.any(Array), {
+			placement: "aboveEditor",
+		});
+		expect(sendSpy(pi).mock.calls[0]?.[0]).toContain("<goal_objective>");
+	});
+
+	it("completes a goal through the terminating tool", async () => {
+		const { captured, ctx, appendEntry } = setup();
+		await command(captured).handler("ship it", ctx as never);
+		const result = await tool(captured).execute(
+			"tc",
+			{ summary: "done", evidence: "tests passed" },
+			undefined,
+			undefined,
+			ctx,
+		);
+
+		expect(appendEntry).toHaveBeenLastCalledWith(STATE_ENTRY, {
+			goal: expect.objectContaining({
+				status: "complete",
+				completedSummary: "done",
+				completionEvidence: "tests passed",
+			}),
+		});
+		expect(result.terminate).toBe(true);
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith(expect.any(String), "🎯 complete");
+	});
+});
+
+describe("auto-continuation guards", () => {
+	it("sends one continuation after a run that used a work tool", async () => {
+		const { pi, captured, ctx } = setup();
+		await command(captured).handler("finish the change", ctx as never);
+		sendSpy(pi).mockClear();
+
+		await event(captured, "agent_start")({ type: "agent_start" }, ctx);
+		await event(captured, "tool_execution_end")(
+			{ type: "tool_execution_end", toolName: "bash", isError: false },
+			ctx,
+		);
+		await event(captured, "agent_end")(
+			{
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "stop", usage: { input: 10, output: 5 } }],
+			},
+			ctx,
+		);
+
+		expect(sendSpy(pi)).toHaveBeenCalledTimes(1);
+		expect(sendSpy(pi).mock.calls[0]?.[0]).toContain("Continue the active /goal");
+	});
+
+	it("suppresses a cancelled continuation marker regardless of input source", async () => {
+		const { pi, captured, ctx } = setup();
+		await command(captured).handler("finish the change", ctx as never);
+		sendSpy(pi).mockClear();
+
+		await event(captured, "agent_start")({ type: "agent_start" }, ctx);
+		await event(captured, "tool_execution_end")(
+			{ type: "tool_execution_end", toolName: "bash", isError: false },
+			ctx,
+		);
+		await event(captured, "agent_end")(
+			{
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "stop", usage: { input: 10 } }],
+			},
+			ctx,
+		);
+		const queuedPrompt = String(sendSpy(pi).mock.calls[0]?.[0] ?? "");
+		expect(extractContinuationMarker(queuedPrompt)).toBeTruthy();
+
+		await command(captured).handler("pause", ctx as never);
+		const result = await event(captured, "input")(
+			{
+				type: "input",
+				source: "interactive",
+				text: queuedPrompt,
+			},
+			ctx,
+		);
+
+		expect(result).toEqual({ action: "handled" });
+	});
+
+	it("does not continue when another message is pending", async () => {
+		const { pi, captured, ctx } = setup();
+		await command(captured).handler("finish the change", ctx as never);
+		(ctx as unknown as { hasPendingMessages: () => boolean }).hasPendingMessages = vi.fn(() => true);
+		sendSpy(pi).mockClear();
+
+		await event(captured, "agent_start")({ type: "agent_start" }, ctx);
+		await event(captured, "tool_execution_end")(
+			{ type: "tool_execution_end", toolName: "bash", isError: false },
+			ctx,
+		);
+		await event(captured, "agent_end")(
+			{
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "stop", usage: { input: 10 } }],
+			},
+			ctx,
+		);
+
+		expect(sendSpy(pi)).not.toHaveBeenCalled();
+	});
+
+	it("pauses instead of looping after an empty turn", async () => {
+		const { pi, captured, ctx, appendEntry } = setup();
+		await command(captured).handler("finish the change", ctx as never);
+		sendSpy(pi).mockClear();
+
+		await event(captured, "agent_start")({ type: "agent_start" }, ctx);
+		await event(captured, "agent_end")(
+			{
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "stop", usage: { input: 10 } }],
+			},
+			ctx,
+		);
+
+		expect(sendSpy(pi)).not.toHaveBeenCalled();
+		expect(appendEntry).toHaveBeenLastCalledWith(STATE_ENTRY, {
+			goal: expect.objectContaining({ status: "paused", pauseReason: "empty_turn" }),
+		});
+	});
+});

--- a/packages/rpiv-goal/index.ts
+++ b/packages/rpiv-goal/index.ts
@@ -1,0 +1,390 @@
+import {
+	defineTool,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import {
+	buildGoalContinuePrompt,
+	buildGoalPrompt,
+	buildGoalResumePrompt,
+	buildGoalSystemPrompt,
+	buildGoalUpdatedPrompt,
+	extractContinuationMarker,
+} from "./prompt.js";
+import {
+	assistantStopReason,
+	assistantTurnTokens,
+	COMMAND_NAME,
+	createGoal,
+	editGoal,
+	finalAssistantMessage,
+	formatGoalStatus,
+	type GoalRecord,
+	type GoalStateEntry,
+	goalSummary,
+	incrementGoal,
+	isBudgetExhausted,
+	MAX_CONTINUATIONS,
+	parseGoalCommand,
+	replayGoalFromEntries,
+	STATE_ENTRY,
+	STATUS_KEY,
+	TOOL_NAME,
+	transitionGoal,
+	truncate,
+	WIDGET_KEY,
+} from "./state.js";
+
+interface PendingContinuation {
+	goalId: string;
+	marker: string;
+}
+
+interface GoalCompleteDetails {
+	goal: GoalRecord | undefined;
+	summary: string;
+	evidence?: string;
+}
+
+let activeGoal: GoalRecord | undefined;
+let pendingContinuation: PendingContinuation | undefined;
+let cancelledContinuationMarkers = new Set<string>();
+let workToolCalledThisRun = false;
+
+export function __resetGoalRuntime(): void {
+	activeGoal = undefined;
+	pendingContinuation = undefined;
+	cancelledContinuationMarkers = new Set<string>();
+	workToolCalledThisRun = false;
+}
+
+const goalCompleteTool = defineTool({
+	name: TOOL_NAME,
+	label: "Goal Complete",
+	description: "Mark the active /goal complete. Only call this after the objective is fully done and verified.",
+	promptSnippet: "Mark the active /goal complete after fully finishing and verifying it",
+	promptGuidelines: [
+		"Use goal_complete only when every explicit goal requirement is satisfied.",
+		"Before calling goal_complete, compare the goal against concrete evidence from files, commands, tests, or external state.",
+		"Do not use goal_complete for partial progress, plans, TODO lists, or blockers.",
+	],
+	parameters: Type.Object({
+		summary: Type.String({ description: "Concise completion summary." }),
+		evidence: Type.Optional(Type.String({ description: "Concrete evidence that proves the goal is complete." })),
+	}),
+	async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+		const completed = activeGoal
+			? transitionGoal(activeGoal, "complete", {
+					completedSummary: params.summary.trim(),
+					...(params.evidence?.trim() ? { completionEvidence: params.evidence.trim() } : {}),
+				})
+			: undefined;
+		if (completed) persistGoal(completed);
+		activeGoal = undefined;
+		clearContinuationState();
+		ctx.ui.setWidget(WIDGET_KEY, undefined);
+		ctx.ui.setStatus(STATUS_KEY, "🎯 complete");
+		ctx.ui.notify(`Goal complete: ${completed ? truncate(completed.objective, 120) : "no active goal"}`, "info");
+		return {
+			content: [
+				{
+					type: "text",
+					text: completed ? `Goal complete: ${params.summary.trim()}` : "No active goal.",
+				},
+			],
+			details: {
+				goal: completed,
+				summary: params.summary.trim(),
+				...(params.evidence?.trim() ? { evidence: params.evidence.trim() } : {}),
+			} satisfies GoalCompleteDetails,
+			terminate: true,
+		};
+	},
+});
+
+export default function goalExtension(pi: ExtensionAPI): void {
+	activePi = pi;
+	pi.registerTool(goalCompleteTool);
+
+	pi.registerCommand(COMMAND_NAME, {
+		description: "Run a session-scoped goal to completion: /goal [--tokens 100k] <objective>",
+		handler: async (args, ctx) => {
+			const parsed = parseGoalCommand(args);
+			if (typeof parsed === "string") {
+				ctx.ui.notify(parsed, "warning");
+				return;
+			}
+			switch (parsed.kind) {
+				case "show":
+					showGoal(ctx);
+					return;
+				case "pause":
+					pauseGoal(ctx, "user");
+					return;
+				case "resume":
+					await resumeGoal(pi, ctx);
+					return;
+				case "clear":
+					clearGoal(ctx);
+					return;
+				case "edit":
+					await updateGoalObjective(pi, ctx, parsed.objective, parsed.tokenBudget);
+					return;
+				case "start":
+					await startGoal(pi, ctx, parsed.objective, parsed.tokenBudget);
+					return;
+			}
+		},
+	});
+
+	pi.on("session_start", (_event, ctx) => {
+		loadGoal(ctx);
+	});
+	pi.on("session_compact", (_event, ctx) => {
+		loadGoal(ctx);
+	});
+	pi.on("session_tree", (_event, ctx) => {
+		loadGoal(ctx);
+	});
+	pi.on("session_shutdown", (_event, ctx) => {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.setWidget(WIDGET_KEY, undefined);
+		clearContinuationState();
+	});
+
+	pi.on("input", (event) => {
+		const marker = extractContinuationMarker(event.text);
+		if (marker && cancelledContinuationMarkers.delete(marker)) {
+			return { action: "handled" as const };
+		}
+	});
+
+	pi.on("before_agent_start", (event) => {
+		const marker = extractContinuationMarker(event.prompt);
+		if (marker && pendingContinuation?.marker === marker) pendingContinuation = undefined;
+		if (activeGoal?.status !== "active") return;
+		return { systemPrompt: `${event.systemPrompt}\n\n${buildGoalSystemPrompt(activeGoal)}` };
+	});
+
+	pi.on("agent_start", () => {
+		workToolCalledThisRun = false;
+	});
+
+	pi.on("tool_execution_end", (event) => {
+		if (activeGoal?.status !== "active") return;
+		if (event.isError || event.toolName === TOOL_NAME) return;
+		workToolCalledThisRun = true;
+	});
+
+	pi.on("agent_end", async (event, ctx) => {
+		if (activeGoal?.status !== "active") return;
+		const finalAssistant = finalAssistantMessage(event.messages as unknown[]);
+		const stopReason = assistantStopReason(finalAssistant);
+		if (stopReason === "aborted" || stopReason === "error") {
+			pauseGoal(ctx, stopReason);
+			return;
+		}
+
+		activeGoal = incrementGoal(activeGoal, assistantTurnTokens(finalAssistant));
+		if (isBudgetExhausted(activeGoal)) {
+			activeGoal = transitionGoal(activeGoal, "budget_limited");
+			persistGoal(activeGoal);
+			updateUI(ctx);
+			ctx.ui.notify(`Goal token budget reached: ${formatGoalStatus(activeGoal)}`, "warning");
+			return;
+		}
+		if (activeGoal.iteration >= MAX_CONTINUATIONS) {
+			pauseGoal(ctx, "continuation_limit");
+			return;
+		}
+		if (!workToolCalledThisRun) {
+			pauseGoal(ctx, "empty_turn");
+			return;
+		}
+
+		persistGoal(activeGoal);
+		updateUI(ctx);
+		if (hasPendingMessages(ctx)) return;
+		await sendContinuationPrompt(pi, ctx, activeGoal);
+	});
+}
+
+async function startGoal(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	objective: string,
+	tokenBudget: number | undefined,
+): Promise<void> {
+	const existing = activeGoal && activeGoal.status !== "complete" ? activeGoal : undefined;
+	if (existing) {
+		const replace = await ctx.ui.confirm(
+			"Replace active goal?",
+			`Current goal: ${existing.objective}\n\nNew goal: ${objective}`,
+		);
+		if (!replace) {
+			ctx.ui.notify("Goal unchanged.", "info");
+			return;
+		}
+	}
+	activeGoal = createGoal(objective, tokenBudget);
+	clearContinuationState();
+	persistGoal(activeGoal);
+	updateUI(ctx);
+	ctx.ui.notify(`Goal started: ${truncate(activeGoal.objective, 120)}`, "info");
+	await sendPrompt(pi, ctx, buildGoalPrompt(activeGoal));
+}
+
+async function updateGoalObjective(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext,
+	objective: string,
+	tokenBudget: number | undefined,
+): Promise<void> {
+	if (!activeGoal) {
+		ctx.ui.notify("No active goal to edit. Use /goal <objective> first.", "warning");
+		return;
+	}
+	activeGoal = editGoal(activeGoal, objective, tokenBudget);
+	clearContinuationState();
+	persistGoal(activeGoal);
+	updateUI(ctx);
+	ctx.ui.notify(`Goal updated: ${truncate(activeGoal.objective, 120)}`, "info");
+	if (activeGoal.status === "active") await sendPrompt(pi, ctx, buildGoalUpdatedPrompt(activeGoal));
+}
+
+function pauseGoal(ctx: ExtensionContext, reason: string): void {
+	if (!activeGoal) {
+		ctx.ui.notify("No active goal.", "warning");
+		return;
+	}
+	if (activeGoal.status !== "active") {
+		ctx.ui.notify(`Goal is ${activeGoal.status}.`, "info");
+		return;
+	}
+	activeGoal = transitionGoal(activeGoal, "paused", { pauseReason: reason });
+	cancelPendingContinuation();
+	persistGoal(activeGoal);
+	updateUI(ctx);
+	ctx.ui.notify(`Goal paused: ${reason}`, reason === "user" ? "info" : "warning");
+}
+
+async function resumeGoal(pi: ExtensionAPI, ctx: ExtensionCommandContext): Promise<void> {
+	if (!activeGoal) {
+		ctx.ui.notify("No paused goal.", "warning");
+		return;
+	}
+	if (activeGoal.status !== "paused" && activeGoal.status !== "budget_limited") {
+		ctx.ui.notify(`Goal is ${activeGoal.status}; only paused or budget-limited goals can resume.`, "warning");
+		return;
+	}
+	activeGoal = transitionGoal(activeGoal, "active", { pauseReason: undefined });
+	persistGoal(activeGoal);
+	updateUI(ctx);
+	ctx.ui.notify(`Goal resumed: ${truncate(activeGoal.objective, 120)}`, "info");
+	await sendPrompt(pi, ctx, buildGoalResumePrompt(activeGoal));
+}
+
+function clearGoal(ctx: ExtensionContext): void {
+	if (!activeGoal) {
+		ctx.ui.notify("No active goal.", "info");
+		return;
+	}
+	const objective = activeGoal.objective;
+	activeGoal = undefined;
+	cancelPendingContinuation();
+	persistGoal(null);
+	updateUI(ctx);
+	ctx.ui.notify(`Goal cleared: ${truncate(objective, 120)}`, "info");
+}
+
+function showGoal(ctx: ExtensionContext): void {
+	ctx.ui.notify(goalSummary(activeGoal), activeGoal ? "info" : "warning");
+	updateUI(ctx);
+}
+
+function loadGoal(ctx: ExtensionContext): void {
+	activeGoal = replayGoalFromEntries(ctx.sessionManager.getBranch());
+	clearContinuationState();
+	workToolCalledThisRun = false;
+	updateUI(ctx);
+}
+
+function persistGoal(goal: GoalRecord | null): void {
+	const state: GoalStateEntry = { goal };
+	activePi?.appendEntry(STATE_ENTRY, state);
+}
+
+let activePi: ExtensionAPI | undefined;
+
+function updateUI(ctx: ExtensionContext): void {
+	if (!ctx.hasUI) return;
+	if (!activeGoal) {
+		ctx.ui.setStatus(STATUS_KEY, undefined);
+		ctx.ui.setWidget(WIDGET_KEY, undefined);
+		return;
+	}
+	ctx.ui.setStatus(STATUS_KEY, formatGoalStatus(activeGoal));
+	ctx.ui.setWidget(
+		WIDGET_KEY,
+		[
+			formatGoalStatus(activeGoal),
+			`├─ ${truncate(activeGoal.objective, 100)}`,
+			`└─ /goal status · /goal pause · /goal clear`,
+		],
+		{ placement: "aboveEditor" },
+	);
+}
+
+async function sendContinuationPrompt(pi: ExtensionAPI, ctx: ExtensionContext, goal: GoalRecord): Promise<boolean> {
+	if (pendingContinuation?.goalId === goal.id) return false;
+	if (hasPendingMessages(ctx)) return false;
+	const marker = `${goal.id}:${goal.iteration}`;
+	pendingContinuation = { goalId: goal.id, marker };
+	const sent = await sendPrompt(pi, ctx, buildGoalContinuePrompt(goal, marker));
+	if (!sent && pendingContinuation?.marker === marker) pendingContinuation = undefined;
+	return sent;
+}
+
+async function sendPrompt(pi: ExtensionAPI, ctx: ExtensionContext, prompt: string): Promise<boolean> {
+	try {
+		if (isIdle(ctx)) pi.sendUserMessage(prompt);
+		else pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+		return true;
+	} catch (error) {
+		ctx.ui.notify(`Goal prompt failed: ${formatError(error)}`, "error");
+		return false;
+	}
+}
+
+function cancelPendingContinuation(): void {
+	if (pendingContinuation) cancelledContinuationMarkers.add(pendingContinuation.marker);
+	pendingContinuation = undefined;
+}
+
+function clearContinuationState(): void {
+	pendingContinuation = undefined;
+	cancelledContinuationMarkers.clear();
+}
+
+function hasPendingMessages(ctx: ExtensionContext): boolean {
+	try {
+		return ctx.hasPendingMessages?.() ?? false;
+	} catch {
+		return true;
+	}
+}
+
+function isIdle(ctx: ExtensionContext): boolean {
+	try {
+		return ctx.isIdle?.() ?? false;
+	} catch {
+		return false;
+	}
+}
+
+function formatError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return truncate(message, 160);
+}

--- a/packages/rpiv-goal/package.json
+++ b/packages/rpiv-goal/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@solforged/rpiv-goal",
+  "version": "0.0.1",
+  "description": "Pi extension. Session-scoped goal mode that keeps the agent working until explicit completion.",
+  "license": "MIT",
+  "type": "module",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "rpiv",
+    "goal",
+    "agent-loop",
+    "autonomous"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/juicesharp/rpiv-mono.git",
+    "directory": "packages/rpiv-goal"
+  },
+  "homepage": "",
+  "files": [
+    "index.ts",
+    "prompt.ts",
+    "state.ts",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/rpiv-goal/prompt.ts
+++ b/packages/rpiv-goal/prompt.ts
@@ -1,0 +1,76 @@
+import type { GoalRecord } from "./state.js";
+import { formatTokenCount } from "./state.js";
+
+export const CONTINUATION_MARKER_PREFIX = "rpiv-goal-continuation:";
+
+export function buildGoalPrompt(goal: GoalRecord): string {
+	return `Goal mode is active. Complete this goal fully:\n\n${goalBlock(goal)}${budgetLine(
+		goal,
+	)}\n\n${persistenceRules("this goal")}`;
+}
+
+export function buildGoalUpdatedPrompt(goal: GoalRecord): string {
+	return `The active /goal objective changed. Continue toward the updated goal:\n\n${goalBlock(
+		goal,
+	)}${budgetLine(goal)}\n\n${persistenceRules("the updated goal")}`;
+}
+
+export function buildGoalResumePrompt(goal: GoalRecord): string {
+	return `The user resumed the paused /goal. Continue toward this goal:\n\n${goalBlock(goal)}${budgetLine(
+		goal,
+	)}\n\n${persistenceRules("this goal")}`;
+}
+
+export function buildGoalSystemPrompt(goal: GoalRecord): string {
+	return `Active /goal:\n${goalBlock(
+		goal,
+	)}\n\nGoal-mode rules:\n- Keep working until the active goal is resolved end-to-end.\n- Do not redefine the goal into a smaller task.\n- Treat the worktree, command output, tests, and external state as authoritative.\n- Do not stop with only analysis, a plan, TODOs, or partial progress.\n- Use normal work tools when they are needed to complete the goal.\n- If blocked, say what blocks the goal and wait for the user instead of pretending it is complete.\n- Call goal_complete only after every explicit requirement is satisfied and verified.${
+		goal.tokenBudget === undefined
+			? ""
+			: `\n- Respect the token budget (${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(
+					goal.tokenBudget,
+				)} used).`
+	}`;
+}
+
+export function buildGoalContinuePrompt(goal: GoalRecord, marker: string): string {
+	return `Continue the active /goal until it is complete:\n\n${goalBlock(
+		goal,
+	)}\n\nAutomatic continuation #${goal.iteration}. Re-check current files and command output as needed. ${persistenceRules(
+		"this goal",
+	)}\n\n${continuationMarkerComment(marker)}`;
+}
+
+export function continuationMarkerComment(marker: string): string {
+	return `<!-- ${CONTINUATION_MARKER_PREFIX}${marker} -->`;
+}
+
+export function extractContinuationMarker(text: string): string | undefined {
+	return continuationPattern().exec(text)?.[1];
+}
+
+function continuationPattern(): RegExp {
+	return new RegExp(`<!--\\s*${escapeRegExp(CONTINUATION_MARKER_PREFIX)}([^\\s>]+)\\s*-->`);
+}
+
+function goalBlock(goal: GoalRecord): string {
+	return `<goal_objective>\n${escapeXml(goal.objective)}\n</goal_objective>`;
+}
+
+function budgetLine(goal: GoalRecord): string {
+	return goal.tokenBudget === undefined
+		? ""
+		: `\nToken budget: ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}.`;
+}
+
+function persistenceRules(goalLabel: string): string {
+	return `Keep going until ${goalLabel} is completely resolved. Before calling goal_complete, audit the goal requirement by requirement against concrete evidence and include the evidence in the tool call.`;
+}
+
+function escapeXml(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/rpiv-goal/ship-manifest.test.ts
+++ b/packages/rpiv-goal/ship-manifest.test.ts
@@ -1,0 +1,8 @@
+import { verifyShipManifest } from "@juicesharp/rpiv-test-utils";
+import { describe, expect, it } from "vitest";
+
+describe("publish manifest", () => {
+	it("`package.json` `files` array covers every production .ts module across the tree", () => {
+		expect(verifyShipManifest(import.meta.url).missing).toEqual([]);
+	});
+});

--- a/packages/rpiv-goal/state.test.ts
+++ b/packages/rpiv-goal/state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+	createGoal,
+	parseGoalCommand,
+	parseTokenBudget,
+	replayGoalFromEntries,
+	STATE_ENTRY,
+	transitionGoal,
+} from "./state.js";
+
+function custom(goal: unknown, id: string) {
+	return {
+		type: "custom",
+		customType: STATE_ENTRY,
+		data: { goal },
+		id,
+		parentId: null,
+		timestamp: "2026-05-28T00:00:00.000Z",
+	};
+}
+
+describe("parseGoalCommand", () => {
+	it("parses a bare command as status", () => {
+		expect(parseGoalCommand(" ")).toEqual({ kind: "show" });
+	});
+
+	it("parses a start command with a token budget", () => {
+		expect(parseGoalCommand("--tokens 100k fix failing tests")).toEqual({
+			kind: "start",
+			objective: "fix failing tests",
+			tokenBudget: 100_000,
+		});
+	});
+
+	it("parses edit with an equals token budget", () => {
+		expect(parseGoalCommand("edit --tokens=1.5m ship smaller fix")).toEqual({
+			kind: "edit",
+			objective: "ship smaller fix",
+			tokenBudget: 1_500_000,
+		});
+	});
+
+	it("rejects invalid token budgets", () => {
+		expect(parseTokenBudget("nope")).toContain("Token budget");
+	});
+});
+
+describe("replayGoalFromEntries", () => {
+	it("returns the latest unfinished goal", () => {
+		const oldGoal = createGoal("old", undefined, new Date("2026-05-28T00:00:00.000Z"));
+		const newGoal = createGoal("new", undefined, new Date("2026-05-28T00:01:00.000Z"));
+		expect(replayGoalFromEntries([custom(oldGoal, "1"), custom(newGoal, "2")])).toMatchObject({
+			id: newGoal.id,
+			objective: "new",
+		});
+	});
+
+	it("treats null and complete entries as no active goal", () => {
+		const goal = createGoal("done", undefined, new Date("2026-05-28T00:00:00.000Z"));
+		const complete = transitionGoal(goal, "complete");
+		expect(replayGoalFromEntries([custom(goal, "1"), custom(null, "2")])).toBeUndefined();
+		expect(replayGoalFromEntries([custom(complete, "1")])).toBeUndefined();
+	});
+});

--- a/packages/rpiv-goal/state.ts
+++ b/packages/rpiv-goal/state.ts
@@ -1,0 +1,266 @@
+import { randomUUID } from "node:crypto";
+
+export const COMMAND_NAME = "goal";
+export const STATE_ENTRY = "rpiv-goal-state";
+export const STATUS_KEY = "rpiv-goal";
+export const WIDGET_KEY = "rpiv-goal";
+export const TOOL_NAME = "goal_complete";
+export const MAX_CONTINUATIONS = 50;
+
+export type GoalStatus = "active" | "paused" | "budget_limited" | "complete";
+
+export interface GoalRecord {
+	id: string;
+	objective: string;
+	status: GoalStatus;
+	createdAt: string;
+	updatedAt: string;
+	iteration: number;
+	tokensUsed: number;
+	tokenBudget?: number;
+	pauseReason?: string;
+	completedSummary?: string;
+	completionEvidence?: string;
+}
+
+export interface GoalStateEntry {
+	goal: GoalRecord | null;
+}
+
+export type ParsedGoalCommand =
+	| { kind: "show" }
+	| { kind: "pause" }
+	| { kind: "resume" }
+	| { kind: "clear" }
+	| { kind: "edit"; objective: string; tokenBudget?: number }
+	| { kind: "start"; objective: string; tokenBudget?: number };
+
+export function createGoal(objective: string, tokenBudget?: number, now = new Date()): GoalRecord {
+	const timestamp = now.toISOString();
+	return {
+		id: randomUUID(),
+		objective: objective.trim(),
+		status: "active",
+		createdAt: timestamp,
+		updatedAt: timestamp,
+		iteration: 0,
+		tokensUsed: 0,
+		...(tokenBudget === undefined ? {} : { tokenBudget }),
+	};
+}
+
+export function parseGoalCommand(rawArgs: string): ParsedGoalCommand | string {
+	const args = rawArgs.trim();
+	if (!args) return { kind: "show" };
+
+	const [first, ...restParts] = args.split(/\s+/);
+	const rest = restParts.join(" ").trim();
+	if (first === "status") return rest ? "Usage: /goal status" : { kind: "show" };
+	if (first === "pause") return rest ? "Usage: /goal pause" : { kind: "pause" };
+	if (first === "resume") return rest ? "Usage: /goal resume" : { kind: "resume" };
+	if (first === "clear") return rest ? "Usage: /goal clear" : { kind: "clear" };
+	if (first === "edit") {
+		const parsed = parseObjectiveWithBudget(rest);
+		if (typeof parsed === "string") return parsed;
+		if (!parsed.objective) return "Usage: /goal edit <objective>";
+		return { kind: "edit", ...parsed };
+	}
+
+	const parsed = parseObjectiveWithBudget(args);
+	if (typeof parsed === "string") return parsed;
+	if (!parsed.objective) return "Usage: /goal [--tokens 100k] <objective>";
+	return { kind: "start", ...parsed };
+}
+
+function parseObjectiveWithBudget(input: string): { objective: string; tokenBudget?: number } | string {
+	let objective = input.trim();
+	let tokenBudget: number | undefined;
+	const eqMatch = /^--tokens=(\S+)\s*/.exec(objective);
+	const spacedMatch = /^--tokens\s+(\S+)\s*/.exec(objective);
+	const match = eqMatch ?? spacedMatch;
+	if (match) {
+		const parsed = parseTokenBudget(match[1] ?? "");
+		if (typeof parsed === "string") return parsed;
+		tokenBudget = parsed;
+		objective = objective.slice(match[0].length).trim();
+	}
+	return tokenBudget === undefined ? { objective } : { objective, tokenBudget };
+}
+
+export function parseTokenBudget(raw: string): number | string {
+	const match = /^(\d+(?:\.\d+)?)([kKmM])?$/.exec(raw.trim());
+	if (!match) return "Token budget must be a number, optionally suffixed with k or m.";
+	const base = Number(match[1]);
+	const suffix = match[2]?.toLowerCase();
+	const multiplier = suffix === "m" ? 1_000_000 : suffix === "k" ? 1_000 : 1;
+	const budget = Math.floor(base * multiplier);
+	if (!Number.isFinite(budget) || budget <= 0) return "Token budget must be greater than zero.";
+	if (budget > 100_000_000) return "Token budget is too large.";
+	return budget;
+}
+
+export function replayGoalFromEntries(entries: Iterable<unknown>): GoalRecord | undefined {
+	let latest: GoalRecord | null | undefined;
+	for (const entry of entries) {
+		const candidate = entry as { type?: string; customType?: string; data?: unknown };
+		if (candidate.type !== "custom" || candidate.customType !== STATE_ENTRY) continue;
+		const state = normalizeGoalStateEntry(candidate.data);
+		if (!state) continue;
+		latest = state.goal;
+	}
+	return latest && latest.status !== "complete" ? latest : undefined;
+}
+
+export function normalizeGoalStateEntry(value: unknown): GoalStateEntry | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const goal = (value as { goal?: unknown }).goal;
+	if (goal === null) return { goal: null };
+	const normalized = normalizeGoalRecord(goal);
+	return normalized ? { goal: normalized } : undefined;
+}
+
+export function normalizeGoalRecord(value: unknown): GoalRecord | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const raw = value as Partial<GoalRecord>;
+	if (typeof raw.id !== "string" || !raw.id) return undefined;
+	if (typeof raw.objective !== "string" || !raw.objective.trim()) return undefined;
+	if (!isGoalStatus(raw.status)) return undefined;
+	if (typeof raw.createdAt !== "string" || typeof raw.updatedAt !== "string") return undefined;
+	if (!isFiniteNonNegative(raw.iteration) || !isFiniteNonNegative(raw.tokensUsed)) return undefined;
+	const tokenBudget =
+		typeof raw.tokenBudget === "number" && raw.tokenBudget > 0 ? Math.floor(raw.tokenBudget) : undefined;
+	return {
+		id: raw.id,
+		objective: raw.objective.trim(),
+		status: raw.status,
+		createdAt: raw.createdAt,
+		updatedAt: raw.updatedAt,
+		iteration: Math.floor(raw.iteration),
+		tokensUsed: Math.floor(raw.tokensUsed),
+		...(tokenBudget === undefined ? {} : { tokenBudget }),
+		...(typeof raw.pauseReason === "string" ? { pauseReason: raw.pauseReason } : {}),
+		...(typeof raw.completedSummary === "string" ? { completedSummary: raw.completedSummary } : {}),
+		...(typeof raw.completionEvidence === "string" ? { completionEvidence: raw.completionEvidence } : {}),
+	};
+}
+
+function isGoalStatus(value: unknown): value is GoalStatus {
+	return value === "active" || value === "paused" || value === "budget_limited" || value === "complete";
+}
+
+function isFiniteNonNegative(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+export function transitionGoal(goal: GoalRecord, status: GoalStatus, patch: Partial<GoalRecord> = {}): GoalRecord {
+	return {
+		...goal,
+		...patch,
+		status,
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function editGoal(goal: GoalRecord, objective: string, tokenBudget?: number): GoalRecord {
+	const next: GoalRecord = {
+		...goal,
+		objective: objective.trim(),
+		status: goal.status === "paused" ? "paused" : "active",
+		updatedAt: new Date().toISOString(),
+	};
+	if (tokenBudget !== undefined) next.tokenBudget = tokenBudget;
+	return next;
+}
+
+export function incrementGoal(goal: GoalRecord, tokens: number): GoalRecord {
+	return {
+		...goal,
+		iteration: goal.iteration + 1,
+		tokensUsed: goal.tokensUsed + Math.max(0, Math.floor(tokens)),
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function isBudgetExhausted(goal: GoalRecord): boolean {
+	return goal.tokenBudget !== undefined && goal.tokensUsed >= goal.tokenBudget;
+}
+
+export function assistantTurnTokens(message: unknown): number {
+	if (!message || typeof message !== "object") return 0;
+	const usage = (message as { usage?: unknown }).usage;
+	if (!usage || typeof usage !== "object") return 0;
+	const raw = usage as Record<string, unknown>;
+	const total = numberValue(raw.totalTokens);
+	if (total > 0) return total;
+	return numberValue(raw.input) + numberValue(raw.output) + numberValue(raw.cacheRead) + numberValue(raw.cacheWrite);
+}
+
+export function finalAssistantMessage(messages: readonly unknown[]): unknown | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message && typeof message === "object" && (message as { role?: unknown }).role === "assistant") {
+			return message;
+		}
+	}
+	return undefined;
+}
+
+export function assistantStopReason(message: unknown): string | undefined {
+	if (!message || typeof message !== "object") return undefined;
+	const value = (message as { stopReason?: unknown }).stopReason;
+	return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function formatTokenCount(value: number): string {
+	if (value < 1_000) return `${value}`;
+	if (value < 1_000_000) return `${trimFixed(value / 1_000)}k`;
+	return `${trimFixed(value / 1_000_000)}m`;
+}
+
+function trimFixed(value: number): string {
+	return Number.isInteger(value) ? String(value) : value.toFixed(1).replace(/\.0$/, "");
+}
+
+export function formatGoalStatus(goal: GoalRecord): string {
+	const budget =
+		goal.tokenBudget === undefined
+			? ""
+			: ` ${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`;
+	if (goal.status === "active") return `🎯 active ${goal.iteration}/${MAX_CONTINUATIONS}${budget}`;
+	if (goal.status === "paused") return "🎯 paused";
+	if (goal.status === "budget_limited") return `🎯 budget${budget}`;
+	return "🎯 complete";
+}
+
+export function goalSummary(goal: GoalRecord | undefined): string {
+	if (!goal) return "No active goal.";
+	const lines = [
+		`Goal: ${goal.objective}`,
+		`Status: ${goal.status}`,
+		`Iteration: ${goal.iteration}/${MAX_CONTINUATIONS}`,
+		`Tokens: ${
+			goal.tokenBudget === undefined
+				? formatTokenCount(goal.tokensUsed)
+				: `${formatTokenCount(goal.tokensUsed)}/${formatTokenCount(goal.tokenBudget)}`
+		}`,
+		`Commands: ${goalCommandHint(goal.status)}`,
+	];
+	if (goal.pauseReason) lines.splice(2, 0, `Pause reason: ${goal.pauseReason}`);
+	return lines.join("\n");
+}
+
+function goalCommandHint(status: GoalStatus): string {
+	if (status === "active") return "/goal edit <objective>, /goal pause, /goal clear";
+	if (status === "paused" || status === "budget_limited") {
+		return "/goal resume, /goal edit <objective>, /goal clear";
+	}
+	return "/goal clear";
+}
+
+export function truncate(value: string, max = 120): string {
+	return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
+}


### PR DESCRIPTION
I have no idea if you would find something like this useful or if I've just completely misunderstood the point of your chain [I suspect I have, at least in part, given the centrality of interviewing and reviewing a plan before just blindly rushing into "code this"]. Coming from OpenCode and the other harnesses, I found myself reaching for a `/goal` skill in Pi and figured I'd ask if you use something of the sort enough to want to pull some variant of this into the core dev loop. 

The loop produces artifacts, design specs, docs, etc., and sometimes I'd like to be able to say "We've produced a design doc, I'm comfortable with where it's at, continue iterating on development until you've completed the whole thing and auto-compact along the way. Don't stop at Phase 1, keep going until it's all done."

The package itself is working, but it needs better tests, I need to back out the dprint-produced formatter changes, etc.