### PR TITLE
Export handleVoiceCommand from voice-command.ts

### DIFF
--- a/packages/rpiv-voice/command/splash-runner.test.ts
+++ b/packages/rpiv-voice/command/splash-runner.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { makeTheme, makeTui } from "@juicesharp/rpiv-test-utils";
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,7 +14,7 @@ interface CapturedComponent {
 // captures the returned component, and returns a `done` resolver the caller
 // invokes when the body's work promise settles.
 function makeCtx(): {
-	ctx: ExtensionCommandContext;
+	ctx: ExtensionContext;
 	getComponent: () => CapturedComponent;
 	donePromise: Promise<void>;
 } {
@@ -43,7 +43,7 @@ function makeCtx(): {
 				});
 			},
 		},
-	} as unknown as ExtensionCommandContext;
+	} as unknown as ExtensionContext;
 	return { ctx, getComponent: () => component!, donePromise };
 }
 

--- a/packages/rpiv-voice/command/splash-runner.ts
+++ b/packages/rpiv-voice/command/splash-runner.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
 	SPLASH_FRAME_INTERVAL_MS,
 	SPLASH_FRAMES,
@@ -15,7 +15,7 @@ export interface SplashRunnerConfig {
 }
 
 export async function runWithSplash<T>(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	config: SplashRunnerConfig,
 	work: (controller: SplashController) => Promise<T>,
 ): Promise<T> {

--- a/packages/rpiv-voice/command/voice-command.test.ts
+++ b/packages/rpiv-voice/command/voice-command.test.ts
@@ -204,7 +204,7 @@ describe("registerVoiceCommand", () => {
 });
 
 // ── runPreflight: every error stage maps to its i18n key ────────────────────
-describe("handleVoiceCommand — preflight error mapping", () => {
+describe("startVoiceDictation — preflight error mapping", () => {
 	beforeEach(() => {
 		// Re-establish happy-path defaults each test so per-test overrides are
 		// the only divergence from green.
@@ -296,7 +296,7 @@ describe("handleVoiceCommand — preflight error mapping", () => {
 });
 
 // ── Whisper language hint, driven via getActiveLocale → createSttEngine ─────
-describe("handleVoiceCommand — whisper language hint", () => {
+describe("startVoiceDictation — whisper language hint", () => {
 	beforeEach(() => {
 		isModelDownloaded.mockReturnValue(true);
 		assertModelIntact.mockReset();
@@ -344,7 +344,7 @@ describe("handleVoiceCommand — whisper language hint", () => {
 });
 
 // ── Happy path: commit dispatch → pasteToEditor ─────────────────────────────
-describe("handleVoiceCommand — happy path", () => {
+describe("startVoiceDictation — happy path", () => {
 	beforeEach(() => {
 		isModelDownloaded.mockReturnValue(true);
 		assertModelIntact.mockReset();

--- a/packages/rpiv-voice/command/voice-command.ts
+++ b/packages/rpiv-voice/command/voice-command.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createMic, type DecibriLike } from "../audio/mic-source.js";
 import {
 	assertModelIntact,
@@ -80,11 +80,11 @@ interface Preflight {
 export function registerVoiceCommand(pi: ExtensionAPI): void {
 	pi.registerCommand(VOICE_COMMAND_NAME, {
 		description: t("command.description", "Dictate text with your voice — local STT, no cloud"),
-		handler: (_args: string, ctx: ExtensionCommandContext) => handleVoiceCommand(ctx),
+		handler: (_args: string, ctx: ExtensionContext) => startVoiceDictation(ctx),
 	});
 }
 
-export async function handleVoiceCommand(ctx: ExtensionCommandContext): Promise<void> {
+export async function startVoiceDictation(ctx: ExtensionContext): Promise<void> {
 	if (!ctx.hasUI) {
 		ctx.ui.notify(t("error.requires_interactive", "/voice requires interactive mode"), "error");
 		return;
@@ -99,7 +99,7 @@ export async function handleVoiceCommand(ctx: ExtensionCommandContext): Promise<
 	}
 }
 
-async function runPreflight(ctx: ExtensionCommandContext): Promise<Preflight | null> {
+async function runPreflight(ctx: ExtensionContext): Promise<Preflight | null> {
 	try {
 		return await runWithSplash<Preflight>(
 			ctx,
@@ -206,7 +206,7 @@ function preflightUserMessage(stage: PreflightStage): string {
 }
 
 async function runDictationSession(
-	ctx: ExtensionCommandContext,
+	ctx: ExtensionContext,
 	sttEngine: SttEngine,
 	mic: DecibriLike,
 ): Promise<VoiceResult> {

--- a/packages/rpiv-voice/command/voice-command.ts
+++ b/packages/rpiv-voice/command/voice-command.ts
@@ -84,7 +84,7 @@ export function registerVoiceCommand(pi: ExtensionAPI): void {
 	});
 }
 
-async function handleVoiceCommand(ctx: ExtensionCommandContext): Promise<void> {
+export async function handleVoiceCommand(ctx: ExtensionCommandContext): Promise<void> {
 	if (!ctx.hasUI) {
 		ctx.ui.notify(t("error.requires_interactive", "/voice requires interactive mode"), "error");
 		return;

--- a/packages/rpiv-voice/index.ts
+++ b/packages/rpiv-voice/index.ts
@@ -17,6 +17,9 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerVoiceCommand } from "./command/voice-command.js";
+
+export { startVoiceDictation } from "./command/voice-command.js";
+
 import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
 
 type I18nLoader = {


### PR DESCRIPTION
Expose the voice command handler so external extensions can trigger dictation programmatically (e.g. from a keyboard shortcut).