### PR TITLE
feat(web-tools): prefer canonical YDC_API_KEY for You.com provider (fallback YOUCOM_API_KEY)

### DIFF
--- a/packages/rpiv-web-tools/CHANGELOG.md
+++ b/packages/rpiv-web-tools/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- You.com provider now reads the canonical `YDC_API_KEY` env var (used by You.com's own docs/SDK and the LangChain/CrewAI/DSPy integrations), falling back to `YOUCOM_API_KEY` for backward compatibility. Existing setups keep working unchanged.
+
 ### Fixed
 - Moved `typebox` from `peerDependencies` to `dependencies` (`^1.1.24`, matching the Pi host's range) so `web_search` / `web_fetch` parameter schemas resolve under installers that don't materialise peer deps. Fixes `ERR_MODULE_NOT_FOUND: typebox` on standalone consumer installs (#79).
 - Test files are no longer published in the npm tarball. `files` packed `providers/**/*.test.ts`, which import the private, unpublished `@juicesharp/rpiv-test-utils` fixture package, so a standalone consumer running the bundled tests hit `ERR_MODULE_NOT_FOUND`. Added a `!**/*.test.ts` exclusion to `files` (#80).

--- a/packages/rpiv-web-tools/README.md
+++ b/packages/rpiv-web-tools/README.md
@@ -22,7 +22,7 @@ Pick one as the active backend; switch any time without losing the others' keys.
 | Tavily | `TAVILY_API_KEY` | [tavily.com](https://tavily.com) | native extraction (plain text) |
 | Serper | `SERPER_API_KEY` | [serper.dev](https://serper.dev) | raw HTTP → htmlToText, `raw: true` available |
 | Exa | `EXA_API_KEY` | [exa.ai](https://exa.ai) | native extraction (plain text) |
-| You.com | `YOUCOM_API_KEY` | [you.com](https://you.com) | native extraction (markdown) |
+| You.com | `YDC_API_KEY` (fallback `YOUCOM_API_KEY`) | [you.com](https://you.com) | native extraction (markdown) |
 | Jina | `JINA_API_KEY` | [jina.ai/reader](https://jina.ai/reader) | native extraction (markdown) |
 | Firecrawl | `FIRECRAWL_API_KEY` | [firecrawl.dev](https://firecrawl.dev) | native extraction (markdown) |
 | Perplexity | `PERPLEXITY_API_KEY` | [docs.perplexity.ai](https://docs.perplexity.ai/) | raw HTTP → htmlToText, `raw: true` available |
@@ -119,7 +119,7 @@ Throws on invalid URL, non-http(s) protocol, private/loopback hostnames (SSRF gu
 
 First match wins:
 
-1. The active provider's environment variable: `BRAVE_SEARCH_API_KEY`, `TAVILY_API_KEY`, `SERPER_API_KEY`, `EXA_API_KEY`, `YOUCOM_API_KEY`, `JINA_API_KEY`, `FIRECRAWL_API_KEY`, `PERPLEXITY_API_KEY`, `SEARXNG_API_KEY`, or `OLLAMA_API_KEY`
+1. The active provider's environment variable: `BRAVE_SEARCH_API_KEY`, `TAVILY_API_KEY`, `SERPER_API_KEY`, `EXA_API_KEY`, `YDC_API_KEY` (fallback `YOUCOM_API_KEY`), `JINA_API_KEY`, `FIRECRAWL_API_KEY`, `PERPLEXITY_API_KEY`, `SEARXNG_API_KEY`, or `OLLAMA_API_KEY`
 2. `apiKeys.<provider>` field in `~/.config/rpiv-web-tools/config.json`
 3. Legacy `apiKey` field (Brave only — auto-migrated to the new shape on next save)
 

--- a/packages/rpiv-web-tools/index.test.ts
+++ b/packages/rpiv-web-tools/index.test.ts
@@ -31,6 +31,7 @@ beforeEach(() => {
 	delete process.env.TAVILY_API_KEY;
 	delete process.env.SERPER_API_KEY;
 	delete process.env.EXA_API_KEY;
+	delete process.env.YDC_API_KEY;
 	delete process.env.YOUCOM_API_KEY;
 	delete process.env.JINA_API_KEY;
 	delete process.env.FIRECRAWL_API_KEY;
@@ -576,7 +577,7 @@ const FETCH_ERROR_MATRIX: ReadonlyArray<{
 	},
 	{
 		provider: "youcom",
-		envVar: "YOUCOM_API_KEY",
+		envVar: "YDC_API_KEY",
 		fetchUrlMatcher: (u) => u.includes("ydc-index.io/v1/contents"),
 		label: "You.com",
 	},
@@ -595,7 +596,7 @@ describe.each(FETCH_ERROR_MATRIX)("web_fetch.execute — $provider error paths",
 			captured.tools
 				.get("web_fetch")
 				?.execute?.("tc", { url: "https://example.com" }, undefined as never, undefined as never, createMockCtx()),
-		).rejects.toThrow(new RegExp(`${envVar} is not set`));
+		).rejects.toThrow(new RegExp(`${envVar}.* is not set`));
 	});
 
 	it(`fetch wraps non-2xx as '${label} Fetch API error (429)'`, async () => {
@@ -1968,7 +1969,30 @@ describe("/web-tools command — ollama", () => {
 
 // You.com has a dedicated test block (like SearXNG/Ollama) for fine-grained assertions.
 describe("web_search.execute — youcom", () => {
-	it("uses env key", async () => {
+	it("uses canonical YDC_API_KEY env key", async () => {
+		process.env.YDC_API_KEY = "ydc-key";
+		writeConfig({ provider: "youcom" });
+		const stub = stubFetch([
+			{
+				match: (u) => u.includes("ydc-index.io/v1/search"),
+				response: () =>
+					new Response(
+						JSON.stringify({
+							results: { web: [{ title: "T", url: "https://x", description: "snip", snippets: ["snip"] }] },
+						}),
+						{ status: 200 },
+					),
+			},
+		]);
+		const { captured } = registerAndCapture();
+		await captured.tools
+			.get("web_search")
+			?.execute?.("tc", { query: "hello", max_results: 3 }, undefined as never, undefined as never, createMockCtx());
+		const headers = stub.calls[0].init?.headers as Record<string, string>;
+		expect(headers["X-API-Key"]).toBe("ydc-key");
+	});
+
+	it("falls back to legacy YOUCOM_API_KEY env key", async () => {
 		process.env.YOUCOM_API_KEY = "env-key";
 		writeConfig({ provider: "youcom" });
 		const stub = stubFetch([
@@ -1989,6 +2013,24 @@ describe("web_search.execute — youcom", () => {
 			?.execute?.("tc", { query: "hello", max_results: 3 }, undefined as never, undefined as never, createMockCtx());
 		const headers = stub.calls[0].init?.headers as Record<string, string>;
 		expect(headers["X-API-Key"]).toBe("env-key");
+	});
+
+	it("prefers YDC_API_KEY over YOUCOM_API_KEY when both are set", async () => {
+		process.env.YDC_API_KEY = "ydc-key";
+		process.env.YOUCOM_API_KEY = "legacy-key";
+		writeConfig({ provider: "youcom" });
+		const stub = stubFetch([
+			{
+				match: (u) => u.includes("ydc-index.io/v1/search"),
+				response: () => new Response(JSON.stringify({ results: { web: [] } }), { status: 200 }),
+			},
+		]);
+		const { captured } = registerAndCapture();
+		await captured.tools
+			.get("web_search")
+			?.execute?.("tc", { query: "x" }, undefined as never, undefined as never, createMockCtx());
+		const headers = stub.calls[0].init?.headers as Record<string, string>;
+		expect(headers["X-API-Key"]).toBe("ydc-key");
 	});
 
 	it("falls back to config key", async () => {
@@ -2020,7 +2062,7 @@ describe("web_search.execute — youcom", () => {
 			captured.tools
 				.get("web_search")
 				?.execute?.("tc", { query: "x" }, undefined as never, undefined as never, createMockCtx()),
-		).rejects.toThrow(/YOUCOM_API_KEY is not set/);
+		).rejects.toThrow(/YDC_API_KEY \(or YOUCOM_API_KEY\) is not set/);
 	});
 
 	it("returns no-results envelope on empty results", async () => {

--- a/packages/rpiv-web-tools/providers/index.ts
+++ b/packages/rpiv-web-tools/providers/index.ts
@@ -61,7 +61,12 @@ export type {
 	SearchResponse,
 	SearchResult,
 } from "./types.js";
-export { YOUCOM_API_KEY_ENV_VAR, YOUCOM_PROVIDER_META, YouComProvider } from "./youcom.js";
+export {
+	YOUCOM_API_KEY_ENV_VAR,
+	YOUCOM_API_KEY_ENV_VAR_FALLBACK,
+	YOUCOM_PROVIDER_META,
+	YouComProvider,
+} from "./youcom.js";
 
 // Typed as readonly ProviderMeta[] (not `as const`) so iterators can access
 // the optional META fields (baseUrlEnvVar, defaultBaseUrl, configure) without

--- a/packages/rpiv-web-tools/providers/types.ts
+++ b/packages/rpiv-web-tools/providers/types.ts
@@ -80,6 +80,9 @@ export interface ProviderConfigChange {
 // touching the orchestrator.
 //
 //   envVar          — the API-key env var (omit if the provider has no key)
+//   fallbackEnvVar  — legacy/alternate API-key env var, checked after envVar
+//                     (lets a provider migrate to a canonical name while
+//                     still honoring the old one)
 //   baseUrlEnvVar   — the URL env var (set for self-hosted providers)
 //   defaultBaseUrl  — fallback URL when neither env nor config supplies one
 //   configure       — interactive setup; if present, /web-tools
@@ -88,6 +91,7 @@ export interface ProviderMeta {
 	name: string;
 	label: string;
 	envVar?: string;
+	fallbackEnvVar?: string;
 	baseUrlEnvVar?: string;
 	defaultBaseUrl?: string;
 	// Which role(s) the provider plays. Search-only providers (Brave, Serper,

--- a/packages/rpiv-web-tools/providers/youcom.ts
+++ b/packages/rpiv-web-tools/providers/youcom.ts
@@ -2,11 +2,16 @@ import type { FetchResponse, FullProvider, SearchResponse, SearchResult } from "
 
 const YOUCOM_SEARCH_URL = "https://ydc-index.io/v1/search";
 const YOUCOM_CONTENTS_URL = "https://ydc-index.io/v1/contents";
-export const YOUCOM_API_KEY_ENV_VAR = "YOUCOM_API_KEY";
+// YDC_API_KEY is You.com's canonical env var (used by their docs/SDK and the
+// LangChain/CrewAI/DSPy integrations). YOUCOM_API_KEY is kept as a
+// backward-compatible fallback for existing setups.
+export const YOUCOM_API_KEY_ENV_VAR = "YDC_API_KEY";
+export const YOUCOM_API_KEY_ENV_VAR_FALLBACK = "YOUCOM_API_KEY";
 export const YOUCOM_PROVIDER_META = {
 	name: "youcom",
 	label: "You.com",
 	envVar: YOUCOM_API_KEY_ENV_VAR,
+	fallbackEnvVar: YOUCOM_API_KEY_ENV_VAR_FALLBACK,
 	roles: ["search", "fetch"] as const,
 } as const;
 
@@ -46,7 +51,9 @@ export class YouComProvider implements FullProvider {
 
 	async search(query: string, maxResults: number, signal?: AbortSignal): Promise<SearchResponse> {
 		if (!this.apiKey) {
-			throw new Error(`${this.envVar} is not set. Run /web-tools to configure, or export the env var.`);
+			throw new Error(
+				`${this.envVar} (or ${YOUCOM_API_KEY_ENV_VAR_FALLBACK}) is not set. Run /web-tools to configure, or export the env var.`,
+			);
 		}
 
 		const res = await fetch(YOUCOM_SEARCH_URL, {
@@ -73,7 +80,9 @@ export class YouComProvider implements FullProvider {
 
 	async fetch(url: string, _raw: boolean, signal?: AbortSignal): Promise<FetchResponse> {
 		if (!this.apiKey) {
-			throw new Error(`${this.envVar} is not set. Run /web-tools to configure, or export the env var.`);
+			throw new Error(
+				`${this.envVar} (or ${YOUCOM_API_KEY_ENV_VAR_FALLBACK}) is not set. Run /web-tools to configure, or export the env var.`,
+			);
 		}
 
 		const res = await fetch(YOUCOM_CONTENTS_URL, {

--- a/packages/rpiv-web-tools/web-tools.ts
+++ b/packages/rpiv-web-tools/web-tools.ts
@@ -103,7 +103,9 @@ function resolveProviderApiKey(providerName: string, config: WebToolsConfig): st
 	const meta = PROVIDERS.find((p) => p.name === providerName);
 	if (!meta) return undefined;
 
-	const envKey = meta.envVar ? process.env[meta.envVar]?.trim() : undefined;
+	const envKey =
+		(meta.envVar ? process.env[meta.envVar]?.trim() : undefined) ||
+		(meta.fallbackEnvVar ? process.env[meta.fallbackEnvVar]?.trim() : undefined);
 	if (envKey) return envKey;
 
 	const configKey = config.apiKeys?.[providerName]?.trim();
@@ -469,7 +471,9 @@ function formatShowConfigMessage(current: WebToolsConfig): string {
 	lines.push(`  active provider: ${providerName}`);
 
 	for (const meta of PROVIDERS) {
-		const envKey = meta.envVar ? process.env[meta.envVar]?.trim() : undefined;
+		const envKey =
+			(meta.envVar ? process.env[meta.envVar]?.trim() : undefined) ||
+			(meta.fallbackEnvVar ? process.env[meta.fallbackEnvVar]?.trim() : undefined);
 		const configKey = current.apiKeys?.[meta.name]?.trim();
 		const legacyKey = meta.name === LEGACY_TOP_LEVEL_KEY_PROVIDER ? current.apiKey?.trim() : undefined;
 		const resolved = envKey ?? configKey ?? legacyKey;


### PR DESCRIPTION
## What

The You.com search/fetch provider now reads the canonical **`YDC_API_KEY`** environment variable, falling back to **`YOUCOM_API_KEY`** when it is not set.

- `YOUCOM_PROVIDER_META.envVar` → `"YDC_API_KEY"`, with a new `fallbackEnvVar: "YOUCOM_API_KEY"`.
- Added an optional `fallbackEnvVar` field to `ProviderMeta` and wired it into the centralized key resolution (`resolveProviderApiKey`) and the `/web-tools` config display, so the fallback is honored everywhere the primary var is read.
- The missing-key error now reads `YDC_API_KEY (or YOUCOM_API_KEY) is not set`.
- Updated the README provider table + env-var list and added an Unreleased CHANGELOG note.
- Added tests for the canonical var, the legacy fallback, and `YDC_API_KEY` taking precedence when both are set.

## Why

`YDC_API_KEY` is You.com's canonical API-key environment variable — it is what You.com's own documentation and SDK use, as well as the LangChain, CrewAI, and DSPy You.com integrations. Standardizing on it makes the provider consistent with the rest of the ecosystem so a single `YDC_API_KEY` works across tools.

Backward compatible: existing `YOUCOM_API_KEY` setups continue to work unchanged via the fallback. No config migration required.

## Verification

- `tsc --noEmit` clean
- `vitest run packages/rpiv-web-tools/index.test.ts` — all tests pass (new fallback/precedence tests included)
- `biome check` clean

Part of a cross-ecosystem standardization effort: youdotcom-oss/integration-tracking#30
