### PR TITLE
feat: add Chinese (zh) localization support

### DIFF
--- a/packages/rpiv-ask-user-question/locales/zh.json
+++ b/packages/rpiv-ask-user-question/locales/zh.json
@@ -1,0 +1,29 @@
+{
+  "_meta.notes": "中文翻译。欢迎中文母语者通过 PR 审校。TUI 符号（↑/↓、⚠）为通用 CLI 约定，保持原文不译。Enter、Space 采用中文惯用说法（回车、空格）；Esc、Tab、Ctrl、n 等保留原文。",
+
+  "sentinel.other": "输入内容",
+  "sentinel.chat": "聊聊这个",
+  "sentinel.next": "下一个",
+
+  "submit.label": "提交答案",
+  "submit.cancel": "取消",
+
+  "hint.enter": "回车选择",
+  "hint.navigate": "↑/↓ 导航",
+  "hint.toggle": "空格切换",
+  "hint.notes": "按 n 添加备注",
+  "hint.tab": "Tab 切换问题",
+  "hint.collapse": "Ctrl+] 折叠",
+  "hint.expand_line": "Ctrl+] 展开 · Esc 取消",
+  "hint.cancel": "Esc 取消",
+
+  "review.heading": "检查你的答案",
+  "review.ready": "准备提交答案了吗？",
+  "review.incomplete": "⚠ 提交前请先回答以下问题：",
+
+  "preview.no_preview": "暂无预览",
+  "preview.notes_affordance": "备注：按 n 添加",
+
+  "chat.summary": "用户想聊聊这个话题",
+  "notes.header": "备注："
+}

--- a/packages/rpiv-i18n/i18n.ts
+++ b/packages/rpiv-i18n/i18n.ts
@@ -63,6 +63,7 @@ export const SUPPORTED_LOCALES: readonly { code: string; label: string }[] = [
 	{ code: "pt-BR", label: "Português (Brasil)" },
 	{ code: "ru", label: "Русский" },
 	{ code: "uk", label: "Українська" },
+	{ code: "zh", label: "中文" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/rpiv-todo/locales/zh.json
+++ b/packages/rpiv-todo/locales/zh.json
@@ -1,0 +1,17 @@
+{
+  "_meta.notes": "中文翻译。欢迎中文母语者通过 PR 审校。",
+
+  "status.pending": "待处理",
+  "status.in_progress": "进行中",
+  "status.completed": "已完成",
+  "status.deleted": "已删除",
+
+  "overlay.heading": "任务清单",
+  "overlay.more": "更多",
+
+  "command.no_todos": "暂无任务。可以让 agent 添加一些！",
+  "command.requires_interactive": "/todos 需要交互模式",
+  "command.section.pending": "── 待处理 ──",
+  "command.section.in_progress": "── 进行中 ──",
+  "command.section.completed": "── 已完成 ──"
+}

--- a/packages/rpiv-voice/locales/en.json
+++ b/packages/rpiv-voice/locales/en.json
@@ -38,5 +38,8 @@
   "settings.language_value_auto": "Auto-detect",
   "settings.language_hint": "Run /languages to change.",
   "settings.hallucination_filter_label": "Filter Whisper noise",
-  "settings.hallucination_filter_hint": "Drops silence-segment artifacts. Turn off for single-word dictation."
+  "settings.hallucination_filter_hint": "Drops silence-segment artifacts. Turn off for single-word dictation.",
+
+  "settings.equalizer_label": "Equalizer",
+  "settings.equalizer_hint": "Show the live audio waveform under the transcript. Off by default."
 }

--- a/packages/rpiv-voice/locales/zh.json
+++ b/packages/rpiv-voice/locales/zh.json
@@ -1,0 +1,47 @@
+{
+  "_meta.notes": "中文翻译。欢迎中文母语者通过 PR 审校。",
+
+  "command.description": "用语音输入文字——本地 STT，无需云端",
+
+  "error.requires_interactive": "/voice 需要交互模式",
+  "error.model_download_failed": "STT 模型下载失败，请检查网络连接。",
+  "error.model_extract_failed": "下载的 STT 模型压缩包已损坏，请重试。",
+  "error.model_verify_failed": "STT 模型文件下载不完整，请重试。",
+  "error.model_stale_install": "STT 模型文件已被删除或损坏，下次启动时将重新下载。",
+  "error.engine_load_failed": "STT 模型加载失败。",
+  "error.mic_unavailable": "麦克风不可用。请检查是否连接了输入设备，以及 Pi 是否有麦克风权限。",
+
+  "splash.preparing": "正在准备模型……",
+  "splash.downloading": "正在下载 Whisper……",
+  "splash.extracting": "正在解压模型文件……",
+  "splash.verifying": "正在校验模型文件……",
+  "splash.loading_engine": "正在加载语音模型……",
+  "splash.initializing_mic": "正在初始化麦克风……",
+
+  "footer.enter_paste": "回车粘贴",
+  "footer.space_pause": "空格暂停",
+  "footer.space_resume": "空格继续",
+  "footer.tab_settings": "Tab 设置",
+  "footer.esc_cancel": "Esc 取消",
+  "footer.esc_back": "Esc 返回",
+  "footer.ctrl_s_save": "Ctrl-S 保存",
+  "footer.enter_toggle": "回车切换",
+
+  "transcript.placeholder": "正在聆听……",
+
+  "notify.settings_saved": "语音设置已保存",
+
+  "status.recording": "录制中",
+  "status.paused": "已暂停",
+
+  "settings.microphone_label": "麦克风",
+  "settings.microphone_value_default": "系统默认输入设备",
+  "settings.language_label": "语言",
+  "settings.language_value_auto": "自动检测",
+  "settings.language_hint": "运行 /languages 切换语言。",
+  "settings.hallucination_filter_label": "过滤 Whisper 噪声",
+  "settings.hallucination_filter_hint": "丢弃静音段伪影。单词语音转写时可关闭。",
+
+  "settings.equalizer_label": "均衡器",
+  "settings.equalizer_hint": "在转录文本下方显示实时音频波形。默认关闭。"
+}


### PR DESCRIPTION
## Summary

Add Chinese (zh) localization for `rpiv-ask-user-question`, `rpiv-todo`, and `rpiv-voice`, and register `zh` in the i18n SDK.

This follows up on the original PR by @Po1nt9 (#27), which was closed due to inactivity.

## Changes

- Added `packages/rpiv-ask-user-question/locales/zh.json` with 20 translated UI strings plus `_meta.notes`
- Added `packages/rpiv-todo/locales/zh.json` with 11 translated UI strings
- Added `packages/rpiv-voice/locales/zh.json` with 35 translated UI strings
- Registered `zh` in `packages/rpiv-i18n/i18n.ts` under `SUPPORTED_LOCALES`
- Included translations for 2 keys added since the original PR:
  - `hint.collapse`
  - `hint.expand_line`
- Fixed missing i18n keys in `packages/rpiv-voice/locales/en.json`:
  - `settings.equalizer_label` (was missing from en.json, always fell back to code default)
  - `settings.equalizer_hint` (same)

## Fixes vs. original PR

- Placed `zh` after `uk` in `SUPPORTED_LOCALES` to preserve locale-code ordering
- No `index.ts` update is needed with the current `registerLocalesFromDir`-based locale loading

## Notes

This PR uses the generic `zh` locale code with Simplified Chinese translations.

Out of scope for this PR, but worth flagging: `tab-bar.ts` appears to hardcode `" ✓ Submit "` instead of using the i18n bridge, so the submit tab label may still render in English regardless of locale.