### PR TITLE
fix: handle stale extension ctx in session_compact and session_tree handlers

### DIFF
--- a/packages/rpiv-btw/btw.ts
+++ b/packages/rpiv-btw/btw.ts
@@ -291,8 +291,23 @@ export function registerMessageEndSnapshot(pi: ExtensionAPI): void {
 }
 
 export function registerInvalidationHooks(pi: ExtensionAPI): void {
-	pi.on("session_compact", async (_e, ctx) => invalidateSnapshot(ctx));
-	pi.on("session_tree", async (_e, ctx) => invalidateSnapshot(ctx));
+	// session_compact / session_tree: invalidate the snapshot cache after compaction
+	// or tree navigation. The extension runner ctx may be stale if a
+	// concurrent session replacement invalidated the proxy.
+	pi.on("session_compact", async (_e, ctx) => {
+		try {
+			invalidateSnapshot(ctx);
+		} catch {
+			// stale ctx — nothing to invalidate
+		}
+	});
+	pi.on("session_tree", async (_e, ctx) => {
+		try {
+			invalidateSnapshot(ctx);
+		} catch {
+			// stale ctx — nothing to invalidate
+		}
+	});
 }
 
 export function registerBtwCommand(pi: ExtensionAPI): void {

--- a/packages/rpiv-pi/extensions/rpiv-core/session-hooks.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/session-hooks.ts
@@ -130,7 +130,16 @@ async function onSessionCompact(_event: unknown, ctx: { cwd: string }, pi: Exten
 	resetInjectionState();
 	clearGitContextCache();
 	resetInjectedMarker();
-	injectRootGuidance(ctx.cwd, pi);
+	// After auto-compaction the extension runner ctx may be stale
+	// (invalidated by a concurrent session replacement or reload).
+	// Fall back to process.cwd() when the proxy throws.
+	let cwd: string;
+	try {
+		cwd = ctx.cwd;
+	} catch {
+		cwd = process.cwd();
+	}
+	injectRootGuidance(cwd, pi);
 	await injectGitContext(pi, (msg) => sendGitContextMessage(pi, msg));
 }
 

--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -62,13 +62,24 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_compact", async (_event, ctx) => {
-		replaceState(replayFromBranch(ctx));
+		// After auto-compaction the extension runner ctx may be stale
+		// (invalidated by a concurrent session replacement or reload).
+		// Keep existing state when replay is unavailable.
+		try {
+			replaceState(replayFromBranch(ctx));
+		} catch {
+			// stale ctx — keep current state
+		}
 		todoOverlay?.resetCompletedDisplayState();
 		todoOverlay?.update();
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
-		replaceState(replayFromBranch(ctx));
+		try {
+			replaceState(replayFromBranch(ctx));
+		} catch {
+			// stale ctx — keep current state
+		}
 		todoOverlay?.resetCompletedDisplayState();
 		todoOverlay?.update();
 	});


### PR DESCRIPTION
## Problem

After auto-compaction, the extension runner context proxy may be stale (invalidated by a concurrent session replacement or reload). Accessing `ctx.cwd` or `ctx.sessionManager` throws:

```
This extension ctx is stale after session replacement or reload.
```

This is a race condition in pi core where `dispose()` invalidates the runner while auto-compaction is still emitting `session_compact`.

## Fix

Defensive handling in three extension handlers:

| Package | Handler | Fix |
|---------|---------|-----|
| `rpiv-core` | `onSessionCompact` | try `ctx.cwd`, fall back to `process.cwd()` |
| `rpiv-todo` | `session_compact` / `session_tree` | try `replayFromBranch(ctx)`, keep existing state on error |
| `rpiv-btw` | `session_compact` / `session_tree` | try `invalidateSnapshot(ctx)`, skip on error |

## Root cause

Pi core — `AgentSession.dispose()` calls `_extensionRunner.invalidate()` while `_runAutoCompaction` is still emitting `session_compact`. A proper fix in pi core would emit the event before invalidation or pass a fresh context, but the extensions should be defensive regardless.

## Testing

Existing tests unaffected — the try/catch only activates when the runner proxy throws, which only happens during the race condition (not in unit tests with mock contexts).