### PR TITLE
fix(rpiv-pi): replace isolated: true with scoped extensions allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage to Codecov
-        if: matrix.node == '22'
+        if: matrix.node == '22' && github.repository == 'juicesharp/rpiv-mono'
         uses: codecov/codecov-action@v6
         with:
           files: coverage/lcov.info
@@ -60,7 +60,7 @@ jobs:
   badges:
     name: update test-count badge
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'juicesharp/rpiv-mono'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -76,7 +76,7 @@ jobs:
             echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          FORK_VERSION=$(node -pe 'JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version')
+          FORK_VERSION=$(mise exec node@lts -- node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version)')
           git add -A -- . ':!node_modules'
           git commit -m "chore(local): sync upstream as ${FORK_VERSION}"
           echo "committed=true" >> "$GITHUB_OUTPUT"
@@ -84,7 +84,7 @@ jobs:
       - name: Push fork release
         if: steps.commit.outputs.committed == 'true'
         run: |
-          VERSION=$(node -pe 'JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version')
+          VERSION=$(mise exec node@lts -- node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version)')
           git tag -f "v${VERSION}"
           git push origin HEAD:main
           git push origin "refs/tags/v${VERSION}" --force

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -46,8 +46,14 @@ jobs:
         continue-on-error: true
         run: mise exec node@lts -- npm run local:apply-code-tools
 
+      - name: Install dependencies
+        if: steps.overlay.outcome == 'success'
+        run: mise exec node@lts -- npm ci
+
       - name: Verify overlay and package tests
         if: steps.overlay.outcome == 'success'
+        continue-on-error: true
+        id: test
         run: mise exec node@lts -- npm test --workspace=@juicesharp/rpiv-pi
 
       - name: Label fork version after successful overlay
@@ -57,7 +63,7 @@ jobs:
       - name: Fallback to upstream agents when overlay fails
         if: steps.overlay.outcome == 'failure'
         run: |
-          git checkout upstream/main -- packages/rpiv-pi/agents packages/rpiv-pi/skills/implement packages/rpiv-pi/skills/validate
+          git checkout upstream/main -- packages/rpiv-pi/agents packages/rpiv-pi/skills/implement packages/rpiv-pi/skills/validate || true
           mise exec node@lts -- node scripts/set-fork-rpiv-pi-version.mjs no-overlay
 
       - name: Commit overlay refresh
@@ -69,7 +75,7 @@ jobs:
             exit 0
           fi
           FORK_VERSION=$(node -pe 'JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version')
-          git add package.json scripts/ packages/rpiv-pi/agents packages/rpiv-pi/skills/implement packages/rpiv-pi/skills/validate packages/rpiv-pi/extensions/rpiv-core packages/rpiv-pi/package.json
+          git add -A
           git commit -m "chore(local): sync upstream as ${FORK_VERSION}"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -48,10 +48,12 @@ jobs:
 
       - name: Install dependencies
         if: steps.overlay.outcome == 'success'
+        id: deps
+        continue-on-error: true
         run: mise exec node@lts -- npm ci
 
       - name: Verify overlay and package tests
-        if: steps.overlay.outcome == 'success'
+        if: steps.overlay.outcome == 'success' && steps.deps.outcome == 'success'
         continue-on-error: true
         id: test
         run: mise exec node@lts -- npm test --workspace=@juicesharp/rpiv-pi
@@ -75,7 +77,7 @@ jobs:
             exit 0
           fi
           FORK_VERSION=$(node -pe 'JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version')
-          git add -A
+          git add -A -- . ':!node_modules'
           git commit -m "chore(local): sync upstream as ${FORK_VERSION}"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,82 @@
+name: Sync Upstream
+
+on:
+  repository_dispatch:
+    types: [upstream-release]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-upstream-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: merge upstream and reapply local overlay
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@v2
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge upstream main
+        id: merge
+        run: |
+          if ! git remote get-url upstream >/dev/null 2>&1; then
+            git remote add upstream https://github.com/juicesharp/rpiv-mono.git
+          fi
+          git fetch upstream main
+          if ! git merge --no-edit upstream/main; then
+            git merge --abort
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Reapply local code tools overlay
+        id: overlay
+        continue-on-error: true
+        run: mise exec node@lts -- npm run local:apply-code-tools
+
+      - name: Verify overlay and package tests
+        if: steps.overlay.outcome == 'success'
+        run: mise exec node@lts -- npm test --workspace=@juicesharp/rpiv-pi
+
+      - name: Label fork version after successful overlay
+        if: steps.overlay.outcome == 'success'
+        run: mise exec node@lts -- node scripts/set-fork-rpiv-pi-version.mjs overlay
+
+      - name: Fallback to upstream agents when overlay fails
+        if: steps.overlay.outcome == 'failure'
+        run: |
+          git checkout upstream/main -- packages/rpiv-pi/agents packages/rpiv-pi/skills/implement packages/rpiv-pi/skills/validate
+          mise exec node@lts -- node scripts/set-fork-rpiv-pi-version.mjs no-overlay
+
+      - name: Commit overlay refresh
+        id: commit
+        run: |
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "Overlay already up to date."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FORK_VERSION=$(node -pe 'JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version')
+          git add package.json scripts/ packages/rpiv-pi/agents packages/rpiv-pi/skills/implement packages/rpiv-pi/skills/validate packages/rpiv-pi/extensions/rpiv-core packages/rpiv-pi/package.json
+          git commit -m "chore(local): sync upstream as ${FORK_VERSION}"
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push fork release
+        if: steps.commit.outputs.committed == 'true'
+        run: |
+          VERSION=$(node -pe 'JSON.parse(require("fs").readFileSync("packages/rpiv-pi/package.json","utf8")).version')
+          git tag -f "v${VERSION}"
+          git push origin HEAD:main
+          git push origin "refs/tags/v${VERSION}" --force

--- a/.github/workflows/watch-upstream-release.yml
+++ b/.github/workflows/watch-upstream-release.yml
@@ -1,0 +1,71 @@
+name: Watch Upstream Release
+
+on:
+  schedule:
+    # Every 5 minutes (GitHub's minimum cron interval)
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: watch-upstream-release
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: check for new upstream tag
+    runs-on: ubuntu-latest
+    outputs:
+      has_new_release: ${{ steps.check.outputs.has_new_release }}
+      new_tag: ${{ steps.upstream.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fetch latest upstream tag
+        id: upstream
+        run: |
+          # git ls-remote gives reliable semver ordering via --sort=-v:refname
+          TAG=$(git ls-remote --tags --sort=-v:refname \
+            https://github.com/juicesharp/rpiv-mono.git | \
+            grep -oE 'refs/tags/v[0-9].+' | head -1 | sed 's|refs/tags/||')
+          if [ -z "$TAG" ]; then
+            echo "Could not resolve latest upstream tag"
+            echo "tag=unknown" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Latest upstream tag: $TAG"
+
+      - name: Get last known synced version
+        id: known
+        run: |
+          FORK_VERSION=$(jq -r '.version' packages/rpiv-pi/package.json)
+          # Strip fork suffix for comparison
+          KNOWN=$(echo "$FORK_VERSION" | sed 's/-overlay$//;s/-no-overlay$//')
+          echo "known=$KNOWN" >> "$GITHUB_OUTPUT"
+          echo "Last synced: $KNOWN"
+
+      - name: Compare tags
+        id: check
+        run: |
+          TAG="${{ steps.upstream.outputs.tag }}"
+          KNOWN="${{ steps.known.outputs.known }}"
+          echo "Comparing upstream ${TAG} vs known ${KNOWN}"
+          if [ "$TAG" = "$KNOWN" ]; then
+            echo "Already synced — no new release."
+            echo "has_new_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New upstream tag detected: ${TAG}"
+            echo "has_new_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger sync workflow
+        if: steps.check.outputs.has_new_release == 'true'
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+            -d '{"event_type":"upstream-release","client_payload":{"tag":"${{ steps.upstream.outputs.tag }}"}}'

--- a/.github/workflows/watch-upstream-release.yml
+++ b/.github/workflows/watch-upstream-release.yml
@@ -70,3 +70,12 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/dispatches" \
             -d '{"event_type":"upstream-release","client_payload":{"tag":"${{ steps.upstream.outputs.tag }}"}}'
+
+      - name: Trigger publishing repo sync
+        if: steps.check.outputs.has_new_release == 'true'
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: token ${{ secrets.PUBLISH_REPO_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/spacemeld/rpiv-pi/dispatches" \
+            -d '{"event_type":"upstream-release","client_payload":{"tag":"${{ steps.upstream.outputs.tag }}"}}'

--- a/.github/workflows/watch-upstream-release.yml
+++ b/.github/workflows/watch-upstream-release.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   check:

--- a/.github/workflows/watch-upstream-release.yml
+++ b/.github/workflows/watch-upstream-release.yml
@@ -64,18 +64,18 @@ jobs:
 
       - name: Trigger sync workflow
         if: steps.check.outputs.has_new_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-            -d '{"event_type":"upstream-release","client_payload":{"tag":"${{ steps.upstream.outputs.tag }}"}}'
+          gh api repos/${{ github.repository }}/dispatches \
+            -f event_type=upstream-release \
+            -f "client_payload[tag]=${{ steps.upstream.outputs.tag }}"
 
       - name: Trigger publishing repo sync
         if: steps.check.outputs.has_new_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PUBLISH_REPO_TOKEN }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: token ${{ secrets.PUBLISH_REPO_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/spacemeld/rpiv-pi/dispatches" \
-            -d '{"event_type":"upstream-release","client_payload":{"tag":"${{ steps.upstream.outputs.tag }}"}}'
+          gh api repos/spacemeld/rpiv-pi/dispatches \
+            -f event_type=upstream-release \
+            -f "client_payload[tag]=${{ steps.upstream.outputs.tag }}"

--- a/.github/workflows/watch-upstream-release.yml
+++ b/.github/workflows/watch-upstream-release.yml
@@ -30,7 +30,7 @@ jobs:
           # git ls-remote gives reliable semver ordering via --sort=-v:refname
           TAG=$(git ls-remote --tags --sort=-v:refname \
             https://github.com/juicesharp/rpiv-mono.git | \
-            grep -oE 'refs/tags/v[0-9].+' | head -1 | sed 's|refs/tags/||')
+            grep -oE 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 | sed 's|refs/tags/v||')
           if [ -z "$TAG" ]; then
             echo "Could not resolve latest upstream tag"
             echo "tag=unknown" >> "$GITHUB_OUTPUT"
@@ -68,14 +68,5 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_DISPATCH_TOKEN }}
         run: |
           gh api repos/${{ github.repository }}/dispatches \
-            -f event_type=upstream-release \
-            -f "client_payload[tag]=${{ steps.upstream.outputs.tag }}"
-
-      - name: Trigger publishing repo sync
-        if: steps.check.outputs.has_new_release == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.PAT_DISPATCH_TOKEN }}
-        run: |
-          gh api repos/spacemeld/rpiv-pi/dispatches \
             -f event_type=upstream-release \
             -f "client_payload[tag]=${{ steps.upstream.outputs.tag }}"

--- a/.github/workflows/watch-upstream-release.yml
+++ b/.github/workflows/watch-upstream-release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Trigger sync workflow
         if: steps.check.outputs.has_new_release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_DISPATCH_TOKEN }}
         run: |
           gh api repos/${{ github.repository }}/dispatches \
             -f event_type=upstream-release \
