### PR TITLE
feat(web-tools): per-call provider override for web_search

### DIFF
--- a/packages/rpiv-web-tools/CHANGELOG.md
+++ b/packages/rpiv-web-tools/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `web_search` now accepts an optional `provider` parameter that routes a single call to a different backend than the active provider set via `/web-tools`, without mutating persisted config or restarting the session. Valid values: `brave`, `tavily`, `serper`, `exa`, `youcom`, `jina`, `firecrawl`, `perplexity`, `searxng`, `ollama`. The named provider must have its own API key / base URL configured (env var or `/web-tools`); an unknown name or an unconfigured provider throws instead of silently falling back, so callers can detect misconfiguration. `details.backend` reflects the actually-used provider. Closes #82.
+
 ### Fixed
 - Moved `typebox` from `peerDependencies` to `dependencies` (`^1.1.24`, matching the Pi host's range) so `web_search` / `web_fetch` parameter schemas resolve under installers that don't materialise peer deps. Fixes `ERR_MODULE_NOT_FOUND: typebox` on standalone consumer installs (#79).
 - Test files are no longer published in the npm tarball. `files` packed `providers/**/*.test.ts`, which import the private, unpublished `@juicesharp/rpiv-test-utils` fixture package, so a standalone consumer running the bundled tests hit `ERR_MODULE_NOT_FOUND`. Added a `!**/*.test.ts` exclusion to `files` (#80).

--- a/packages/rpiv-web-tools/README.md
+++ b/packages/rpiv-web-tools/README.md
@@ -47,8 +47,7 @@ Then restart your Pi session.
 
 ## Tools
 
-- **`web_search`** - query the active provider's search API and return titled snippets.
-  1–10 results per call.
+- **`web_search`** - query a search provider's API and return titled snippets. Defaults to the active provider set via `/web-tools`; pass `provider` to target a different backend on a single call without switching the persisted default. 1–10 results per call.
 - **`web_fetch`** - read an http/https URL. Lookup order: opt-in URL interceptors
   (see [§GitHub URL interceptor](#github-url-interceptor)), then the active provider's native
   fetch endpoint when it has one (Tavily/Exa/You.com/Jina/Firecrawl/Ollama → vendor extraction;
@@ -61,6 +60,9 @@ Then restart your Pi session.
 web_search({
   query: string,                    // natural-language query
   max_results?: number,             // 1-10, default 5
+  provider?:                        // per-call provider override; see below
+    | "brave" | "tavily" | "serper" | "exa" | "youcom" | "jina"
+    | "firecrawl" | "perplexity" | "searxng" | "ollama",
 })
 ```
 
@@ -78,7 +80,17 @@ Returns:
 }
 ```
 
-Throws when the active provider's API key is unset (e.g. `EXA_API_KEY is not set`) or the provider's API returns a non-2xx response.
+Throws when the resolved provider's API key is unset (e.g. `EXA_API_KEY is not set`), the provider's API returns a non-2xx response, or an explicit `provider` names a provider with no configured credentials (no silent fallback — the caller can detect the misconfiguration).
+
+#### Per-call `provider` override
+
+The optional `provider` parameter routes a single call to a different backend than the active provider set via `/web-tools`, without mutating persisted config or restarting the session. Resolution:
+
+1. `params.provider` (if present) — must be one of the literal provider names listed above. Unknown names throw `Unknown web_search provider: "<name>"`.
+2. `config.provider` (the active provider selected via `/web-tools`).
+3. `brave` (default when `config.provider` is absent).
+
+The named provider must have its own API key / base URL configured (via env var or `/web-tools`); the override does not inherit credentials from the active provider. A request for an unconfigured provider throws the provider's usual `… is not set` error rather than silently falling back, so agents can detect and react. Use this for provider comparison, falling back to a second backend when the active one returns poor results, or any multi-provider workflow that previously required a config switch and session restart.
 
 ### Schema - `web_fetch`
 

--- a/packages/rpiv-web-tools/index.test.ts
+++ b/packages/rpiv-web-tools/index.test.ts
@@ -2224,3 +2224,165 @@ describe("formatShowConfigMessage — URL interceptors block", () => {
 		expect(msg).toContain("clonePath:");
 	});
 });
+
+// Per-call provider override — web_search accepts an optional `provider` param
+// that routes the call to a different backend than `config.provider` without
+// mutating persisted state. Key/URL resolution still reads from env/config
+// under the named provider, so the override must have its own credentials.
+describe("web_search.execute — per-call provider override", () => {
+	it("routes to the override provider when its key is configured", async () => {
+		// Active provider is brave (with key), but the call asks for tavily.
+		process.env.BRAVE_SEARCH_API_KEY = "brave-key";
+		process.env.TAVILY_API_KEY = "tavily-key";
+		writeConfig({ provider: "brave" });
+		const stub = stubFetch([
+			{
+				match: (u) => u.includes("api.tavily.com"),
+				response: () =>
+					new Response(JSON.stringify({ results: [{ title: "T", url: "https://x", content: "snip" }] }), {
+						status: 200,
+					}),
+			},
+		]);
+		const { captured } = registerAndCapture();
+		const r = await captured.tools
+			.get("web_search")
+			?.execute?.(
+				"tc",
+				{ query: "hello", provider: "tavily" },
+				undefined as never,
+				undefined as never,
+				createMockCtx(),
+			);
+		expect((r?.details as { backend: string }).backend).toBe("tavily");
+		expect(stub.calls[0].url).toContain("api.tavily.com");
+		const body = JSON.parse(stub.calls[0].init?.body as string);
+		expect(body.api_key).toBe("tavily-key");
+	});
+
+	it("override works with config-file key (no env var)", async () => {
+		writeConfig({ provider: "brave", apiKeys: { brave: "brave-key", exa: "exa-config-key" } });
+		const stub = stubFetch([
+			{
+				match: (u) => u.includes("api.exa.ai"),
+				response: () =>
+					new Response(JSON.stringify({ results: [{ title: "T", url: "https://x", text: "snip" }] }), {
+						status: 200,
+					}),
+			},
+		]);
+		const { captured } = registerAndCapture();
+		const r = await captured.tools
+			.get("web_search")
+			?.execute?.("tc", { query: "x", provider: "exa" }, undefined as never, undefined as never, createMockCtx());
+		expect((r?.details as { backend: string }).backend).toBe("exa");
+		const headers = stub.calls[0].init?.headers as Record<string, string>;
+		expect(headers["x-api-key"]).toBe("exa-config-key");
+	});
+
+	it("override resolves baseUrl for self-hosted providers (searxng)", async () => {
+		process.env.SEARXNG_URL = "http://override-host:9090";
+		// Active provider is brave; override to searxng should pick up SEARXNG_URL.
+		process.env.BRAVE_SEARCH_API_KEY = "brave-key";
+		writeConfig({ provider: "brave" });
+		const stub = stubFetch([
+			{
+				match: (u) => u.startsWith("http://override-host:9090/"),
+				response: () =>
+					new Response(
+						JSON.stringify({
+							results: [{ title: "T", url: "https://x", content: "snip" }],
+						}),
+						{ status: 200 },
+					),
+			},
+		]);
+		const { captured } = registerAndCapture();
+		const r = await captured.tools
+			.get("web_search")
+			?.execute?.(
+				"tc",
+				{ query: "x", provider: "searxng" },
+				undefined as never,
+				undefined as never,
+				createMockCtx(),
+			);
+		expect((r?.details as { backend: string }).backend).toBe("searxng");
+		expect(new URL(stub.calls[0].url).host).toBe("override-host:9090");
+	});
+
+	it("override throws when the named provider has no key configured (no silent fallback)", async () => {
+		// Active provider brave has a key, but the override (exa) does not.
+		process.env.BRAVE_SEARCH_API_KEY = "brave-key";
+		writeConfig({ provider: "brave" });
+		const { captured } = registerAndCapture();
+		await expect(
+			captured.tools
+				.get("web_search")
+				?.execute?.("tc", { query: "x", provider: "exa" }, undefined as never, undefined as never, createMockCtx()),
+		).rejects.toThrow(/EXA_API_KEY is not set/);
+	});
+
+	it("override with an unknown provider name throws a clear error", async () => {
+		process.env.BRAVE_SEARCH_API_KEY = "brave-key";
+		writeConfig({ provider: "brave" });
+		const { captured } = registerAndCapture();
+		await expect(
+			captured.tools
+				.get("web_search")
+				?.execute?.(
+					"tc",
+					{ query: "x", provider: "nonexistent" },
+					undefined as never,
+					undefined as never,
+					createMockCtx(),
+				),
+		).rejects.toThrow(/Unknown web_search provider: "nonexistent"/);
+	});
+
+	it("override omitted falls back to config.provider (default path unchanged)", async () => {
+		process.env.BRAVE_SEARCH_API_KEY = "brave-key";
+		writeConfig({ provider: "brave" });
+		const stub = stubFetch([
+			{
+				match: (u) => u.includes("api.search.brave.com"),
+				response: () =>
+					new Response(
+						JSON.stringify({
+							web: { results: [{ title: "T", url: "https://x", description: "snip" }] },
+						}),
+						{ status: 200 },
+					),
+			},
+		]);
+		const { captured } = registerAndCapture();
+		const r = await captured.tools
+			.get("web_search")
+			?.execute?.("tc", { query: "x" }, undefined as never, undefined as never, createMockCtx());
+		expect((r?.details as { backend: string }).backend).toBe("brave");
+		expect(stub.calls[0].url).toContain("api.search.brave.com");
+	});
+
+	it("schema declares the provider enum with all known names", () => {
+		const { captured } = registerAndCapture();
+		const params = captured.tools.get("web_search")?.parameters as unknown as {
+			properties: { provider: { anyOf: Array<{ const: string }> } };
+		};
+		const literals = params.properties.provider?.anyOf?.map((e) => e.const) ?? [];
+		expect(literals).toEqual(
+			expect.arrayContaining([
+				"brave",
+				"tavily",
+				"serper",
+				"exa",
+				"youcom",
+				"jina",
+				"firecrawl",
+				"perplexity",
+				"searxng",
+				"ollama",
+			]),
+		);
+		expect(literals).toHaveLength(10);
+	});
+});

--- a/packages/rpiv-web-tools/web-tools.ts
+++ b/packages/rpiv-web-tools/web-tools.ts
@@ -130,12 +130,45 @@ function resolveProviderBaseUrl(meta: ProviderMeta, config: WebToolsConfig): str
 	return meta.defaultBaseUrl ?? "";
 }
 
+// Known provider names — derived once from PROVIDERS so the schema enum,
+// the per-call override validation, and the error messages all stay in sync
+// when a provider is added or removed.
+const KNOWN_PROVIDER_NAMES = PROVIDERS.map((p) => p.name) as readonly string[];
+
+function isKnownProviderName(name: string): boolean {
+	return PROVIDERS.some((p) => p.name === name);
+}
+
 // Centralized instantiation: load active provider name + creds, build via
 // the factory. Called by both registerWebSearchTool and registerWebFetchTool.
-function instantiateActiveProvider(config: WebToolsConfig): {
+//
+// `override` lets a single tool call target a different provider than
+// `config.provider` without mutating persisted state. Resolution:
+//   1. override (if present) — validated against PROVIDERS; unknown names throw
+//      so callers can detect misconfiguration instead of silently falling back.
+//   2. config.provider (the /web-tools-selected default)
+//   3. DEFAULT_PROVIDER_NAME ("brave")
+// Key/baseURL resolution is unchanged — it always reads from env/config under
+// the resolved provider name, so an override still needs its own credentials.
+function instantiateActiveProvider(
+	config: WebToolsConfig,
+	override?: string,
+): {
 	providerName: string;
 	provider: SearchProvider | FullProvider;
 } {
+	if (override !== undefined) {
+		if (!isKnownProviderName(override)) {
+			throw new Error(
+				`Unknown web_search provider: "${override}". Valid providers: ${KNOWN_PROVIDER_NAMES.join(", ")}.`,
+			);
+		}
+		const apiKey = resolveProviderApiKey(override, config);
+		const meta = PROVIDERS.find((p) => p.name === override)!;
+		const baseUrl = meta.baseUrlEnvVar ? resolveProviderBaseUrl(meta, config) : undefined;
+		const provider = createSearchProvider(override, { apiKey: apiKey ?? "", baseUrl });
+		return { providerName: override, provider };
+	}
 	const providerName = config.provider ?? DEFAULT_PROVIDER_NAME;
 	const apiKey = resolveProviderApiKey(providerName, config);
 	const meta = PROVIDERS.find((p) => p.name === providerName);
@@ -275,12 +308,23 @@ export function registerWebSearchTool(pi: ExtensionAPI): void {
 					maximum: MAX_SEARCH_RESULTS,
 				}),
 			),
+			provider: Type.Optional(
+				Type.Union(
+					KNOWN_PROVIDER_NAMES.map((name) => Type.Literal(name)),
+					{
+						description:
+							"Search provider to use for this call only, overriding the active provider set via /web-tools. " +
+							`Valid values: ${KNOWN_PROVIDER_NAMES.join(", ")}. ` +
+							"Omit to use the configured active provider. The named provider must have its API key/URL configured (via env var or /web-tools) or the call throws — there is no silent fallback.",
+					},
+				),
+			),
 		}),
 
 		async execute(_toolCallId, params, signal, onUpdate, _ctx) {
 			const maxResults = clampSearchResultCount(params.max_results);
 			const config = loadConfig();
-			const { providerName, provider } = instantiateActiveProvider(config);
+			const { providerName, provider } = instantiateActiveProvider(config, params.provider);
 
 			onUpdate?.({
 				content: [{ type: "text", text: `Searching ${provider.label} for: "${params.query}"...` }],
@@ -307,6 +351,9 @@ export function registerWebSearchTool(pi: ExtensionAPI): void {
 		renderCall(args, theme, _context) {
 			let text = theme.fg("toolTitle", theme.bold("WebSearch "));
 			text += theme.fg("accent", `"${args.query}"`);
+			if (args.provider) {
+				text += theme.fg("dim", ` via ${args.provider}`);
+			}
 			return new Text(text, 0, 0);
 		},
 


### PR DESCRIPTION
## What

Adds optional `provider` parameter to `web_search` so a single call can target a different backend than the active provider set via `/web-tools`, without mutating persisted config or restarting the session.

Closes #82.

## Why

Today `web_search` always uses `config.provider`. Switching providers for a single call requires editing `~/.config/rpiv-web-tools/config.json` (or running `/web-tools`) and restarting the Pi session. That blocks multi-provider workflows:

- falling back to a second provider when the active one returns poor results,
- comparing results across providers for the same query,
- using one provider for search and another for `web_fetch` extraction in the same turn.

## Schema

```ts
web_search({
  query: string,
  max_results?: number,             // 1-10, default 5
  provider?:                        // per-call override; see below
    | "brave" | "tavily" | "serper" | "exa" | "youcom" | "jina"
    | "firecrawl" | "perplexity" | "searxng" | "ollama",
})
```

The `provider` enum is derived from `PROVIDERS` (`providers/index.ts`), so adding a new provider automatically extends the schema.

## Resolution

1. `params.provider` (if present) — validated against `PROVIDERS`. Unknown names throw `Unknown web_search provider: "<name>"` so callers detect misconfiguration instead of silently falling back.
2. `config.provider` (the `/web-tools`-selected default).
3. `brave` (default when `config.provider` is absent).

Key / base-URL resolution is unchanged: it always reads from env / config under the **resolved** provider name. An override does not inherit credentials from the active provider — a request for an unconfigured provider throws the provider's usual `… is not set` error (e.g. `EXA_API_KEY is not set`), not a silent fallback. This matches the behavior requested in the issue: an explicit `provider` that fails to resolve should throw, so the agent can react.

`details.backend` reflects the actually-used provider (already did — just propagates the override). `renderCall` shows `via <provider>` when an override is in effect.

## Implementation

`web-tools.ts`:
- New `KNOWN_PROVIDER_NAMES` / `isKnownProviderName()` derived from `PROVIDERS` (single source of truth for the schema enum + validation).
- `instantiateActiveProvider(config, override?)` — takes an optional override. When present, validates it against `PROVIDERS` and resolves credentials under that name. Falls back to the existing `config.provider → brave` path when omitted, so the default behavior is byte-identical.
- `web_search` schema gets `Type.Optional(Type.Union(KNOWN_PROVIDER_NAMES.map(Type.Literal)))` for `provider`.
- `execute` passes `params.provider` through.
- `renderCall` appends ` via <provider>` when set.

`web_fetch` is intentionally untouched — its dispatch already routes by URL/interceptor, and per-call provider selection for fetch extraction is a separate question (raised as open question #1 on the issue).

## Tests

7 new cases in `index.test.ts` under `web_search.execute — per-call provider override`:

1. routes to override when its env key is configured (brave active → tavily call hits tavily endpoint with tavily key)
2. override works with config-file key (no env var)
3. override resolves baseUrl for self-hosted providers (searxng via `SEARXNG_URL`)
4. override throws when named provider has no key configured (no silent fallback to active provider)
5. override with unknown provider name throws `Unknown web_search provider`
6. override omitted falls back to `config.provider` (default path unchanged)
7. schema declares the provider enum with all 10 known names

Full suite: **323/323 `rpiv-web-tools` tests pass.** `npx tsc --noEmit -p tsconfig.base.json` clean. `biome check --write --error-on-warnings` clean.

Two unrelated pre-existing failures in `packages/rpiv-pi/skills/_shared/git-changes.test.ts` reproduce on clean `main` (verified by `git stash` + re-run) — not touched by this PR.

## Docs

- `README.md`: schema block updated with `provider` param + a new "Per-call `provider` override" subsection explaining resolution, credential requirements, and no-silent-fallback semantics. Tools blurb updated.
- `CHANGELOG.md`: `## [Unreleased] → ### Added` entry referencing #82.

## Out of scope (open questions from #82)

1. `web_fetch` per-call provider override — left out; fetch routing is already URL/interceptor-driven.
2. Throw-vs-warn-and-fallback for unconfigured explicit provider — implemented as **throw** per the issue's preference.
3. `details.backend` propagation — already worked; verified by test #1.