### PR TITLE
test(rpiv-web-tools): mock Jina search with real flat-array data shape

### DIFF
--- a/packages/rpiv-web-tools/index.test.ts
+++ b/packages/rpiv-web-tools/index.test.ts
@@ -108,11 +108,9 @@ const PROVIDER_MATRIX = [
 			JSON.stringify({
 				code: 200,
 				status: 20000,
-				data: {
-					results: [{ title: "T", url: "https://x", description: "snip" }],
-				},
+				data: [{ title: "T", url: "https://x", description: "snip" }],
 			}),
-		emptyResponse: () => JSON.stringify({ code: 200, status: 20000, data: { results: [] } }),
+		emptyResponse: () => JSON.stringify({ code: 200, status: 20000, data: [] }),
 		authHeader: "Authorization" as string | null,
 	},
 	{

--- a/packages/rpiv-web-tools/providers/jina.ts
+++ b/packages/rpiv-web-tools/providers/jina.ts
@@ -70,9 +70,10 @@ export class JinaProvider implements FullProvider {
 		}
 
 		const raw = (await res.json()) as JinaSearchResponse;
-		const results = normalizeJinaResults(
-			Array.isArray(raw.data) ? raw.data : (raw.data?.results ?? [])
-		).slice(0, maxResults);
+		const results = normalizeJinaResults(Array.isArray(raw.data) ? raw.data : (raw.data?.results ?? [])).slice(
+			0,
+			maxResults,
+		);
 		return { query, results };
 	}
 


### PR DESCRIPTION
## Follow-up to #73

#73 fixed the Jina search provider to read `data` as a flat array (the real `s.jina.ai` shape), but the test mock still encoded the **fabricated** nested shape:

```ts
data: { results: [{ title: "T", url: "https://x", description: "snip" }] }
```

That nested shape is exactly what caused the original bug — it was never what the API returns. Because the fix kept backward handling of it, the mock stayed green and the new `Array.isArray(raw.data)` branch (the only path the real API exercises) had **zero coverage**.

## Change

- Update the Jina `buildResponse` mock to the real flat-array shape: `data: [{ ... }]`.
- Update `emptyResponse` to the matching empty shape: `data: []` (still drives the "No results found" assertion).
- Apply biome's canonical formatting to `jina.ts` (no logic change — the merged PR wasn't formatted to repo style).

## Verification

- `npx vitest run packages/rpiv-web-tools` → 316 passed
- `npm run check` (biome + tsc) → clean

The mock now matches Jina's documented response and exercises the fix's array branch.