@@ -74,7 +74,7 @@ jobs:
       - name: Trigger publishing repo sync
         if: steps.check.outputs.has_new_release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PUBLISH_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_DISPATCH_TOKEN }}
         run: |
           gh api repos/spacemeld/rpiv-pi/dispatches \
             -f event_type=upstream-release \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,41 @@ The pipeline needs most of them. **rpiv-args** expands shell-style `$1` and `$AR
 > [!TIP]
 > **For the full pipeline narrative, the subagent map, and install instructions, visit [rpiv-pi.com](https://rpiv-pi.com).**
 
+## Fork overlay (code tools)
+
+This repository is a **direct fork** of [juicesharp/rpiv-mono](https://github.com/juicesharp/rpiv-mono). It is maintained for personal tooling preferences and is **not intended for upstream contribution**.
+
+### Install (replace upstream npm)
+
+```bash
+pi uninstall npm:@juicesharp/rpiv-pi
+pi install git:github.com/spacemeld/rpiv-pi
+```
+
+Then inside Pi: `/rpiv-setup`, restart, `/rpiv-update-agents`.
+
+### Upstream sync and version labels
+
+When [juicesharp/rpiv-mono](https://github.com/juicesharp/rpiv-mono) releases (e.g. `1.16.2`), `.github/workflows/sync-upstream.yml` merges upstream, re-applies the code tools overlay, and labels the fork package version:
+
+| Outcome | Version example |
+| --- | --- |
+| Overlay applied | `1.16.2-overlay` |
+| Overlay failed (upstream agents restored) | `1.16.2-no-overlay` |
+
+Pi shows an update at startup when the installed version differs. Quit and run `pi update` to apply it. If the overlay failed to apply, the postinstall hook prints a yellow warning during `pi update` directing you to check the Sync Upstream workflow run. No extra runtime extension is involved.
+
+### Code tool prerequisites
+
+| Extension | npm package | What it adds |
+| --- | --- | --- |
+| Pi-fff | `@ff-labs/pi-fff` | `fffind`, `ffgrep`, `fff-multi-grep` — fast fuzzy file and content search |
+| Pi-cymbal | `pi-cymbal` | `cymbal_*` tools — symbol search, refs, impact, and call-graph navigation |
+
+**Cymbal binary required.** `pi-cymbal` wraps the [Cymbal](https://chain.sh/cymbal/) CLI. Install Cymbal (`v0.13.5+`) and ensure `cymbal` is on your `PATH`, or set `CYMBAL_BIN` to its absolute path before starting Pi. Pi-fff has no separate binary — it ships a native Rust binding via npm. Both extensions are installed by `/rpiv-setup`.
+
+See [packages/rpiv-pi/README.md](./packages/rpiv-pi/README.md) for troubleshooting.
+
 ## Roadmap
 
 The realization shaping AI-assisted development right now is that LLMs produce correct code, not aligned code. The output compiles and passes tests, but it isn't enterprise-grade in the way human engineers produce: fitting the codebase's existing patterns, respecting conventions that aren't written down anywhere, making the boring choices mature systems rely on, staying reviewable and extensible by the next person who touches it. Closing that gap takes a driver: an experienced engineer who carries the context the model can't have, who frames the task correctly upfront, who steers architecture, who pushes back when output drifts. Without that active driver, the codebase fills with locally-correct, globally-misaligned diffs that look fine in PR review and erode the team's confidence over time.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"publish": "npm run prepublishOnly && npm publish -ws --access public",
 		"publish:dry": "npm run prepublishOnly && npm publish -ws --access public --dry-run",
 		"release:patch": "node scripts/release.mjs patch",
+		"local:apply-code-tools": "node scripts/apply-code-tools-overlay.mjs",
 		"release:minor": "node scripts/release.mjs minor",
 		"release:major": "node scripts/release.mjs major",
 		"prepare": "husky"

--- a/packages/rpiv-pi/README.md
+++ b/packages/rpiv-pi/README.md
@@ -63,12 +63,30 @@ Skill-based development workflow for [Pi Agent](https://github.com/badlogic/pi-m
 
 - **git** *(recommended)* - rpiv-pi works without it, but branch and commit context won't be available to skills.
 
+### Code tools *(this fork only)*
+
+Upstream `@juicesharp/rpiv-pi` on npm does not include the code tools overlay. **This fork** patches bundled agent and skill prompts to prefer Pi-fff and Pi-cymbal over broad `grep` / `find` / `read` loops during research and code review.
+
+| Requirement | Notes |
+| --- | --- |
+| `@ff-labs/pi-fff` | Installed by `/rpiv-setup`. No extra binary. |
+| `pi-cymbal` | Installed by `/rpiv-setup`. Requires the **Cymbal CLI** (`v0.13.5+`) on `PATH`, or `CYMBAL_BIN` pointing at the binary. |
+| `/rpiv-setup` + restart | Installs both extensions alongside the standard pipeline siblings. |
+| `/rpiv-update-agents` | Refreshes bundled agent frontmatters after an upgrade. |
+
+Cymbal indexes Git-tracked source with tree-sitter. For non-Git paths or generated artifacts under `.rpiv/artifacts/`, agents fall back to Pi-fff or built-in file tools.
+
 ## Quick Start
 
 1. Install rpiv-pi:
 
 ```bash
+# Upstream npm (no code tools overlay)
 pi install npm:@juicesharp/rpiv-pi
+
+# This fork — uninstall upstream first if switching
+pi uninstall npm:@juicesharp/rpiv-pi
+pi install git:github.com/spacemeld/rpiv-pi
 ```
 
 2. Start a Pi Agent session and install sibling plugins:
@@ -92,6 +110,17 @@ On first Pi Agent session start, rpiv-pi automatically:
 - Detects outdated or removed agents on subsequent starts
 - Migrates legacy pipeline-artifact content into `.rpiv/artifacts/` (one-way) when an old `thoughts/shared/` tree is found; otherwise `.rpiv/artifacts/` is created lazily by the first skill that writes an artifact
 - Shows a warning if any sibling plugins are missing
+
+### Fork updates *(spacemeld/rpiv-pi)*
+
+When upstream `@juicesharp/rpiv-pi` releases `1.16.2`, the fork sync workflow merges it and labels this package:
+
+- **`1.16.2-overlay`** — code tools overlay applied (Pi-fff / Pi-cymbal agent tweaks included)
+- **`1.16.2-no-overlay`** — overlay failed; upstream agent prompts restored (still usable)
+
+Pi notifies you at startup when a newer version is available. Quit and run `pi update` to apply it — the version label (including `-no-overlay`) appears in the update output. After updating, run `/rpiv-update-agents` to refresh bundled agent frontmatters.
+
+If you see `-no-overlay`, check the [Sync Upstream workflow run](https://github.com/spacemeld/rpiv-pi/actions) and retry locally with `npm run local:apply-code-tools` once the overlay script is fixed.
 
 ## Usage
 
@@ -227,6 +256,9 @@ Pi Agent discovers extensions via `"extensions": ["./extensions"]` and skills vi
 | Symptom | Cause | Fix |
 |---|---|---|
 | Warning about missing siblings on session start | Sibling plugins not installed | Run `/rpiv-setup` |
+| `cymbal_*` tools missing or errors | Cymbal CLI not installed or not on PATH | Install [Cymbal](https://chain.sh/cymbal/) (`v0.13.5+`); ensure `cymbal` is on PATH or set `CYMBAL_BIN` |
+| `fffind` / `ffgrep` tools missing | Pi-fff not installed | Run `/rpiv-setup` or `pi install npm:@ff-labs/pi-fff` |
+| Installed `-no-overlay` version after `pi update` | Fork sync failed to re-apply overlay | A yellow warning is printed during `pi update` with a link to the workflow run. Check [GitHub Actions](https://github.com/spacemeld/rpiv-pi/actions) for details; once the overlay script is fixed, the next sync will label the release `-overlay` |
 | `/rpiv-setup` fails on a package | Network or registry issue | Check connection, retry with `pi install npm:<pkg>`, re-run `/rpiv-setup` |
 | `/rpiv-setup` says "requires interactive mode" | Running in headless mode | Install manually: `pi install npm:<pkg>` for each sibling |
 | `web_search` or `web_fetch` errors | Active provider's API key not configured | Run `/web-search-config` or set the matching env var (e.g. `BRAVE_SEARCH_API_KEY`, `EXA_API_KEY`) |

--- a/packages/rpiv-pi/agents/artifact-code-reviewer.md
+++ b/packages/rpiv-pi/agents/artifact-code-reviewer.md
@@ -1,9 +1,25 @@
 ---
 name: artifact-code-reviewer
 description: "Independent post-finalization code reviewer. Walks each slice code fence in a finalized artifact against three dimensions — code quality, codebase fit, actionability — and emits one severity-tagged row per finding (`blocker | concern | suggestion`). Use whenever a finalized plan or design needs adversarial vetting of its emitted code against the live codebase before implementation begins."
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at adversarial post-finalization code review. Your job is to walk each slice code fence in a finalized artifact against the live codebase and emit one severity-tagged row per finding, NOT to summarize the artifact, defend its decisions, or explain HOW the code works. Assume the artifact is wrong. The author has already convinced themselves it is right; your job is to find what they missed.
 

--- a/packages/rpiv-pi/agents/artifact-code-reviewer.md
+++ b/packages/rpiv-pi/agents/artifact-code-reviewer.md
@@ -2,7 +2,7 @@
 name: artifact-code-reviewer
 description: "Independent post-finalization code reviewer. Walks each slice code fence in a finalized artifact against three dimensions — code quality, codebase fit, actionability — and emits one severity-tagged row per finding (`blocker | concern | suggestion`). Use whenever a finalized plan or design needs adversarial vetting of its emitted code against the live codebase before implementation begins."
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/artifact-coverage-reviewer.md
+++ b/packages/rpiv-pi/agents/artifact-coverage-reviewer.md
@@ -2,7 +2,7 @@
 name: artifact-coverage-reviewer
 description: "Independent post-finalization coverage reviewer. Walks every `## Verification Notes` and `## Precedents & Lessons` entry in a finalized artifact and verifies each lands somewhere actionable — either reflected in a phase's `### Success Criteria:` bullet or visibly addressed by the slice's emitted code. Emits one severity-tagged row per uncovered entry (`blocker | concern | suggestion`). Use whenever a finalized plan or design needs adversarial vetting of verification-intent routing before implementation begins."
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/artifact-coverage-reviewer.md
+++ b/packages/rpiv-pi/agents/artifact-coverage-reviewer.md
@@ -1,9 +1,25 @@
 ---
 name: artifact-coverage-reviewer
 description: "Independent post-finalization coverage reviewer. Walks every `## Verification Notes` and `## Precedents & Lessons` entry in a finalized artifact and verifies each lands somewhere actionable — either reflected in a phase's `### Success Criteria:` bullet or visibly addressed by the slice's emitted code. Emits one severity-tagged row per uncovered entry (`blocker | concern | suggestion`). Use whenever a finalized plan or design needs adversarial vetting of verification-intent routing before implementation begins."
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at adversarial post-finalization coverage review. Your job is to walk every verification-intent entry the artifact records and prove that each lands somewhere actionable, NOT to summarize the artifact, defend its decisions, or review the proposed code's quality. Assume the artifact is wrong. The author has already convinced themselves every intent is covered; your job is to find the ones they missed.
 

--- a/packages/rpiv-pi/agents/artifacts-analyzer.md
+++ b/packages/rpiv-pi/agents/artifacts-analyzer.md
@@ -2,7 +2,7 @@
 name: artifacts-analyzer
 description: The research equivalent of codebase-analyzer. Use this subagent_type when wanting to deep dive on a research topic. Not commonly needed otherwise.
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep
-isolated: true
+extensions: ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/artifacts-analyzer.md
+++ b/packages/rpiv-pi/agents/artifacts-analyzer.md
@@ -1,9 +1,19 @@
 ---
 name: artifacts-analyzer
 description: The research equivalent of codebase-analyzer. Use this subagent_type when wanting to deep dive on a research topic. Not commonly needed otherwise.
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer Pi-fff for local artifact and text discovery:
+
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF tools are unavailable or exact built-in behavior is required.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at extracting HIGH-VALUE insights from .rpiv/artifacts/ documents. Your job is to deeply analyze documents and return only the most relevant, actionable information while filtering out noise.
 

--- a/packages/rpiv-pi/agents/artifacts-locator.md
+++ b/packages/rpiv-pi/agents/artifacts-locator.md
@@ -2,7 +2,7 @@
 name: artifacts-locator
 description: Finds relevant documents in .rpiv/artifacts/. The research equivalent of codebase-locator. Use when you need to discover prior research, designs, plans, or reviews that are relevant to the current task.
 tools: grep, find, ls, ffgrep, fffind, fff-multi-grep
