### PR TITLE
fix(jina): handle Jina Search API returning data as a direct array

### DIFF
--- a/packages/rpiv-web-tools/providers/jina.ts
+++ b/packages/rpiv-web-tools/providers/jina.ts
@@ -19,11 +19,13 @@ interface JinaSearchResult {
 interface JinaSearchResponse {
 	code?: number;
 	status?: number;
-	data?: {
-		query?: string;
-		total?: number;
-		results?: JinaSearchResult[];
-	};
+	data?:
+		| JinaSearchResult[]
+		| {
+				query?: string;
+				total?: number;
+				results?: JinaSearchResult[];
+		  };
 }
 
 function normalizeJinaResults(results: JinaSearchResult[]): SearchResult[] {
@@ -68,7 +70,9 @@ export class JinaProvider implements FullProvider {
 		}
 
 		const raw = (await res.json()) as JinaSearchResponse;
-		const results = normalizeJinaResults(raw.data?.results ?? []).slice(0, maxResults);
+		const results = normalizeJinaResults(
+			Array.isArray(raw.data) ? raw.data : (raw.data?.results ?? [])
+		).slice(0, maxResults);
 		return { query, results };
 	}
 


### PR DESCRIPTION
## Problem

`web_search` with the Jina provider always returns "No results found" regardless of the query. The Jina Search API (`s.jina.ai`) responds with:

```json
{
  "code": 200,
  "data": [
    {"title": "...", "url": "...", "description": "..."},
    ...
  ]
}
```

But the code treats `data` as an object with a `results` property:

```ts
raw.data?.results ?? []
```

On an array, `data?.results` is always `undefined`, so every search falls through to an empty array.

## Fix

Update the `JinaSearchResponse` type and result extraction to accept both shapes: the current flat array, and the previously-expected nested object (forward-compat if the API shape changes back).

## Verification

| Query | Before | After |
|-------|--------|-------|
| "TypeScript 7.0 Go rewrite" | 0 results | 10 results ✅ |
| "weather today" | 0 results | 10 results ✅ |

Verified by direct API calls and via the `web_search` tool after reload.