### PR TITLE
fix(rpiv-pi): accept @gotgenes/pi-subagents as a valid SIBLINGS[0] sibling

### DIFF
--- a/packages/rpiv-pi/extensions/rpiv-core/siblings.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/siblings.test.ts
@@ -44,6 +44,30 @@ describe("SIBLINGS registry", () => {
 		expect(i18nEntry?.matches.test("@juicesharp/rpiv-i18n")).toBe(true);
 	});
 
+	it("pi-subagents SIBLINGS[0] matches BOTH the @tintinweb/pi-subagents fork and the @gotgenes/pi-subagents fork", () => {
+		const subagentsEntry = SIBLINGS[0];
+		expect(subagentsEntry).toBeDefined();
+		// Upstream fork (default install target via /rpiv-setup)
+		expect(subagentsEntry?.matches.test("@tintinweb/pi-subagents")).toBe(true);
+		// @gotgenes/pi-subagents — API-compatible fork with the same tool surface
+		expect(subagentsEntry?.matches.test("@gotgenes/pi-subagents")).toBe(true);
+	});
+
+	it("pi-subagents SIBLINGS[0] regex is case-insensitive across both fork namespaces", () => {
+		const subagentsEntry = SIBLINGS[0];
+		expect(subagentsEntry?.matches.test("@TINTINWEB/PI-SUBAGENTS")).toBe(true);
+		expect(subagentsEntry?.matches.test("@GOTGENES/PI-SUBAGENTS")).toBe(true);
+	});
+
+	it("pi-subagents SIBLINGS[0] regex does NOT match unrelated @-scoped pi-subagents-* variants", () => {
+		const subagentsEntry = SIBLINGS[0];
+		// Word-boundary guard: must not over-match a hypothetical future sibling
+		// such as `@juicesharp/pi-subagents-utils` (a dash right after the
+		// `pi-subagents` token is excluded via `(?![-\w])`).
+		expect(subagentsEntry?.matches.test("@tintinweb/pi-subagents-utils")).toBe(false);
+		expect(subagentsEntry?.matches.test("@gotgenes/pi-subagents-utils")).toBe(false);
+	});
+
 	it("every entry has non-empty pkg + provides", () => {
 		for (const s of SIBLINGS) {
 			expect(s.pkg.length).toBeGreaterThan(0);

--- a/packages/rpiv-pi/extensions/rpiv-core/siblings.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/siblings.ts
@@ -22,8 +22,17 @@ export interface SiblingPlugin {
 export const SIBLINGS: readonly SiblingPlugin[] = [
 	{
 		pkg: "npm:@tintinweb/pi-subagents",
-		matches: /@tintinweb\/pi-subagents/i,
-		provides: "Agent / get_subagent_result / steer_subagent tools",
+		// Accept both the upstream tintinweb fork AND the @gotgenes/pi-subagents
+		// fork (API-compatible: same `subagent` / `get_subagent_result` /
+		// `steer_subagent` tool surface). Default `pkg` stays the upstream fork
+		// because that's what /rpiv-setup installs; the regex widens the
+		// detection so users on the gotgenes fork don't see a false
+		// "missing sibling" banner on session_start. The trailing `(?![-\w])`
+		// word boundary matches the defensive pattern used by LEGACY_SIBLINGS
+		// and prevents over-matching a hypothetical `@scope/pi-subagents-*`
+		// variant (e.g. `pi-subagents-utils`).
+		matches: /@(tintinweb|gotgenes)\/pi-subagents(?![-\w])/i,
+		provides: "Agent / get_subagent_result / steer_subagent tools (tintinweb or gotgenes fork)",
 	},
 	{
 		pkg: "npm:@juicesharp/rpiv-ask-user-question",


### PR DESCRIPTION
## Problem

`SIBLINGS[0]` in `packages/rpiv-pi/extensions/rpiv-core/siblings.ts` hard-codes
`/@tintinweb\/pi-subagents/i` for the regex. Users running the
[API-compatible `@gotgenes/pi-subagents` fork](https://www.npmjs.com/package/@gotgenes/pi-subagents)
get a false positive on every `session_start`:

```
╭─ rpiv-pi: 1 sibling extension missing ─╮
│  • @tintinweb/pi-subagents              │
│                                         │
│  Run /rpiv-setup to install them.       │
╰─────────────────────────────────────────╯
```

The fork exposes the same tool surface (`subagent`, `get_subagent_result`,
`steer_subagent`) — only the npm namespace differs. `package-checks.ts`
reads the regex as a pure presence detector, so widening it is safe and
purely additive.

## Change

```diff
- matches: /@tintinweb\/pi-subagents/i,
+ matches: /@(tintinweb|gotgenes)\/pi-subagents(?![-\w])/i,
```

- `pkg` stays `npm:@tintinweb/pi-subagents` so `/rpiv-setup` still installs
  the upstream fork by default.
- Added the trailing `(?![-\w])` word boundary, matching the defensive
  pattern already used by `LEGACY_SIBLINGS`, to prevent over-matching a
  hypothetical future `@scope/pi-subagents-*` variant (e.g.
  `pi-subagents-utils`).

## Test coverage

Added three cases to `siblings.test.ts`:

1. `SIBLINGS[0]` matches BOTH `@tintinweb/pi-subagents` and
   `@gotgenes/pi-subagents`.
2. The regex is case-insensitive across both namespaces
   (`@TINTINWEB/PI-SUBAGENTS`, `@GOTGENES/PI-SUBAGENTS`).
3. The word boundary correctly rejects
   `@tintinweb/pi-subagents-utils` and `@gotgenes/pi-subagents-utils`.

`siblings.test.ts`: 27 → 30 tests, all green.
`siblings + package-checks + setup-command + session-hooks` combined:
**85/85 pass** on this branch.

## Notes for reviewers

- The local pre-push `vitest run` on this branch reports 74 pre-existing
  failures across the monorepo, all in the
  `github.test.ts`/`git-context.test.ts` family — these are Windows
  path/symlink artefacts that fail on the local `main` checkout too.
  CI on `ubuntu-latest` should be clean. If you want me to file a
  separate issue for those, happy to.
- `LEGACY_SIBLINGS` is left untouched: the `@gotgenes` namespace is
  scoped (the leading `/` in the namespace prevents the
  `(^|[^\w/-])` legacy regex from matching it), so no false prune
  on `/rpiv-setup`.