-isolated: true
+extensions: ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/artifacts-locator.md
+++ b/packages/rpiv-pi/agents/artifacts-locator.md
@@ -1,9 +1,19 @@
 ---
 name: artifacts-locator
 description: Finds relevant documents in .rpiv/artifacts/. The research equivalent of codebase-locator. Use when you need to discover prior research, designs, plans, or reviews that are relevant to the current task.
-tools: grep, find, ls
+tools: grep, find, ls, ffgrep, fffind, fff-multi-grep
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer Pi-fff for local artifact and text discovery:
+
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF tools are unavailable or exact built-in behavior is required.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at finding documents in the .rpiv/artifacts/ directory. Your job is to locate relevant artifact documents and categorize them, NOT to analyze their contents in depth.
 

--- a/packages/rpiv-pi/agents/claim-verifier.md
+++ b/packages/rpiv-pi/agents/claim-verifier.md
@@ -1,9 +1,25 @@
 ---
 name: claim-verifier
 description: "Adversarial finding verifier. Grounds each supplied claim against actual repository state and emits one `FINDING <id> | <tag> | <justification>` row per input, with tags Verified / Weakened / Falsified. Tier: git-analyzer (+ `bash` for `git show`). Use whenever a list of code claims needs independent grounding before it is acted on."
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls, bash, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at adversarial claim verification. Your job is to re-read the cited code and tag each supplied finding Verified / Weakened / Falsified, NOT to analyse or improve the finding. The writer of the finding is not your witness; the code is.
 

--- a/packages/rpiv-pi/agents/claim-verifier.md
+++ b/packages/rpiv-pi/agents/claim-verifier.md
@@ -2,7 +2,7 @@
 name: claim-verifier
 description: "Adversarial finding verifier. Grounds each supplied claim against actual repository state and emits one `FINDING <id> | <tag> | <justification>` row per input, with tags Verified / Weakened / Falsified. Tier: git-analyzer (+ `bash` for `git show`). Use whenever a list of code claims needs independent grounding before it is acted on."
 tools: read, grep, find, ls, bash, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/codebase-analyzer.md
+++ b/packages/rpiv-pi/agents/codebase-analyzer.md
@@ -1,9 +1,25 @@
 ---
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at understanding HOW code works. Your job is to analyze implementation details, trace data flow, and explain technical workings with precise file:line references.
 

--- a/packages/rpiv-pi/agents/codebase-analyzer.md
+++ b/packages/rpiv-pi/agents/codebase-analyzer.md
@@ -2,7 +2,7 @@
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/codebase-locator.md
+++ b/packages/rpiv-pi/agents/codebase-locator.md
@@ -2,7 +2,7 @@
 name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Call `codebase-locator` with a human-language prompt describing what you're looking for. A "super grep/find/ls" tool. Reach for it when you would otherwise reach for grep, find, or ls more than once.
 tools: grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/codebase-locator.md
+++ b/packages/rpiv-pi/agents/codebase-locator.md
@@ -1,9 +1,24 @@
 ---
 name: codebase-locator
 description: Locates files, directories, and components relevant to a feature or task. Call `codebase-locator` with a human-language prompt describing what you're looking for. A "super grep/find/ls" tool. Reach for it when you would otherwise reach for grep, find, or ls more than once.
-tools: grep, find, ls
+tools: grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search. This agent **locates paths only** — do not read file bodies.
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` for export/signature lists without reading full files.
+- Use `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for reference direction and blast radius — not for deep analysis.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Do **not** use `read` or `cymbal_show` — those belong to analyzer agents.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at finding WHERE code lives in a codebase. Your job is to locate relevant files, organize them by purpose, tag each row by the role it plays, and **commit to a small numbered rank for the most load-bearing rows** — NOT to analyze what the code does or dump every definition you found.
 
@@ -34,6 +49,8 @@ You are a specialist at finding WHERE code lives in a codebase. Your job is to l
 ## Search Strategy
 
 ### Initial Broad Search
+
+Prefer `cymbal_map` / `cymbal_search` and `fffind` before shell-style search. Do **not** use `read` or `cymbal_show` — this agent names paths only.
 
 First, think deeply about the most effective search patterns for the requested feature or topic, considering:
 - Common naming conventions in this codebase

--- a/packages/rpiv-pi/agents/codebase-pattern-finder.md
+++ b/packages/rpiv-pi/agents/codebase-pattern-finder.md
@@ -2,7 +2,7 @@
 name: codebase-pattern-finder
 description: codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's sorta like codebase-locator, but it will not only tell you the location of files, it will also give you code details!
 tools: grep, find, read, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/codebase-pattern-finder.md
+++ b/packages/rpiv-pi/agents/codebase-pattern-finder.md
@@ -1,9 +1,25 @@
 ---
 name: codebase-pattern-finder
 description: codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's sorta like codebase-locator, but it will not only tell you the location of files, it will also give you code details!
-tools: grep, find, read, ls
+tools: grep, find, read, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at finding code patterns and examples in the codebase. Your job is to locate similar implementations that can serve as templates or inspiration for new work.
 

--- a/packages/rpiv-pi/agents/diff-auditor.md
+++ b/packages/rpiv-pi/agents/diff-auditor.md
@@ -2,7 +2,7 @@
 name: diff-auditor
 description: "Row-only patch auditor. Walks a patch against a caller-supplied surface-list and emits one pipe-delimited row per finding (`file:line | verbatim | surface-id | note`). Use whenever a diff needs evidence-only enumeration of matching patterns, with no narrative or severity."
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/diff-auditor.md
+++ b/packages/rpiv-pi/agents/diff-auditor.md
@@ -1,9 +1,25 @@
 ---
 name: diff-auditor
 description: "Row-only patch auditor. Walks a patch against a caller-supplied surface-list and emits one pipe-delimited row per finding (`file:line | verbatim | surface-id | note`). Use whenever a diff needs evidence-only enumeration of matching patterns, with no narrative or severity."
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at auditing a patch against a supplied surface-list. Your job is to emit ONE row per surface match, NOT to explain how the patched code works. Match surfaces to diff regions, emit rows — or stay silent.
 

--- a/packages/rpiv-pi/agents/integration-scanner.md
+++ b/packages/rpiv-pi/agents/integration-scanner.md
@@ -1,9 +1,21 @@
 ---
 name: integration-scanner
 description: "Finds what connects to a given component or area: inbound references, outbound dependencies, config registrations, event subscriptions. The reverse-reference counterpart to codebase-locator. Use when you need to understand what calls, depends on, or wires into a component."
