### PR TITLE
feat(rpiv-advisor): fuzzy type-to-filter in /advisor model & effort pickers

### DIFF
--- a/packages/rpiv-advisor/CHANGELOG.md
+++ b/packages/rpiv-advisor/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Type-to-filter fuzzy search in the `/advisor` model and reasoning-level pickers — start typing to narrow a long model list, with contiguous-run and word-boundary ranking; matches both the model name and the `provider:id` key. ([#50](https://github.com/juicesharp/rpiv-mono/issues/50))
+
 ## [1.15.0] - 2026-05-28
 
 ## [1.14.7] - 2026-05-28

--- a/packages/rpiv-advisor/README.md
+++ b/packages/rpiv-advisor/README.md
@@ -14,7 +14,7 @@ Let the model ask a stronger model for a second opinion before it acts. `rpiv-ad
 
 ## Features
 
-- **Reviewer model selector** - `/advisor` opens a picker over any model in Pi's registry, plus a reasoning-effort picker for reasoning-capable models.
+- **Reviewer model selector** - `/advisor` opens a picker over any model in Pi's registry, plus a reasoning-effort picker for reasoning-capable models. Start typing to fuzzy-filter the list by model name or `provider:id`.
 - **Persisted across sessions** - selection saved at `~/.config/rpiv-advisor/advisor.json` (chmod 0600).
 - **Off by default** - the `advisor` tool is excluded until you pick a model; choose "No advisor" to disable.
 - **Per-executor blocklist** - list executor models in `disabledForModels` (in `advisor.json`) to strip the `advisor` tool when those models drive the session. Entries can be plain strings (block at any effort) or `{ "model": "<provider:id>", "minEffort": "<level>" }` to block only when the executor's effort meets or exceeds the threshold. Available levels, lowest to highest: `minimal`, `low`, `medium`, `high`, `xhigh`.

--- a/packages/rpiv-advisor/advisor-ui.filter.test.ts
+++ b/packages/rpiv-advisor/advisor-ui.filter.test.ts
@@ -1,0 +1,154 @@
+import type { SelectItem } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { filterItems, fuzzyScore, showAdvisorPicker } from "./advisor-ui.js";
+
+interface RenderableComponent {
+	render: (w: number) => string[];
+	invalidate: () => void;
+	handleInput: (data: string) => void;
+}
+
+const identityTheme = {
+	fg: (_c: string, s: string) => s,
+	bg: (_c: string, s: string) => s,
+	bold: (s: string) => s,
+	strikethrough: (s: string) => s,
+};
+
+function driveCustom<T>(script: (c: RenderableComponent, done: (v: T) => void) => void) {
+	const requestRender = vi.fn();
+	const custom = vi.fn((factory: unknown) => {
+		return new Promise((resolve) => {
+			const f = factory as (
+				tui: { requestRender: () => void },
+				theme: typeof identityTheme,
+				kb: undefined,
+				done: (v: unknown) => void,
+			) => RenderableComponent;
+			const component = f({ requestRender }, identityTheme, undefined, resolve);
+			script(component, resolve as (v: T) => void);
+		});
+	});
+	return { custom, requestRender };
+}
+
+const advisorItems: SelectItem[] = [
+	{ label: "Claude Opus", value: "anthropic:claude-opus-4-7" },
+	{ label: "Claude Sonnet", value: "anthropic:claude-sonnet-4-6" },
+	{ label: "Claude Haiku", value: "anthropic:claude-haiku-4-5" },
+	{ label: "GPT-5", value: "openai:gpt-5" },
+	{ label: "GLM-4.6", value: "zai:glm-4-6" },
+	{ label: "No advisor", value: "__none__" },
+];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("fuzzyScore", () => {
+	it("returns 0 for an empty query (matches everything)", () => {
+		expect(fuzzyScore("", "anything")).toBe(0);
+	});
+
+	it("returns null when the query is not a subsequence", () => {
+		expect(fuzzyScore("xyz", "claude opus")).toBeNull();
+	});
+
+	it("matches a subsequence regardless of contiguity", () => {
+		expect(fuzzyScore("cop", "claude opus")).not.toBeNull();
+	});
+
+	it("is case-insensitive", () => {
+		expect(fuzzyScore("OPUS", "claude opus")).not.toBeNull();
+	});
+
+	it("scores a contiguous run higher than a scattered match", () => {
+		const contiguous = fuzzyScore("opus", "claude opus") as number;
+		const scattered = fuzzyScore("clop", "claude opus") as number;
+		expect(contiguous).toBeGreaterThan(scattered);
+	});
+
+	it("rewards word-boundary matches", () => {
+		const boundary = fuzzyScore("o", "claude opus") as number; // matches the 'o' at a space boundary
+		const midword = fuzzyScore("d", "claude opus") as number; // matches 'd' mid-word
+		expect(boundary).toBeGreaterThan(midword);
+	});
+});
+
+describe("filterItems", () => {
+	it("returns the original list (same order) for an empty query", () => {
+		expect(filterItems(advisorItems, "")).toEqual(advisorItems);
+	});
+
+	it("matches against the value, not just the label", () => {
+		const result = filterItems(advisorItems, "gpt-5");
+		expect(result.map((i) => i.value)).toContain("openai:gpt-5");
+	});
+
+	it("matches a label substring that is not a prefix of the value", () => {
+		// "opus" is not a prefix of "anthropic:claude-opus-4-7" — the built-in
+		// SelectList.setFilter would miss this; fuzzy matching catches it.
+		const result = filterItems(advisorItems, "opus");
+		expect(result[0]?.value).toBe("anthropic:claude-opus-4-7");
+	});
+
+	it("drops items that do not match", () => {
+		const result = filterItems(advisorItems, "glm");
+		expect(result).toHaveLength(1);
+		expect(result[0]?.value).toBe("zai:glm-4-6");
+	});
+
+	it("returns an empty list when nothing matches", () => {
+		expect(filterItems(advisorItems, "zzzzzz")).toEqual([]);
+	});
+});
+
+describe("showAdvisorPicker — type-to-filter flow", () => {
+	it("typing narrows the list so ENTER picks the filtered match", async () => {
+		const { custom } = driveCustom<string | null>((c) => {
+			for (const ch of "opus") c.handleInput(ch);
+			c.handleInput("\r");
+		});
+		const ctx = { ui: { custom } } as never;
+		const r = await showAdvisorPicker(ctx, advisorItems);
+		expect(r).toBe("anthropic:claude-opus-4-7");
+	});
+
+	it("backspace widens the query again", async () => {
+		const { custom } = driveCustom<string | null>((c) => {
+			for (const ch of "glm") c.handleInput(ch);
+			// remove all three chars (DEL) -> full list restored, first item selected
+			c.handleInput("\u007f");
+			c.handleInput("\u007f");
+			c.handleInput("\u007f");
+			c.handleInput("\r");
+		});
+		const ctx = { ui: { custom } } as never;
+		const r = await showAdvisorPicker(ctx, advisorItems);
+		expect(r).toBe("anthropic:claude-opus-4-7");
+	});
+
+	it("renders the typed filter in the panel", async () => {
+		const { custom } = driveCustom<string | null>((c, done) => {
+			for (const ch of "son") c.handleInput(ch);
+			const out = c.render(100).join("\n");
+			expect(out).toContain("Filter: son");
+			expect(out).toContain("Claude Sonnet");
+			expect(out).not.toContain("Claude Haiku");
+			done(null);
+		});
+		const ctx = { ui: { custom } } as never;
+		await showAdvisorPicker(ctx, advisorItems);
+	});
+
+	it("shows the type-to-filter hint before any input", async () => {
+		const { custom } = driveCustom<string | null>((c, done) => {
+			const out = c.render(100).join("\n");
+			expect(out).toContain("Type to filter…");
+			expect(out).toContain("type to filter • ↑↓ navigate • enter select • esc cancel");
+			done(null);
+		});
+		const ctx = { ui: { custom } } as never;
+		await showAdvisorPicker(ctx, advisorItems);
+	});
+});

--- a/packages/rpiv-advisor/advisor-ui.ts
+++ b/packages/rpiv-advisor/advisor-ui.ts
@@ -2,8 +2,8 @@
  * advisor-ui — bordered select-panel builders for the /advisor command.
  *
  * Two public functions (showAdvisorPicker, showEffortPicker) share a private
- * buildSelectPanel helper that owns the bordered-container layout and the
- * SelectList theme wiring.
+ * showFilterablePicker helper that owns the bordered-container layout, the
+ * SelectList theme wiring, and a type-to-filter fuzzy search over the items.
  */
 
 import type { ThinkingLevel } from "@earendil-works/pi-ai";
@@ -11,7 +11,7 @@ import { DynamicBorder, type ExtensionContext, type Theme } from "@earendil-work
 import { Container, type SelectItem, SelectList, Spacer, Text } from "@earendil-works/pi-tui";
 
 const MAX_VISIBLE_ROWS = 10;
-const NAV_HINT = "↑↓ navigate • enter select • esc cancel";
+const NAV_HINT = "type to filter • ↑↓ navigate • enter select • esc cancel";
 
 const ADVISOR_HEADER_TITLE = "Advisor Tool";
 const ADVISOR_HEADER_PROSE_1 =
@@ -29,6 +29,68 @@ const EFFORT_HEADER_PROSE =
 	"Choose the reasoning effort level for the advisor. " +
 	"Higher levels produce stronger judgment but use more tokens.";
 
+/**
+ * Fuzzy subsequence match. Returns a relevance score (higher is better) when
+ * every character of `query` appears in `text` in order, or null when it does
+ * not match. Contiguous runs and word-boundary hits (start, space, ":", "-")
+ * score higher so "opus" ranks an "Opus" model above an incidental scatter.
+ */
+export function fuzzyScore(query: string, text: string): number | null {
+	const q = query.toLowerCase();
+	const t = text.toLowerCase();
+	if (q.length === 0) return 0;
+
+	let qi = 0;
+	let score = 0;
+	let streak = 0;
+	let prevMatch = -2;
+
+	for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+		if (t[ti] !== q[qi]) continue;
+
+		if (prevMatch === ti - 1) {
+			streak += 1;
+			score += 5 + streak;
+		} else {
+			streak = 0;
+			score += 1;
+		}
+
+		const prev = t[ti - 1];
+		if (ti === 0 || prev === " " || prev === ":" || prev === "-") score += 3;
+
+		prevMatch = ti;
+		qi += 1;
+	}
+
+	return qi === q.length ? score : null;
+}
+
+/**
+ * Filter + rank items by a fuzzy query, matching against both the visible
+ * label and the underlying value (e.g. "anthropic:claude-opus-4-7"). An empty
+ * query returns the items unchanged, preserving the caller's ordering.
+ */
+export function filterItems(items: SelectItem[], query: string): SelectItem[] {
+	if (query.length === 0) return items;
+
+	return items
+		.map((item, idx) => ({ item, idx, score: fuzzyScore(query, `${item.label} ${item.value}`) }))
+		.filter((scored): scored is { item: SelectItem; idx: number; score: number } => scored.score !== null)
+		.sort((a, b) => b.score - a.score || a.idx - b.idx)
+		.map((scored) => scored.item);
+}
+
+function isBackspace(data: string): boolean {
+	return data === "\u007f" || data === "\b";
+}
+
+function isPrintable(data: string): boolean {
+	if (data.length !== 1) return false;
+	const code = data.charCodeAt(0);
+	return code >= 0x20 && code !== 0x7f;
+}
+
 function selectListTheme(theme: Theme) {
 	return {
 		selectedPrefix: (t: string) => theme.bg("selectedBg", theme.fg("accent", t)),
@@ -39,7 +101,13 @@ function selectListTheme(theme: Theme) {
 	};
 }
 
-function buildSelectPanel(theme: Theme, title: string, proseLines: string[], selectList: SelectList): Container {
+function buildSelectPanel(
+	theme: Theme,
+	title: string,
+	proseLines: string[],
+	query: string,
+	selectList: SelectList,
+): Container {
 	const container = new Container();
 	const border = () => new DynamicBorder((s: string) => theme.fg("accent", s));
 
@@ -51,6 +119,9 @@ function buildSelectPanel(theme: Theme, title: string, proseLines: string[], sel
 		container.addChild(new Text(line, 1, 0));
 		container.addChild(new Spacer(1));
 	}
+	const filterText = query.length > 0 ? `Filter: ${query}` : "Type to filter…";
+	container.addChild(new Text(theme.fg(query.length > 0 ? "accent" : "dim", filterText), 1, 0));
+	container.addChild(new Spacer(1));
 	container.addChild(selectList);
 	container.addChild(new Spacer(1));
 	container.addChild(new Text(theme.fg("dim", NAV_HINT), 1, 0));
@@ -59,27 +130,61 @@ function buildSelectPanel(theme: Theme, title: string, proseLines: string[], sel
 	return container;
 }
 
-export async function showAdvisorPicker(ctx: ExtensionContext, items: SelectItem[]): Promise<string | null> {
-	return ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
-		const selectList = new SelectList(items, Math.min(items.length, MAX_VISIBLE_ROWS), selectListTheme(theme));
-		selectList.onSelect = (item) => done(item.value);
-		selectList.onCancel = () => done(null);
+interface FilterablePickerOptions {
+	title: string;
+	proseLines: string[];
+	items: SelectItem[];
+	/** Value to preselect while the query is empty (e.g. the current effort). */
+	preferredValue?: string;
+}
 
-		const container = buildSelectPanel(
-			theme,
-			ADVISOR_HEADER_TITLE,
-			[ADVISOR_HEADER_PROSE_1, ADVISOR_HEADER_PROSE_2],
-			selectList,
-		);
+function showFilterablePicker(ctx: ExtensionContext, opts: FilterablePickerOptions): Promise<string | null> {
+	return ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
+		let query = "";
+		let selectList: SelectList;
+		let container: Container;
+
+		const rebuild = () => {
+			const filtered = filterItems(opts.items, query);
+			const visibleRows = Math.min(Math.max(filtered.length, 1), MAX_VISIBLE_ROWS);
+			selectList = new SelectList(filtered, visibleRows, selectListTheme(theme));
+			selectList.onSelect = (item) => done(item.value);
+			selectList.onCancel = () => done(null);
+			if (query.length === 0 && opts.preferredValue) {
+				const idx = filtered.findIndex((item) => item.value === opts.preferredValue);
+				if (idx >= 0) selectList.setSelectedIndex(idx);
+			}
+			container = buildSelectPanel(theme, opts.title, opts.proseLines, query, selectList);
+		};
+
+		rebuild();
 
 		return {
 			render: (w) => container.render(w),
 			invalidate: () => container.invalidate(),
 			handleInput: (data) => {
-				selectList.handleInput(data);
+				if (isBackspace(data)) {
+					if (query.length > 0) {
+						query = query.slice(0, -1);
+						rebuild();
+					}
+				} else if (isPrintable(data)) {
+					query += data;
+					rebuild();
+				} else {
+					selectList.handleInput(data);
+				}
 				tui.requestRender();
 			},
 		};
+	});
+}
+
+export async function showAdvisorPicker(ctx: ExtensionContext, items: SelectItem[]): Promise<string | null> {
+	return showFilterablePicker(ctx, {
+		title: ADVISOR_HEADER_TITLE,
+		proseLines: [ADVISOR_HEADER_PROSE_1, ADVISOR_HEADER_PROSE_2],
+		items,
 	});
 }
 
@@ -89,24 +194,11 @@ export async function showEffortPicker(
 	currentEffort: ThinkingLevel | undefined,
 	defaultEffort: ThinkingLevel,
 ): Promise<string | null> {
-	return ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
-		const selectList = new SelectList(items, Math.min(items.length, MAX_VISIBLE_ROWS), selectListTheme(theme));
-		const preferredIdx = currentEffort ? items.findIndex((item) => item.value === currentEffort) : -1;
-		selectList.setSelectedIndex(
-			preferredIdx >= 0 ? preferredIdx : items.findIndex((item) => item.value === defaultEffort),
-		);
-		selectList.onSelect = (item) => done(item.value);
-		selectList.onCancel = () => done(null);
-
-		const container = buildSelectPanel(theme, EFFORT_HEADER_TITLE, [EFFORT_HEADER_PROSE], selectList);
-
-		return {
-			render: (w) => container.render(w),
-			invalidate: () => container.invalidate(),
-			handleInput: (data) => {
-				selectList.handleInput(data);
-				tui.requestRender();
-			},
-		};
+	const preferredValue = items.some((item) => item.value === currentEffort) ? currentEffort : defaultEffort;
+	return showFilterablePicker(ctx, {
+		title: EFFORT_HEADER_TITLE,
+		proseLines: [EFFORT_HEADER_PROSE],
+		items,
+		preferredValue,
 	});
 }


### PR DESCRIPTION
Closes #50.

## What

Adds **type-to-filter fuzzy search** to the `/advisor` pickers. Previously the model picker listed every registered model in a scroll-only `SelectList` capped at 10 visible rows — with many providers configured, selection meant arrow-key scrolling. The built-in `SelectList.setFilter` only does a **prefix** match on the model key (`provider:id`), so typing `opus` would not surface `anthropic:claude-opus-4-7`.

## How

- **`fuzzyScore(query, text)`** — subsequence matcher returning a relevance score (or `null` for no match), with bonuses for contiguous runs and word-boundary hits (start, space, `:`, `-`) so `opus` ranks the Opus model above an incidental scatter.
- **`filterItems(items, query)`** — filters + ranks items, matching against **both** the visible label and the `provider:id` value. Empty query returns the list unchanged.
- **`showFilterablePicker`** — shared helper now backing both the model picker and the reasoning-level picker. Printable keys append to the query, backspace trims it; navigation/confirm/cancel still pass straight through to `SelectList`. The panel renders the live filter and an updated nav hint (`type to filter • ↑↓ navigate • enter select • esc cancel`).

`showAdvisorPicker` / `showEffortPicker` keep their existing signatures, so callers in `advisor.ts` are unchanged.

## Tests

- New `advisor-ui.filter.test.ts`: unit coverage for `fuzzyScore` (subsequence, case-insensitivity, contiguity/boundary ranking) and `filterItems` (label-vs-value matching, the `opus` non-prefix case, drops, empty result), plus picker-flow tests driving real keystrokes (type-to-narrow, backspace-to-widen, live filter render, hint).
- Existing `advisor-ui.picker.test.ts` / `advisor-ui.panel.test.ts` pass unchanged.
- Full package suite green (148 tests); repo `check` (biome + tsc) clean — both run by the pre-commit hook.

## Docs

- README feature bullet + `[Unreleased]` CHANGELOG entry.

I opened #50 first per the contribution policy; happy to adjust direction (e.g. ranking heuristics, or scoping filtering to the model picker only) on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)