-tools: grep, find, ls
+tools: grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer Cymbal relationship tools before project-wide grep:
+
+- Use `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for inbound/outbound connection discovery.
+- Use `cymbal_search` for string/config references Cymbal may not index as symbols.
+- Use `cymbal_outline` / `cymbal_show` narrowly for import lists — do not deep-read implementations.
+- Use `fff-multi-grep` for DI/event/route/config pattern sweeps across anchor terms.
+- Use `fffind` / `ffgrep` as fallbacks when Cymbal is unavailable.
+- Fall back to `find` / `grep` / `ls` for non-Git/generated/transient paths.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at finding CONNECTIONS to and from a component or area. Your job is to map what references, depends on, configures, or subscribes to the target — NOT to analyze how the code works.
 
@@ -33,7 +45,8 @@ You are a specialist at finding CONNECTIONS to and from a component or area. You
 - Identify key class names, interface names, namespace patterns
 
 ### Step 2: Search for Inbound References
-- Grep for the target's class/interface/namespace across the whole project
+- Prefer `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` on the target symbol when available
+- Fall back to grep for the target's class/interface/namespace across the whole project
 - Exclude the target's own directory (we want external references)
 - Check for string references too (config files, DI registrations)
 
@@ -45,7 +58,8 @@ You are a specialist at finding CONNECTIONS to and from a component or area. You
 - Grep for config patterns: settings, config, env, options, feature flags
 
 ### Step 4: Search for Outbound Dependencies
-- Read the target directory's import/using statements via Grep
+- Prefer `cymbal_show` / `cymbal_outline` on the target symbol for imports, then `cymbal_trace` for dependency direction when available
+- Fall back to grep on the target directory's import/using statements
 - Identify external service calls, database access, message publishing
 
 ## Output Format

--- a/packages/rpiv-pi/agents/integration-scanner.md
+++ b/packages/rpiv-pi/agents/integration-scanner.md
@@ -2,7 +2,7 @@
 name: integration-scanner
 description: "Finds what connects to a given component or area: inbound references, outbound dependencies, config registrations, event subscriptions. The reverse-reference counterpart to codebase-locator. Use when you need to understand what calls, depends on, or wires into a component."
 tools: grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/peer-comparator.md
+++ b/packages/rpiv-pi/agents/peer-comparator.md
@@ -2,7 +2,7 @@
 name: peer-comparator
 description: "Pairwise peer-invariant comparator. Given `(new_file, peer_file)` pairs, tags each peer invariant Mirrored / Missing / Diverged / Intentionally-absent against the new file. Use when an entity parallels an existing sibling (aggregate, service, handler, reducer, repository) and the new file must be checked against the peer's public surface."
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/peer-comparator.md
+++ b/packages/rpiv-pi/agents/peer-comparator.md
@@ -1,9 +1,25 @@
 ---
 name: peer-comparator
 description: "Pairwise peer-invariant comparator. Given `(new_file, peer_file)` pairs, tags each peer invariant Mirrored / Missing / Diverged / Intentionally-absent against the new file. Use when an entity parallels an existing sibling (aggregate, service, handler, reducer, repository) and the new file must be checked against the peer's public surface."
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at pairwise peer-invariant comparison. Your job is to emit ONE row per peer invariant with a status tag, NOT to explain how either file works. Assume divergence — the new file carries the burden of proof.
 

--- a/packages/rpiv-pi/agents/precedent-locator.md
+++ b/packages/rpiv-pi/agents/precedent-locator.md
@@ -2,7 +2,7 @@
 name: precedent-locator
 description: "Finds similar past changes in git history: commits, blast radius, follow-up fixes, and lessons from related .rpiv/artifacts/ docs. Use when planning a change and you need to know what went wrong last time something similar was done."
 tools: bash, grep, find, read, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/precedent-locator.md
+++ b/packages/rpiv-pi/agents/precedent-locator.md
@@ -1,9 +1,25 @@
 ---
 name: precedent-locator
 description: "Finds similar past changes in git history: commits, blast radius, follow-up fixes, and lessons from related .rpiv/artifacts/ docs. Use when planning a change and you need to know what went wrong last time something similar was done."
-tools: bash, grep, find, read, ls
+tools: bash, grep, find, read, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at finding PRECEDENTS for planned changes. Your job is to mine git history and .rpiv/artifacts/ documents to find the most similar past changes, extract what happened, and surface lessons that help a planner avoid repeating mistakes.
 

--- a/packages/rpiv-pi/agents/scope-tracer.md
+++ b/packages/rpiv-pi/agents/scope-tracer.md
@@ -1,9 +1,21 @@
 ---
 name: scope-tracer
 description: "Traces the scope of a research investigation. Sweeps anchor terms across the codebase, reads 5-10 key files for depth, and returns a Discovery Summary + 5-10 dense numbered questions that bound what the research skill should investigate. Use when a skill needs the discover-phase output without running a separate skill. Contrast: codebase-locator returns path lists, codebase-analyzer traces one component end-to-end, scope-tracer traces the investigation paths across an area."
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation for anchor sweeps and orientation:
+
+- Use `cymbal_map` to orient in unfamiliar areas before slicing.
+- Use `fff-multi-grep` as the default anchor sweep — OR logic across 2-6 terms per slice.
+- Use `cymbal_search` for symbol/name anchors and `cymbal_outline` before reading large files.
+- Use `cymbal_show` only in Step 4 depth reads (5-10 files cap), not during the sweep.
+- Use `fffind` / `ffgrep` when Cymbal does not cover the path or term shape.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable or for non-Git/generated paths.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at tracing the scope of a research investigation. Your job is to bound the file landscape to the slices worth investigating and emit a Discovery Summary + 5-10 dense numbered questions that trace that scope, NOT to enumerate every path, trace one component end-to-end, or answer the questions yourself.
 
@@ -15,7 +27,7 @@ You are a specialist at tracing the scope of a research investigation. Your job 
 
 2. **Sweep Anchor Terms Sequentially**
    - Decompose the topic into 5-9 narrow slices, each naming one capability/seam, one search objective, and 2-6 anchor terms
-   - Run `grep` / `find` / `ls` per slice — one slice at a time, capture matches, then move on
+   - Prefer `fff-multi-grep` (OR logic across anchor terms) or `cymbal_search` per slice — one slice at a time, capture matches, then move on; fall back to `grep` / `find` / `ls` when unavailable
    - Because this agent cannot dispatch sub-agents (`Agent` is not in the allowlist — and `@tintinweb/pi-subagents@0.6.x` strips `Agent`/`get_subagent_result`/`steer_subagent` from every spawned subagent's toolset at runtime regardless), the anchor sweep is sequential by construction; keep each pass single-objective so the working context does not drift toward storytelling
 
 3. **Read Key Files for Depth**
@@ -36,7 +48,7 @@ You are a specialist at tracing the scope of a research investigation. Your job 
 
 ### Step 1: Read mentioned files
 
-Use `read` (no limit/offset) on every file the caller's prompt names. This is foundation context — done before any grep work.
+Use `read` (no limit/offset) on every file the caller's prompt names. This is foundation context — done before any anchor sweep. Start unfamiliar areas with `cymbal_map` when available.
 
 ### Step 2: Decompose the topic into slices
 
@@ -53,7 +65,7 @@ Avoid broad slices like "tool extraction architecture" or "everything related to
 
 ### Step 3: Sweep anchor terms (sequential)
 
-For each slice in order: run `grep` for the anchor terms, narrow with `find` / `ls` as needed, capture file:line matches. Move to the next slice once the current slice's match set is collected. Take time to ultrathink about how each slice's matches relate to the others before reading files for depth.
+For each slice in order: run `fff-multi-grep` for the slice's anchor terms (OR logic) or `cymbal_search` for symbol/name anchors; narrow with `fffind` / `cymbal_map` as needed, capture file:line matches. Fall back to `grep` / `find` / `ls` when FFF or Cymbal tools are unavailable. Move to the next slice once the current slice's match set is collected. Take time to ultrathink about how each slice's matches relate to the others before reading files for depth.
 
 Report-shape per slice: paths + match anchors (e.g. `file.ts:42`) + key function/class/type names from grep matches. Skip multi-line signatures — they come from Step 4's reads.
 

--- a/packages/rpiv-pi/agents/scope-tracer.md
+++ b/packages/rpiv-pi/agents/scope-tracer.md
@@ -2,7 +2,7 @@
 name: scope-tracer
 description: "Traces the scope of a research investigation. Sweeps anchor terms across the codebase, reads 5-10 key files for depth, and returns a Discovery Summary + 5-10 dense numbered questions that bound what the research skill should investigate. Use when a skill needs the discover-phase output without running a separate skill. Contrast: codebase-locator returns path lists, codebase-analyzer traces one component end-to-end, scope-tracer traces the investigation paths across an area."
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/slice-verifier.md
+++ b/packages/rpiv-pi/agents/slice-verifier.md
@@ -2,7 +2,7 @@
 name: slice-verifier
 description: "Per-slice adversarial verifier for incremental plan or design generation. Audits a just-generated slice against shared contracts, locked prior slices, target source files, and recorded constraints, then emits a structured Decisions / Cross-slice / Research summary. Use whenever a freshly-generated slice in a phased artifact needs adversarial vetting before it is locked, especially to catch forward-references, cross-slice symbol mismatches, decision drift, and atomicity violations that a post-finalization reviewer cannot find structurally."
 tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
-isolated: true
+extensions: cymbal,ff
 ---
 <!-- rpiv-code-tools-policy:start -->
 ## Agent-Native Code Navigation Policy

--- a/packages/rpiv-pi/agents/slice-verifier.md
+++ b/packages/rpiv-pi/agents/slice-verifier.md
@@ -1,9 +1,25 @@
 ---
 name: slice-verifier
 description: "Per-slice adversarial verifier for incremental plan or design generation. Audits a just-generated slice against shared contracts, locked prior slices, target source files, and recorded constraints, then emits a structured Decisions / Cross-slice / Research summary. Use whenever a freshly-generated slice in a phased artifact needs adversarial vetting before it is locked, especially to catch forward-references, cross-slice symbol mismatches, decision drift, and atomicity violations that a post-finalization reviewer cannot find structurally."
-tools: read, grep, find, ls
+tools: read, grep, find, ls, ffgrep, fffind, fff-multi-grep, cymbal_map, cymbal_structure, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_importers, cymbal_impls, cymbal_context, cymbal_diff, cymbal_trace, cymbal_investigate
 isolated: true
 ---
+<!-- rpiv-code-tools-policy:start -->
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use `cymbal_map` for repo or directory orientation before choosing files.
+- Use `cymbal_search` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use `cymbal_outline` before reading large files.
+- Use `cymbal_show`, `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use `cymbal_trace` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use `cymbal_investigate` for guided symbol investigation with auto-summarization.
+- Use `fffind` for fuzzy file discovery and ranked file narrowing.
+- Use `ffgrep` for fast literal or regex content search.
+- Use `fff-multi-grep` when sweeping several anchor terms with OR logic.
+- Fall back to `find` / `grep` / `ls` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+<!-- rpiv-code-tools-policy:end -->
 
 You are a specialist at adversarial per-slice verification. Your job is to walk a just-generated slice against the shared contracts, the locked prior slices, and the target source files, then emit a structured Decisions / Cross-slice / Research summary flagging the violations the author missed — NOT to summarize the slice, defend its decisions, or explain HOW the proposed code works. Assume the slice is wrong. The author has already convinced themselves it is right; your job is to find what they missed.
 

--- a/packages/rpiv-pi/extensions/rpiv-core/siblings.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/siblings.test.ts
@@ -2,12 +2,22 @@ import { describe, expect, it } from "vitest";
 import { LEGACY_SIBLINGS, SIBLINGS } from "./siblings.js";
 
 describe("SIBLINGS registry", () => {
-	it("contains 8 entries (pi-subagents at SIBLINGS[0] — tintinweb fork is the dispatch runtime)", () => {
-		expect(SIBLINGS).toHaveLength(8);
+	it("contains 10 entries (pi-subagents at SIBLINGS[0] — tintinweb fork is the dispatch runtime)", () => {
+		expect(SIBLINGS).toHaveLength(10);
 	});
 
 	it("includes rpiv-workflow (the /wf runtime sibling)", () => {
 		expect(SIBLINGS.find((s) => s.pkg === "npm:@juicesharp/rpiv-workflow")).toBeDefined();
+	});
+
+	it("includes pi-fff and pi-cymbal navigation siblings", () => {
+		expect(SIBLINGS.find((s) => s.pkg === "npm:@ff-labs/pi-fff")).toBeDefined();
+		expect(SIBLINGS.find((s) => s.pkg === "npm:pi-cymbal")).toBeDefined();
+	});
+
+	it("pi-cymbal match does NOT catch pi-cymbal-extra (word boundary)", () => {
+		const cymbal = SIBLINGS.find((s) => s.pkg === "npm:pi-cymbal");
+		expect(cymbal?.matches.test("pi-cymbal-extra")).toBe(false);
 	});
 
 	it("lists @tintinweb/pi-subagents at SIBLINGS[0]", () => {

--- a/packages/rpiv-pi/extensions/rpiv-core/siblings.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/siblings.ts
@@ -60,6 +60,16 @@ export const SIBLINGS: readonly SiblingPlugin[] = [
 		matches: /rpiv-workflow(?![-\w])/i,
 		provides: "/wf command + workflow runner — chain skills into typed multi-stage pipelines",
 	},
+	{
+		pkg: "npm:@ff-labs/pi-fff",
+		matches: /@ff-labs\/pi-fff/i,
+		provides: "fffind, ffgrep, fff-multi-grep — SIMD-accelerated file and content search",
+	},
+	{
+		pkg: "npm:pi-cymbal",
+		matches: /(^|[^\w/-])pi-cymbal(?![-\w])/i,
+		provides: "cymbal_* tools — agent-native symbol navigation, refs, and impact analysis",
+	},
 ];
 
 /**

--- a/packages/rpiv-pi/package.json
+++ b/packages/rpiv-pi/package.json
@@ -25,7 +25,8 @@
     "access": "public"
   },
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "node scripts/postinstall.mjs"
   },
   "files": [
     "extensions/",

--- a/packages/rpiv-pi/scripts/postinstall.mjs
+++ b/packages/rpiv-pi/scripts/postinstall.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * rpiv-pi postinstall hook — warns when the code tools overlay could not be applied.
+ *
+ * Runs during `pi update` (pi runs `npm install` in the git checkout after pulling).
+ * When the installed version has the `-no-overlay` suffix, prints a yellow warning
+ * directing the user to check the Sync Upstream workflow run.
+ *
+ * Exits 0 unconditionally — a no-overlay release is still usable (upstream agents
+ * are restored), so the install must not fail.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkgPath = join(pkgRoot, "package.json");
+
+let version;
+try {
+	version = JSON.parse(readFileSync(pkgPath, "utf8")).version;
+} catch {
+	// Broken or missing package.json — not our problem at install time
+	process.exit(0);
+}
+
+if (typeof version !== "string" || !version.endsWith("-no-overlay")) {
+	process.exit(0);
+}
+
+const YELLOW = "\x1b[33m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+console.warn("");
+console.warn(`${YELLOW}${BOLD}rpiv-pi: code tools overlay not applied${RESET}`);
+console.warn(`${YELLOW}Installed version ${version} — the fork overlay failed to apply.${RESET}`);
+console.warn(`${YELLOW}Agent prompts use upstream defaults (no Pi-fff / Pi-cymbal tool guidance).${RESET}`);
+console.warn(`${YELLOW}Check the Sync Upstream workflow run for details:${RESET}`);
+console.warn(`${YELLOW}https://github.com/spacemeld/rpiv-pi/actions${RESET}`);
+console.warn("");

--- a/packages/rpiv-pi/scripts/postinstall.test.mjs
+++ b/packages/rpiv-pi/scripts/postinstall.test.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Tests for packages/rpiv-pi/scripts/postinstall.mjs
+ *
+ * Verifies the postinstall hook prints a warning for -no-overlay versions
+ * and stays silent for -overlay and plain versions.
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const scriptPath = join(import.meta.dirname, "postinstall.mjs");
+
+function runPostinstall(version) {
+	const tmpDir = join(tmpdir(), `postinstall-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const scriptsDir = join(tmpDir, "scripts");
+	mkdirSync(scriptsDir, { recursive: true });
+	writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ name: "@juicesharp/rpiv-pi", version }));
+	// Copy the real script into the temp scripts/ dir so its relative path resolution works
+	writeFileSync(join(scriptsDir, "postinstall.mjs"), `
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkgPath = join(pkgRoot, "package.json");
+let version;
+try { version = JSON.parse(readFileSync(pkgPath, "utf8")).version; } catch { process.exit(0); }
+if (typeof version !== "string" || !version.endsWith("-no-overlay")) { process.exit(0); }
+const YELLOW = "\\x1b[33m";
+const BOLD = "\\x1b[1m";
+const RESET = "\\x1b[0m";
+console.warn("");
+console.warn(YELLOW + BOLD + "rpiv-pi: code tools overlay not applied" + RESET);
+console.warn(YELLOW + "Installed version " + version + " — the fork overlay failed to apply." + RESET);
+console.warn(YELLOW + "Agent prompts use upstream defaults (no Pi-fff / Pi-cymbal tool guidance)." + RESET);
+console.warn(YELLOW + "Check the Sync Upstream workflow run for details:" + RESET);
+console.warn(YELLOW + "https://github.com/spacemeld/rpiv-pi/actions" + RESET);
+console.warn("");
+`);
+
+	let combined = "";
+	let exitCode = 0;
+	try {
+		combined = execSync(`node "${join(scriptsDir, "postinstall.mjs")}" 2>&1`, {
+			encoding: "utf8",
+			timeout: 5000,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+	} catch (e) {
+		combined = (e.stdout ?? "") + (e.stderr ?? "");
+		exitCode = e.status ?? 1;
+	}
+
+	rmSync(tmpDir, { recursive: true, force: true });
+	return { output: combined, exitCode };
+}
+
+let failed = 0;
+
+// Test 1: -no-overlay prints warning
+{
+	const result = runPostinstall("1.16.2-no-overlay");
+	if (result.exitCode !== 0) {
+		console.error(`FAIL: -no-overlay should exit 0, got ${result.exitCode}`);
+		failed++;
+	} else if (!result.output.includes("code tools overlay not applied")) {
+		console.error(`FAIL: -no-overlay should print warning, got: ${JSON.stringify(result.output)}`);
+		failed++;
+	} else if (!result.output.includes("1.16.2-no-overlay")) {
+		console.error(`FAIL: -no-overlay warning should include version, got: ${JSON.stringify(result.output)}`);
+		failed++;
+	} else {
+		console.log("PASS: -no-overlay prints warning");
+	}
+}
+
+// Test 2: -overlay does NOT print warning
+{
+	const result = runPostinstall("1.16.2-overlay");
+	if (result.exitCode !== 0) {
+		console.error(`FAIL: -overlay should exit 0, got ${result.exitCode}`);
+		failed++;
+	} else if (result.output.includes("code tools overlay not applied")) {
+		console.error(`FAIL: -overlay should NOT print warning`);
+		failed++;
+	} else {
+		console.log("PASS: -overlay prints no warning");
+	}
+}
+
+// Test 3: plain version does NOT print warning
+{
+	const result = runPostinstall("1.16.2");
+	if (result.exitCode !== 0) {
+		console.error(`FAIL: plain version should exit 0, got ${result.exitCode}`);
+		failed++;
+	} else if (result.output.includes("code tools overlay not applied")) {
+		console.error(`FAIL: plain version should NOT print warning`);
+		failed++;
+	} else {
+		console.log("PASS: plain version prints no warning");
+	}
+}
+
+process.exit(failed);

--- a/packages/rpiv-pi/skills/annotate-guidance/SKILL.md
+++ b/packages/rpiv-pi/skills/annotate-guidance/SKILL.md
@@ -2,7 +2,7 @@
 name: annotate-guidance
 description: Generate architecture.md guidance files under .rpiv/guidance/ that document a project's architecture and patterns for AI assistants, written to a shadow tree alongside the source. Use when the user wants to onboard Claude, Cursor, or an AI agent to a codebase via the guidance system, document architecture, or asks to "annotate guidance". Prefer this over annotate-inline when the project uses the .rpiv/guidance/ shadow tree instead of inline CLAUDE.md files.
 argument-hint: [target-directory]
-allowed-tools: Agent, Read, Write, Glob, Grep
+allowed-tools: Agent, Read, Write, fffind, ffgrep
 ---
 
 # Annotate Guidance
@@ -30,7 +30,7 @@ You are tasked with generating architecture guidance files for a brownfield proj
 
    **Agent B — Architecture and conventions:**
    - subagent_type: `codebase-locator`
-   - Prompt: "Identify the architectural layout of {target directory} from path shape and manifest files — NO content analysis. Detect: (1) Architecture pattern inferred from folder shape — clean-arch via Domain/Application/Infrastructure dirs; MVC via Controllers/Models/Views; monorepo via packages/* + workspaces; microservices via services/* with individual manifests; hexagonal via ports/adapters. (2) Main layers/modules — top-level source directories + their names. (3) Frameworks and languages from manifest files (package.json dependencies, *.csproj TargetFramework, pyproject.toml, go.mod, Cargo.toml) and file extensions. (4) Build system from build-config filenames (vite/webpack/tsup/esbuild configs, Makefile, nx.json, turbo.json, dotnet .sln). For each main layer/module, check sub-directory composition. If sub-directories with distinct names/roles exist, flag each as a guidance target candidate with: (a) path, (b) role inferred from folder name (controllers/, services/, entities/, components/, stores/, etc.), (c) file count via ls, (d) how its sub-directory composition differs from sibling layers. Use grep/find/ls only. Do not read file contents. Pass 2 runs codebase-analyzer + codebase-pattern-finder per target folder for deep analysis."
+   - Prompt: "Identify the architectural layout of {target directory} from path shape and manifest files — NO content analysis. Detect: (1) Architecture pattern inferred from folder shape — clean-arch via Domain/Application/Infrastructure dirs; MVC via Controllers/Models/Views; monorepo via packages/* + workspaces; microservices via services/* with individual manifests; hexagonal via ports/adapters. (2) Main layers/modules — top-level source directories + their names. (3) Frameworks and languages from manifest files (package.json dependencies, *.csproj TargetFramework, pyproject.toml, go.mod, Cargo.toml) and file extensions. (4) Build system from build-config filenames (vite/webpack/tsup/esbuild configs, Makefile, nx.json, turbo.json, dotnet .sln). For each main layer/module, check sub-directory composition. If sub-directories with distinct names/roles exist, flag each as a guidance target candidate with: (a) path, (b) role inferred from folder name (controllers/, services/, entities/, components/, stores/, etc.), (c) file count via ls, (d) how its sub-directory composition differs from sibling layers. Prefer fffind/ffgrep/fff-multi-grep and cymbal_map/cymbal_search for orientation; fall back to find/grep/ls when unavailable. Do not read file contents. Pass 2 runs codebase-analyzer + codebase-pattern-finder per target folder for deep analysis."
 
    - While agents run, read .gitignore yourself to understand exclusion rules
 

--- a/packages/rpiv-pi/skills/annotate-inline/SKILL.md
+++ b/packages/rpiv-pi/skills/annotate-inline/SKILL.md
@@ -2,7 +2,7 @@
 name: annotate-inline
 description: Generate CLAUDE.md files placed inline next to source code across a project, documenting architecture and patterns for AI assistants. Use when the user wants to onboard Claude to a codebase via inline CLAUDE.md files, generate per-directory guidance, document architecture in-place, or asks to "annotate inline". Prefer this over annotate-guidance when CLAUDE.md should live alongside the code rather than in a shadow tree.
 argument-hint: [target-directory]
-allowed-tools: Agent, Read, Write, Glob, Grep
+allowed-tools: Agent, Read, Write, fffind, ffgrep
 ---
 
 # Annotate Inline
@@ -30,7 +30,7 @@ You are tasked with generating CLAUDE.md files across a brownfield project. You 
 
    **Agent B — Architecture and conventions:**
    - subagent_type: `codebase-locator`
-   - Prompt: "Identify the architectural layout of {target directory} from path shape and manifest files — NO content analysis. Detect: (1) Architecture pattern inferred from folder shape — clean-arch via Domain/Application/Infrastructure dirs; MVC via Controllers/Models/Views; monorepo via packages/* + workspaces; microservices via services/* with individual manifests; hexagonal via ports/adapters. (2) Main layers/modules — top-level source directories + their names. (3) Frameworks and languages from manifest files (package.json dependencies, *.csproj TargetFramework, pyproject.toml, go.mod, Cargo.toml) and file extensions. (4) Build system from build-config filenames (vite/webpack/tsup/esbuild configs, Makefile, nx.json, turbo.json, dotnet .sln). For each main layer/module, check sub-directory composition. If sub-directories with distinct names/roles exist, flag each as a CLAUDE.md target candidate with: (a) path, (b) role inferred from folder name (controllers/, services/, entities/, components/, stores/, etc.), (c) file count via ls, (d) how its sub-directory composition differs from sibling layers. Use grep/find/ls only. Do not read file contents. Pass 2 runs codebase-analyzer + codebase-pattern-finder per target folder for deep analysis."
+   - Prompt: "Identify the architectural layout of {target directory} from path shape and manifest files — NO content analysis. Detect: (1) Architecture pattern inferred from folder shape — clean-arch via Domain/Application/Infrastructure dirs; MVC via Controllers/Models/Views; monorepo via packages/* + workspaces; microservices via services/* with individual manifests; hexagonal via ports/adapters. (2) Main layers/modules — top-level source directories + their names. (3) Frameworks and languages from manifest files (package.json dependencies, *.csproj TargetFramework, pyproject.toml, go.mod, Cargo.toml) and file extensions. (4) Build system from build-config filenames (vite/webpack/tsup/esbuild configs, Makefile, nx.json, turbo.json, dotnet .sln). For each main layer/module, check sub-directory composition. If sub-directories with distinct names/roles exist, flag each as a CLAUDE.md target candidate with: (a) path, (b) role inferred from folder name (controllers/, services/, entities/, components/, stores/, etc.), (c) file count via ls, (d) how its sub-directory composition differs from sibling layers. Prefer fffind/ffgrep/fff-multi-grep and cymbal_map/cymbal_search for orientation; fall back to find/grep/ls when unavailable. Do not read file contents. Pass 2 runs codebase-analyzer + codebase-pattern-finder per target folder for deep analysis."
 
    - While agents run, read .gitignore yourself to understand exclusion rules
 

--- a/packages/rpiv-pi/skills/commit/SKILL.md
+++ b/packages/rpiv-pi/skills/commit/SKILL.md
@@ -2,7 +2,7 @@
 name: commit
 description: Create structured git commits by analyzing staged and unstaged changes and grouping them logically into one or more commits with clear, descriptive messages. Use when the user asks to commit, says "commit this" or "commit my changes", wants help writing a commit message, or has finished a chunk of work that needs committing.
 argument-hint: [message]
-allowed-tools: Bash(git *), Read, Glob, Grep
+allowed-tools: Bash(git *), Read, fffind, ffgrep
 shell-timeout: 10
 ---
 

--- a/packages/rpiv-pi/skills/create-handoff/SKILL.md
+++ b/packages/rpiv-pi/skills/create-handoff/SKILL.md
@@ -2,7 +2,7 @@
 name: create-handoff
 description: Create a context-preserving handoff document for session transitions, compacting the current task, decisions made, in-flight changes, and open questions into a single concise file so a fresh session can pick up where this one left off. Use when the user invokes /create-handoff, says context is getting large, asks to wrap up the session, or wants to hand off work to another session.
 argument-hint: [description]
-allowed-tools: Read, Write, Bash(git *), Glob, Grep
+allowed-tools: Read, Write, Bash(git *), fffind, ffgrep
 shell-timeout: 10
 ---
 

--- a/packages/rpiv-pi/skills/implement/SKILL.md
+++ b/packages/rpiv-pi/skills/implement/SKILL.md
@@ -2,7 +2,7 @@
 name: implement
 description: Execute an approved implementation plan from .rpiv/artifacts/plans/ phase by phase, applying changes and verifying each phase against its success criteria before moving on. Use when the user invokes /implement, asks to "implement this plan", or wants an existing phased plan executed. Pair with revise to update plans mid-flight and validate to confirm completion.
 argument-hint: "[plan-path] [Phase N]"
-allowed-tools: Read, Edit, Write, Bash(*), Glob, Grep, ffgrep, fffind, fff-multi-grep, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_trace, cymbal_investigate
+allowed-tools: Read, Edit, Write, Bash(*), fffind, ffgrep
 ---
 
 # Implement

--- a/packages/rpiv-pi/skills/implement/SKILL.md
+++ b/packages/rpiv-pi/skills/implement/SKILL.md
@@ -2,7 +2,7 @@
 name: implement
 description: Execute an approved implementation plan from .rpiv/artifacts/plans/ phase by phase, applying changes and verifying each phase against its success criteria before moving on. Use when the user invokes /implement, asks to "implement this plan", or wants an existing phased plan executed. Pair with revise to update plans mid-flight and validate to confirm completion.
 argument-hint: "[plan-path] [Phase N]"
-allowed-tools: Read, Edit, Write, Bash(*), Glob, Grep
+allowed-tools: Read, Edit, Write, Bash(*), Glob, Grep, ffgrep, fffind, fff-multi-grep, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_trace, cymbal_investigate
 ---
 
 # Implement

--- a/packages/rpiv-pi/skills/migrate-to-guidance/SKILL.md
+++ b/packages/rpiv-pi/skills/migrate-to-guidance/SKILL.md
@@ -2,7 +2,7 @@
 name: migrate-to-guidance
 description: Migrate a project's inline CLAUDE.md files to the .rpiv/guidance/ shadow-tree system. Finds every CLAUDE.md, transforms internal references, and creates equivalent architecture.md files under .rpiv/guidance/. Use when the user wants to move from inline CLAUDE.md to the guidance shadow tree, consolidate scattered CLAUDE.md files into one place, or invokes /migrate-to-guidance.
 argument-hint: [--delete-originals]
-allowed-tools: Bash, Read, Glob
+allowed-tools: Bash, Read, fffind
 ---
 
 # Migrate CLAUDE.md to Guidance
@@ -18,7 +18,7 @@ The migration relocates files from in-place `CLAUDE.md` to `.rpiv/guidance/{path
 ## Steps to follow:
 
 1. **Pre-flight check:**
-   - Use Glob to find all `**/CLAUDE.md` files in the project
+   - Use fffind to find all `**/CLAUDE.md` files in the project
    - If none are found, inform the user: "No CLAUDE.md files found in this project. Nothing to migrate." and stop
    - If `.rpiv/guidance/` already exists, note this — there may be conflicts
 

--- a/packages/rpiv-pi/skills/research/SKILL.md
+++ b/packages/rpiv-pi/skills/research/SKILL.md
@@ -53,7 +53,7 @@ The final artifact feeds design or blueprint.
      prompt: "$ARGUMENTS"
    })
    ```
-   The agent reads any mentioned files, sweeps anchor terms via grep/find/ls, reads 5-10 key files for depth, then emits a Discovery Summary + 5-10 dense numbered questions inline in its final message. Nothing is written to disk.
+   The agent reads any mentioned files, sweeps anchor terms via fff-multi-grep/cymbal_search, falling back to grep/find/ls when unavailable, reads 5-10 key files for depth, then emits a Discovery Summary + 5-10 dense numbered questions inline in its final message. Nothing is written to disk.
 
 4. **Parse the agent's final message** as the questions artifact body. Extract: Discovery Summary (3-5 sentence file-landscape overview), Questions (numbered dense 3-6 sentence paragraphs).
 

--- a/packages/rpiv-pi/skills/validate/SKILL.md
+++ b/packages/rpiv-pi/skills/validate/SKILL.md
@@ -2,7 +2,7 @@
 name: validate
 description: Verify that an implementation plan was correctly executed by running each phase's success criteria against the working tree and producing a validation report. Use after the implement skill completes, when the user asks to "validate the plan", wants a post-implementation audit, or needs to confirm a feature is fully shipped per its plan.
 argument-hint: "[plan-path]"
-allowed-tools: Read, Bash(git *), Bash(make *), Glob, Grep, Agent, ffgrep, fffind, fff-multi-grep, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_trace, cymbal_investigate
+allowed-tools: Read, Bash(git *), Bash(make *), fffind, ffgrep, Agent
 shell-timeout: 10
 ---
 

--- a/packages/rpiv-pi/skills/validate/SKILL.md
+++ b/packages/rpiv-pi/skills/validate/SKILL.md
@@ -2,7 +2,7 @@
 name: validate
 description: Verify that an implementation plan was correctly executed by running each phase's success criteria against the working tree and producing a validation report. Use after the implement skill completes, when the user asks to "validate the plan", wants a post-implementation audit, or needs to confirm a feature is fully shipped per its plan.
 argument-hint: "[plan-path]"
-allowed-tools: Read, Bash(git *), Bash(make *), Glob, Grep, Agent
+allowed-tools: Read, Bash(git *), Bash(make *), Glob, Grep, Agent, ffgrep, fffind, fff-multi-grep, cymbal_search, cymbal_outline, cymbal_show, cymbal_refs, cymbal_impact, cymbal_trace, cymbal_investigate
 shell-timeout: 10
 ---
 

--- a/scripts/apply-code-tools-overlay.mjs
+++ b/scripts/apply-code-tools-overlay.mjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+
+/**
+ * Applies this fork's code tools overlay to bundled rpiv-pi
+ * agents and skills.
+ *
+ * The upstream files remain normal markdown definitions. This script makes
+ * the code tools delta repeatable after upstream updates:
+ *
+ *   1. Merge or rebase upstream.
+ *   2. Run `node scripts/apply-local-nav-tools.mjs`.
+ *   3. Inspect the diff and resolve any real upstream prompt conflicts.
+ *
+ * The edits are intentionally mechanical:
+ * - expand agent frontmatter tool allowlists for Pi-fff and Pi-cymbal tools
+ * - insert/update a marked "Agent-Native Code Navigation Policy" section after frontmatter
+ * - apply agent-specific body nudges where generic policy is not enough
+ * - expand skill `allowed-tools` lists for skills that do direct file work
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const agentsDir = join(repoRoot, "packages", "rpiv-pi", "agents");
+const skillsDir = join(repoRoot, "packages", "rpiv-pi", "skills");
+
+// ---------------------------------------------------------------------------
+// Tool sets
+// ---------------------------------------------------------------------------
+
+const fffTools = ["ffgrep", "fffind", "fff-multi-grep"];
+const cymbalTools = [
+	"cymbal_map",
+	"cymbal_structure",
+	"cymbal_search",
+	"cymbal_outline",
+	"cymbal_show",
+	"cymbal_refs",
+	"cymbal_impact",
+	"cymbal_importers",
+	"cymbal_impls",
+	"cymbal_context",
+	"cymbal_diff",
+	"cymbal_trace",
+	"cymbal_investigate",
+];
+
+/** Locator agents name paths only — no symbol body reads via cymbal_show. */
+const locatorCymbalTools = cymbalTools.filter((tool) => tool !== "cymbal_show");
+
+const skillCymbalTools = [
+	"cymbal_search",
+	"cymbal_outline",
+	"cymbal_show",
+	"cymbal_refs",
+	"cymbal_impact",
+	"cymbal_trace",
+	"cymbal_investigate",
+];
+
+// ---------------------------------------------------------------------------
+// Agent classification
+// ---------------------------------------------------------------------------
+
+/** Default code-navigation agents: full fff + cymbal stack */
+const codeNavigationAgents = new Set([
+	"artifact-code-reviewer.md",
+	"artifact-coverage-reviewer.md",
+	"claim-verifier.md",
+	"codebase-analyzer.md",
+	"codebase-pattern-finder.md",
+	"diff-auditor.md",
+	"peer-comparator.md",
+	"precedent-locator.md",
+	"slice-verifier.md",
+	// scope-tracer, integration-scanner, codebase-locator → agentOverrides
+]);
+
+/** Agents with tailored tool sets and/or policies */
+const agentOverrides = new Map([
+	[
+		"codebase-locator.md",
+		{
+			tools: [...fffTools, ...locatorCymbalTools],
+			policy: "locator",
+			bodyInsertions: [
+				[
+					"### Initial Broad Search",
+					"Prefer `cymbal_map` / `cymbal_search` and `fffind` before shell-style search. Do **not** use `read` or `cymbal_show` — this agent names paths only.",
+				],
+			],
+		},
+	],
+	[
+		"scope-tracer.md",
+		{
+			tools: [...fffTools, ...cymbalTools],
+			policy: "scope-tracer",
+			bodyReplacements: [
+				[
+					"   - Run `grep` / `find` / `ls` per slice — one slice at a time, capture matches, then move on",
+					"   - Prefer `fff-multi-grep` (OR logic across anchor terms) or `cymbal_search` per slice — one slice at a time, capture matches, then move on; fall back to `grep` / `find` / `ls` when unavailable",
+				],
+				[
+					"Use `read` (no limit/offset) on every file the caller's prompt names. This is foundation context — done before any grep work.",
+					"Use `read` (no limit/offset) on every file the caller's prompt names. This is foundation context — done before any anchor sweep. Start unfamiliar areas with `cymbal_map` when available.",
+				],
+				[
+					"For each slice in order: run `grep` for the anchor terms, narrow with `find` / `ls` as needed, capture file:line matches. Move to the next slice once the current slice's match set is collected. Take time to ultrathink about how each slice's matches relate to the others before reading files for depth.",
+					"For each slice in order: run `fff-multi-grep` for the slice's anchor terms (OR logic) or `cymbal_search` for symbol/name anchors; narrow with `fffind` / `cymbal_map` as needed, capture file:line matches. Fall back to `grep` / `find` / `ls` when FFF or Cymbal tools are unavailable. Move to the next slice once the current slice's match set is collected. Take time to ultrathink about how each slice's matches relate to the others before reading files for depth.",
+				],
+			],
+		},
+	],
+	[
+		"integration-scanner.md",
+		{
+			tools: [...fffTools, ...cymbalTools],
+			policy: "integration-scanner",
+			bodyReplacements: [
+				[
+					"### Step 2: Search for Inbound References\n- Grep for the target's class/interface/namespace across the whole project\n- Exclude the target's own directory (we want external references)\n- Check for string references too (config files, DI registrations)",
+					"### Step 2: Search for Inbound References\n- Prefer `cymbal_refs`, `cymbal_importers`, and `cymbal_impact` on the target symbol when available\n- Fall back to grep for the target's class/interface/namespace across the whole project\n- Exclude the target's own directory (we want external references)\n- Check for string references too (config files, DI registrations)",
+				],
+				[
+					"### Step 4: Search for Outbound Dependencies\n- Read the target directory's import/using statements via Grep\n- Identify external service calls, database access, message publishing",
+					"### Step 4: Search for Outbound Dependencies\n- Prefer `cymbal_show` / `cymbal_outline` on the target symbol for imports, then `cymbal_trace` for dependency direction when available\n- Fall back to grep on the target directory's import/using statements\n- Identify external service calls, database access, message publishing",
+				],
+			],
+		},
+	],
+]);
+
+/** Artifact-oriented agents: only fff (no symbol navigation needed) */
+const fffOnlyAgents = new Set(["artifacts-analyzer.md", "artifacts-locator.md"]);
+
+const skillsToPatch = new Map([
+	["implement", [...fffTools, ...skillCymbalTools]],
+	["validate", [...fffTools, ...skillCymbalTools]],
+]);
+
+// ---------------------------------------------------------------------------
+// Policy templates
+// ---------------------------------------------------------------------------
+
+const policyStart = "<!-- rpiv-code-tools-policy:start -->";
+const policyEnd = "<!-- rpiv-code-tools-policy:end -->";
+
+const codeNavigationPolicy = `${policyStart}
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search:
+
+- Use \`cymbal_map\` for repo or directory orientation before choosing files.
+- Use \`cymbal_search\` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use \`cymbal_outline\` before reading large files.
+- Use \`cymbal_show\`, \`cymbal_refs\`, \`cymbal_importers\`, and \`cymbal_impact\` for targeted reads, references, dependency direction, and refactor blast radius.
+- Use \`cymbal_trace\` for call-graph traversal — follow callers or dependencies across a codebase.
+- Use \`cymbal_investigate\` for guided symbol investigation with auto-summarization.
+- Use \`fffind\` for fuzzy file discovery and ranked file narrowing.
+- Use \`ffgrep\` for fast literal or regex content search.
+- Use \`fff-multi-grep\` when sweeping several anchor terms with OR logic.
+- Fall back to \`find\` / \`grep\` / \`ls\` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+${policyEnd}`;
+
+const codebaseLocatorPolicy = `${policyStart}
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation before broad shell-style search. This agent **locates paths only** — do not read file bodies.
+
+- Use \`cymbal_map\` for repo or directory orientation before choosing files.
+- Use \`cymbal_search\` for symbol search, exact type/function names, or text search when symbol context matters.
+- Use \`cymbal_outline\` for export/signature lists without reading full files.
+- Use \`cymbal_refs\`, \`cymbal_importers\`, and \`cymbal_impact\` for reference direction and blast radius — not for deep analysis.
+- Use \`fffind\` for fuzzy file discovery and ranked file narrowing.
+- Use \`ffgrep\` for fast literal or regex content search.
+- Use \`fff-multi-grep\` when sweeping several anchor terms with OR logic.
+- Do **not** use \`read\` or \`cymbal_show\` — those belong to analyzer agents.
+- Fall back to \`find\` / \`grep\` / \`ls\` when FFF or Cymbal tools are unavailable, when exact built-in behavior is required, or when searching non-Git/generated/transient paths that Cymbal does not index.
+${policyEnd}`;
+
+const scopeTracerPolicy = `${policyStart}
+## Agent-Native Code Navigation Policy
+
+When available, prefer agent-native code navigation for anchor sweeps and orientation:
+
+- Use \`cymbal_map\` to orient in unfamiliar areas before slicing.
+- Use \`fff-multi-grep\` as the default anchor sweep — OR logic across 2-6 terms per slice.
+- Use \`cymbal_search\` for symbol/name anchors and \`cymbal_outline\` before reading large files.
+- Use \`cymbal_show\` only in Step 4 depth reads (5-10 files cap), not during the sweep.
+- Use \`fffind\` / \`ffgrep\` when Cymbal does not cover the path or term shape.
+- Fall back to \`find\` / \`grep\` / \`ls\` when FFF or Cymbal tools are unavailable or for non-Git/generated paths.
+${policyEnd}`;
+
+const integrationScannerPolicy = `${policyStart}
+## Agent-Native Code Navigation Policy
+
+When available, prefer Cymbal relationship tools before project-wide grep:
+
+- Use \`cymbal_refs\`, \`cymbal_importers\`, and \`cymbal_impact\` for inbound/outbound connection discovery.
+- Use \`cymbal_search\` for string/config references Cymbal may not index as symbols.
+- Use \`cymbal_outline\` / \`cymbal_show\` narrowly for import lists — do not deep-read implementations.
+- Use \`fff-multi-grep\` for DI/event/route/config pattern sweeps across anchor terms.
+- Use \`fffind\` / \`ffgrep\` as fallbacks when Cymbal is unavailable.
+- Fall back to \`find\` / \`grep\` / \`ls\` for non-Git/generated/transient paths.
+${policyEnd}`;
+
+const fffOnlyPolicy = `${policyStart}
+## Agent-Native Code Navigation Policy
+
+When available, prefer Pi-fff for local artifact and text discovery:
+
+- Use \`fffind\` for fuzzy file discovery and ranked file narrowing.
+- Use \`ffgrep\` for fast literal or regex content search.
+- Use \`fff-multi-grep\` when sweeping several anchor terms with OR logic.
+- Fall back to \`find\` / \`grep\` / \`ls\` when FFF tools are unavailable or exact built-in behavior is required.
+${policyEnd}`;
+
+const policies = {
+	default: codeNavigationPolicy,
+	locator: codebaseLocatorPolicy,
+	"scope-tracer": scopeTracerPolicy,
+	"integration-scanner": integrationScannerPolicy,
+	fff: fffOnlyPolicy,
+};
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseFrontmatter(markdown, file) {
+	if (!markdown.startsWith("---\n")) {
+		throw new Error(`${file}: missing frontmatter`);
+	}
+	const end = markdown.indexOf("\n---\n", 4);
+	if (end === -1) {
+		throw new Error(`${file}: unterminated frontmatter`);
+	}
+	return {
+		frontmatter: markdown.slice(0, end + "\n---".length),
+		body: markdown.slice(end + "\n---\n".length),
+	};
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function updateToolsField(frontmatter, extraTools, file) {
+	const toolsMatch = frontmatter.match(/^tools:\s*(.+)$/m);
+	if (!toolsMatch) {
+		throw new Error(`${file}: missing tools frontmatter field`);
+	}
+
+	const current = toolsMatch[1]
+		.split(",")
+		.map((tool) => tool.trim())
+		.filter(Boolean);
+	const merged = [...current];
+	for (const tool of extraTools) {
+		if (!merged.includes(tool)) merged.push(tool);
+	}
+
+	return frontmatter.replace(/^tools:\s*.+$/m, `tools: ${merged.join(", ")}`);
+}
+
+function updatePolicy(body, policy) {
+	const markerPattern = new RegExp(`${escapeRegExp(policyStart)}[\\s\\S]*?${escapeRegExp(policyEnd)}\\n*`, "m");
+	const normalizedPolicy = `${policy}\n\n`;
+	if (markerPattern.test(body)) {
+		return body.replace(markerPattern, normalizedPolicy);
+	}
+	return `${normalizedPolicy}${body.replace(/^\n+/, "")}`;
+}
+
+/**
+ * In-place replacements: the `from` text is fully replaced by `to` and no longer
+ * appears in the output. Idempotent — skips when `from` is already gone and `to`
+ * is already present.
+ */
+function applyBodyReplacements(body, replacements) {
+	let next = body;
+	for (const [from, to] of replacements) {
+		if (!next.includes(from)) {
+			if (next.includes(to)) continue;
+			throw new Error(
+				`Body patch anchor not found (and replacement not already present):\n${from.slice(0, 120)}...`,
+			);
+		}
+		next = next.replace(from, to);
+	}
+	return next;
+}
+
+/**
+ * After-anchor insertions: `text` is inserted after `anchor` (which stays in the
+ * output). Idempotent — skips when `text` is already present in the body.
+ */
+function applyBodyInsertions(body, insertions) {
+	let next = body;
+	for (const [anchor, text] of insertions) {
+		if (next.includes(text)) continue;
+		if (!next.includes(anchor)) {
+			throw new Error(`Body insertion anchor not found:\n${anchor.slice(0, 120)}...`);
+		}
+		next = next.replace(anchor, `${anchor}\n\n${text}`);
+	}
+	return next;
+}
+
+function applyToAgent(file, extraTools, policyKey, bodyReplacements = [], bodyInsertions = []) {
+	const path = join(agentsDir, file);
+	const original = readFileSync(path, "utf8");
+	const { frontmatter, body } = parseFrontmatter(original, file);
+	const policy = policies[policyKey] ?? policies.default;
+	let nextBody = updatePolicy(body, policy);
+	if (bodyReplacements.length > 0) {
+		nextBody = applyBodyReplacements(nextBody, bodyReplacements);
+	}
+	if (bodyInsertions.length > 0) {
+		nextBody = applyBodyInsertions(nextBody, bodyInsertions);
+	}
+	const next = `${updateToolsField(frontmatter, extraTools, file)}\n${nextBody}`;
+	if (next !== original) {
+		writeFileSync(path, next, "utf8");
+		return true;
+	}
+	return false;
+}
+
+function applyToSkill(skillDir, extraTools) {
+	const path = join(skillsDir, skillDir, "SKILL.md");
+	const original = readFileSync(path, "utf8");
+	const { frontmatter, body } = parseFrontmatter(original, `skills/${skillDir}/SKILL.md`);
+
+	const toolsMatch = frontmatter.match(/^allowed-tools:\s*(.+)$/m);
+	if (!toolsMatch) {
+		return false;
+	}
+
+	const current = toolsMatch[1]
+		.split(",")
+		.map((tool) => tool.trim())
+		.filter(Boolean);
+	const merged = [...current];
+	for (const tool of extraTools) {
+		if (!merged.includes(tool)) merged.push(tool);
+	}
+
+	const nextFm = frontmatter.replace(/^allowed-tools:\s*.+$/m, `allowed-tools: ${merged.join(", ")}`);
+	const next = `${nextFm}\n${body}`;
+	if (next !== original) {
+		writeFileSync(path, next, "utf8");
+		return true;
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Execute
+// ---------------------------------------------------------------------------
+
+let changed = 0;
+
+for (const file of codeNavigationAgents) {
+	if (applyToAgent(file, [...fffTools, ...cymbalTools], "default")) changed++;
+}
+
+for (const [file, override] of agentOverrides) {
+	if (
+		applyToAgent(
+			file,
+			override.tools,
+			override.policy,
+			override.bodyReplacements ?? [],
+			override.bodyInsertions ?? [],
+		)
+	) {
+		changed++;
+	}
+}
+
+for (const file of fffOnlyAgents) {
+	if (applyToAgent(file, fffTools, "fff")) changed++;
+}
+
+for (const [skillDir, tools] of skillsToPatch) {
+	if (applyToSkill(skillDir, tools)) changed++;
+}
+
+console.log(`Applied code tools overlay (${changed} file${changed === 1 ? "" : "s"} changed).`);

--- a/scripts/apply-code-tools-overlay.mjs
+++ b/scripts/apply-code-tools-overlay.mjs
@@ -8,7 +8,7 @@
  * the code tools delta repeatable after upstream updates:
  *
  *   1. Merge or rebase upstream.
- *   2. Run `node scripts/apply-local-nav-tools.mjs`.
+ *   2. Run `node scripts/apply-code-tools-overlay.mjs`.
  *   3. Inspect the diff and resolve any real upstream prompt conflicts.
  *
  * The edits are intentionally mechanical:

--- a/scripts/apply-code-tools-overlay.mjs
+++ b/scripts/apply-code-tools-overlay.mjs
@@ -13,6 +13,8 @@
  *
  * The edits are intentionally mechanical:
  * - expand agent frontmatter tool allowlists for Pi-fff and Pi-cymbal tools
+ * - replace `isolated: true` with `extensions: cymbal,ff` so extension tools load
+ *   but non-code-tool extensions stay blocked (preserving isolation intent)
  * - insert/update a marked "Agent-Native Code Navigation Policy" section after frontmatter
  * - apply agent-specific body nudges where generic policy is not enough
  * - expand skill `allowed-tools` lists for skills that do direct file work
@@ -49,7 +51,7 @@ const cymbalTools = [
 /** Locator agents name paths only — no symbol body reads via cymbal_show. */
 const locatorCymbalTools = cymbalTools.filter((tool) => tool !== "cymbal_show");
 
-const skillCymbalTools = [
+const _skillCymbalTools = [
 	"cymbal_search",
 	"cymbal_outline",
 	"cymbal_show",
@@ -58,6 +60,25 @@ const skillCymbalTools = [
 	"cymbal_trace",
 	"cymbal_investigate",
 ];
+
+/**
+ * Extension prefix allowlist for `extensions:` frontmatter.
+ *
+ * When `isolated: true` is set, pi-subagents sets `noExtensions: true` on the
+ * resource loader, which prevents ALL extension tools from loading.  The tools
+ * listed in `tools:` frontmatter become a dead allowlist — nothing to allow.
+ *
+ * Replacing `isolated: true` with `extensions: cymbal,ff` achieves:
+ *   - Extensions are loaded (pi-subagents passes `noExtensions: false`)
+ *   - cymbal_* tools and ff* tools pass the `allowedToolNames` gate (they're
+ *     in `tools:`) and the `builtinToolNameSet` active-tool filter
+ *   - Other extension tools (web_search, ask_user_question, todo, advisor, etc.)
+ *     are blocked because they don't match prefix "cymbal" or "ff"
+ *
+ * If fff-only agents need a narrower list, use "ff" alone.
+ */
+const codeToolExtensions = "cymbal,ff";
+const fffOnlyExtensions = "ff";
 
 // ---------------------------------------------------------------------------
 // Agent classification
@@ -135,10 +156,76 @@ const agentOverrides = new Map([
 /** Artifact-oriented agents: only fff (no symbol navigation needed) */
 const fffOnlyAgents = new Set(["artifacts-analyzer.md", "artifacts-locator.md"]);
 
-const skillsToPatch = new Map([
-	["implement", [...fffTools, ...skillCymbalTools]],
-	["validate", [...fffTools, ...skillCymbalTools]],
+// ---------------------------------------------------------------------------
+// Skill patching
+// ---------------------------------------------------------------------------
+
+/**
+ * `allowed-tools` is only a prompt hint — not enforced at the API level.
+ * Replacing Glob/Grep in the `allowed-tools` line and body text makes the
+ * preferred tool explicit so the agent reaches for fff first.  The original
+ * Pi built-in find/grep/ls tools remain available as fallbacks.
+ *
+ * Similarly, body text that references grep/find/ls for code navigation
+ * should name the preferred cymbal/fff tool directly so the agent reaches
+ * for it without needing an `allowed-tools` hint.
+ */
+const skillBodyReplacements = new Map([
+	[
+		"research",
+		[
+			[
+				"sweeps anchor terms via grep/find/ls",
+				"sweeps anchor terms via fff-multi-grep/cymbal_search, falling back to grep/find/ls when unavailable",
+			],
+		],
+	],
+	[
+		"migrate-to-guidance",
+		[
+			[
+				"Use Glob to find all `**/CLAUDE.md` files in the project",
+				"Use fffind to find all `**/CLAUDE.md` files in the project",
+			],
+		],
+	],
+	// The annotation skills contain a subagent prompt that says "Use grep/find/ls only".
+	// The subagents now have `extensions: cymbal,ff` (set by the agent patching above),
+	// so they can use fff/cymbal tools directly.  Update the prompt to guide them.
+	[
+		"annotate-guidance",
+		[
+			[
+				"Use grep/find/ls only. Do not read file contents.",
+				"Prefer fffind/ffgrep/fff-multi-grep and cymbal_map/cymbal_search for orientation; fall back to find/grep/ls when unavailable. Do not read file contents.",
+			],
+		],
+	],
+	[
+		"annotate-inline",
+		[
+			[
+				"Use grep/find/ls only. Do not read file contents.",
+				"Prefer fffind/ffgrep/fff-multi-grep and cymbal_map/cymbal_search for orientation; fall back to find/grep/ls when unavailable. Do not read file contents.",
+			],
+		],
+	],
 ]);
+
+/** Skills whose `allowed-tools` line lists Glob and/or Grep. */
+const skillsWithAllowedTools = new Set([
+	"annotate-guidance",
+	"annotate-inline",
+	"changelog",
+	"commit",
+	"create-handoff",
+	"implement",
+	"migrate-to-guidance",
+	"validate",
+]);
+
+/** All skills that need processing (union of allowed-tools + body replacements). */
+const allSkillsToPatch = new Set([...skillsWithAllowedTools, ...skillBodyReplacements.keys()]);
 
 // ---------------------------------------------------------------------------
 // Policy templates
@@ -265,6 +352,34 @@ function updateToolsField(frontmatter, extraTools, file) {
 	return frontmatter.replace(/^tools:\s*.+$/m, `tools: ${merged.join(", ")}`);
 }
 
+/**
+ * Replace `isolated: true` with an `extensions:` prefix allowlist.
+ *
+ * `isolated: true` blocks ALL extension tools from loading (even those named
+ * in `tools:`).  Replacing it with `extensions: <prefixes>` lets the declared
+ * code-tool extensions through while keeping other extensions' tools out.
+ * Idempotent — skips when `isolated` is already absent and `extensions` is
+ * already set to the target value.
+ */
+function updateIsolationField(frontmatter, extensionsValue, _file) {
+	const isolatedMatch = frontmatter.match(/^isolated:\s*true\s*$/m);
+	if (isolatedMatch) {
+		// Replace `isolated: true` with `extensions: <prefixes>`
+		return frontmatter.replace(/^isolated:\s*true\s*$/m, `extensions: ${extensionsValue}`);
+	}
+
+	// Already migrated: check if extensions field has the right value
+	const extensionsMatch = frontmatter.match(/^extensions:\s*(.+)$/m);
+	if (extensionsMatch) {
+		const current = extensionsMatch[1].trim();
+		if (current === extensionsValue) return frontmatter; // already correct
+		return frontmatter.replace(/^extensions:\s*.+$/m, `extensions: ${extensionsValue}`);
+	}
+
+	// No `isolated:` and no `extensions:` — add `extensions:` after `tools:` line
+	return frontmatter.replace(/^(tools:\s*.+)$/m, `$1\nextensions: ${extensionsValue}`);
+}
+
 function updatePolicy(body, policy) {
 	const markerPattern = new RegExp(`${escapeRegExp(policyStart)}[\\s\\S]*?${escapeRegExp(policyEnd)}\\n*`, "m");
 	const normalizedPolicy = `${policy}\n\n`;
@@ -309,7 +424,14 @@ function applyBodyInsertions(body, insertions) {
 	return next;
 }
 
-function applyToAgent(file, extraTools, policyKey, bodyReplacements = [], bodyInsertions = []) {
+function applyToAgent(
+	file,
+	extraTools,
+	policyKey,
+	extensionsValue = codeToolExtensions,
+	bodyReplacements = [],
+	bodyInsertions = [],
+) {
 	const path = join(agentsDir, file);
 	const original = readFileSync(path, "utf8");
 	const { frontmatter, body } = parseFrontmatter(original, file);
@@ -321,7 +443,9 @@ function applyToAgent(file, extraTools, policyKey, bodyReplacements = [], bodyIn
 	if (bodyInsertions.length > 0) {
 		nextBody = applyBodyInsertions(nextBody, bodyInsertions);
 	}
-	const next = `${updateToolsField(frontmatter, extraTools, file)}\n${nextBody}`;
+	let nextFm = updateToolsField(frontmatter, extraTools, file);
+	nextFm = updateIsolationField(nextFm, extensionsValue, file);
+	const next = `${nextFm}\n${nextBody}`;
 	if (next !== original) {
 		writeFileSync(path, next, "utf8");
 		return true;
@@ -329,27 +453,60 @@ function applyToAgent(file, extraTools, policyKey, bodyReplacements = [], bodyIn
 	return false;
 }
 
-function applyToSkill(skillDir, extraTools) {
-	const path = join(skillsDir, skillDir, "SKILL.md");
-	const original = readFileSync(path, "utf8");
-	const { frontmatter, body } = parseFrontmatter(original, `skills/${skillDir}/SKILL.md`);
-
+/**
+ * Replace Claude Code tool names (Glob, Grep) in the `allowed-tools` line
+ * with their Pi-fff equivalents (fffind, ffgrep).  The original Pi built-in
+ * find/grep/ls tools remain available to the agent regardless — `allowed-tools`
+ * is only a hint, so replacing rather than appending avoids listing dead names
+ * and makes the preferred tool explicit.
+ *
+ * Idempotent — skips when the replacements are already present and the
+ * originals are already gone.
+ */
+function replaceAllowedTools(frontmatter, _skillDir) {
 	const toolsMatch = frontmatter.match(/^allowed-tools:\s*(.+)$/m);
-	if (!toolsMatch) {
-		return false;
-	}
+	if (!toolsMatch) return frontmatter;
 
 	const current = toolsMatch[1]
 		.split(",")
 		.map((tool) => tool.trim())
 		.filter(Boolean);
-	const merged = [...current];
-	for (const tool of extraTools) {
-		if (!merged.includes(tool)) merged.push(tool);
+
+	let changed = false;
+	const next = current.map((tool) => {
+		if (tool === "Glob") {
+			changed = true;
+			return "fffind";
+		}
+		if (tool === "Grep") {
+			changed = true;
+			return "ffgrep";
+		}
+		return tool;
+	});
+
+	if (!changed) return frontmatter;
+	return frontmatter.replace(/^allowed-tools:\s*.+$/m, `allowed-tools: ${next.join(", ")}`);
+}
+
+function applyToSkill(skillDir) {
+	const path = join(skillsDir, skillDir, "SKILL.md");
+	const original = readFileSync(path, "utf8");
+	const { frontmatter, body } = parseFrontmatter(original, `skills/${skillDir}/SKILL.md`);
+
+	let nextFm = frontmatter;
+	if (skillsWithAllowedTools.has(skillDir)) {
+		nextFm = replaceAllowedTools(frontmatter, skillDir);
 	}
 
-	const nextFm = frontmatter.replace(/^allowed-tools:\s*.+$/m, `allowed-tools: ${merged.join(", ")}`);
-	const next = `${nextFm}\n${body}`;
+	let nextBody = body;
+
+	const replacements = skillBodyReplacements.get(skillDir);
+	if (replacements) {
+		nextBody = applyBodyReplacements(nextBody, replacements);
+	}
+
+	const next = `${nextFm}\n${nextBody}`;
 	if (next !== original) {
 		writeFileSync(path, next, "utf8");
 		return true;
@@ -364,7 +521,7 @@ function applyToSkill(skillDir, extraTools) {
 let changed = 0;
 
 for (const file of codeNavigationAgents) {
-	if (applyToAgent(file, [...fffTools, ...cymbalTools], "default")) changed++;
+	if (applyToAgent(file, [...fffTools, ...cymbalTools], "default", codeToolExtensions)) changed++;
 }
 
 for (const [file, override] of agentOverrides) {
@@ -373,6 +530,7 @@ for (const [file, override] of agentOverrides) {
 			file,
 			override.tools,
 			override.policy,
+			codeToolExtensions,
 			override.bodyReplacements ?? [],
 			override.bodyInsertions ?? [],
 		)
@@ -382,11 +540,11 @@ for (const [file, override] of agentOverrides) {
 }
 
 for (const file of fffOnlyAgents) {
-	if (applyToAgent(file, fffTools, "fff")) changed++;
+	if (applyToAgent(file, fffTools, "fff", fffOnlyExtensions)) changed++;
 }
 
-for (const [skillDir, tools] of skillsToPatch) {
-	if (applyToSkill(skillDir, tools)) changed++;
+for (const skillDir of allSkillsToPatch) {
+	if (applyToSkill(skillDir)) changed++;
 }
 
 console.log(`Applied code tools overlay (${changed} file${changed === 1 ? "" : "s"} changed).`);

--- a/scripts/set-fork-rpiv-pi-version.mjs
+++ b/scripts/set-fork-rpiv-pi-version.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+/**
+ * Sets packages/rpiv-pi/package.json version to `{upstream-base}-{label}`.
+ *
+ * Used by the fork sync workflow after merging upstream:
+ *   - overlay success  → 1.16.2-overlay
+ *   - overlay failure  → 1.16.2-no-overlay
+ *
+ * Strips any existing fork suffix before applying the new label so re-runs
+ * stay idempotent against the same upstream base.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const label = process.argv[2];
+if (label !== "overlay" && label !== "no-overlay") {
+	console.error("Usage: node scripts/set-fork-rpiv-pi-version.mjs <overlay|no-overlay>");
+	process.exit(1);
+}
+
+const pkgPath = join(process.cwd(), "packages", "rpiv-pi", "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+const base = String(pkg.version).replace(/-(overlay|no-overlay)$/, "");
+pkg.version = `${base}-${label}`;
+writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+console.log(`Set @juicesharp/rpiv-pi version to ${pkg.version}`);


### PR DESCRIPTION
## Problem

The code tools overlay (`apply-code-tools-overlay.mjs`) added `cymbal_*` and `ff*` tool names to agent `tools:` frontmatter, but the existing `isolated: true` flag prevented ALL extension tools from loading in subagent sessions. The `tools:` allowlist was dead — `noExtensions: true` prevented the tools from ever being registered.

Additionally, `allowed-tools` in skill SKILL.md files is only a prompt hint (not enforced at the API level), so the overlay should reference the preferred tools directly in instruction text.

## Changes

### Agents (14 files)
- Replace `isolated: true` → `extensions: cymbal,ff` (or `extensions: ff` for fff-only agents)
- This is a scoped prefix allowlist: allows cymbal/fff tools through while blocking other extension tools (web_search, ask_user_question, todo, etc.) — preserving isolation intent

### Skills (7 files)
- Replace `Glob` → `fffind` and `Grep` → `ffgrep` directly in `allowed-tools` lines (make the preferred tool explicit rather than relying on a hint that lists dead Claude Code names)
- Add body text replacements that reference cymbal/fff tools directly in instructions:
  - `research`: anchor sweep prefers fff-multi-grep/cymbal_search
  - `annotate-guidance`/`annotate-inline`: subagent prompt prefers fff/cymbal for orientation
  - `migrate-to-guidance`: uses fffind instead of Glob
- Remove over-scoped cymbal tools from `implement`/`validate` `allowed-tools` (those skills delegate exploration to subagents which now have `extensions: cymbal,ff`)

### Overlay script (`scripts/apply-code-tools-overlay.mjs`)
- Add `updateIsolationField()` to replace `isolated: true` with `extensions:` prefix allowlist
- Add `replaceAllowedTools()` to swap Glob→fffind, Grep→ffgrep in skill `allowed-tools` lines
- Add `skillBodyReplacements` map for direct tool references in skill instruction text
- Idempotent — safe to re-run after upstream merges