### PR TITLE
feat(i18n): add ja, ko, zh-Hant, lzh (Classical Chinese) to SUPPORTED_LOCALES

### DIFF
--- a/packages/rpiv-i18n/i18n.ts
+++ b/packages/rpiv-i18n/i18n.ts
@@ -59,11 +59,15 @@ export const SUPPORTED_LOCALES: readonly { code: string; label: string }[] = [
 	{ code: DEFAULT_FALLBACK_LOCALE, label: "English" },
 	{ code: "es", label: "Español" },
 	{ code: "fr", label: "Français" },
+	{ code: "ja", label: "日本語" },
+	{ code: "ko", label: "한국어" },
+	{ code: "lzh", label: "文言（華夏）" },
 	{ code: "pt", label: "Português" },
 	{ code: "pt-BR", label: "Português (Brasil)" },
 	{ code: "ru", label: "Русский" },
 	{ code: "uk", label: "Українська" },
 	{ code: "zh", label: "中文" },
+	{ code: "zh-Hant", label: "繁體中文" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/rpiv-i18n/loader.test.ts
+++ b/packages/rpiv-i18n/loader.test.ts
@@ -37,13 +37,13 @@ describe("registerLocalesFromDir", () => {
 	});
 
 	it("records an empty map and warns when a locale file is missing — extension stays online", () => {
-		// Only en.json present; the other 7 SUPPORTED_LOCALES files are missing.
+		// Only en.json present; the other 11 SUPPORTED_LOCALES files are missing.
 		writeFileSync(join(pkgDir, "locales", "en.json"), JSON.stringify({ greeting: "Hi" }));
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 		registerLocalesFromDir("@test/ns", pkgUrl);
 
-		// 7 warns for the 7 missing files; en still resolves.
+		// 11 warns for the 11 missing files; en still resolves.
 		expect(warn).toHaveBeenCalled();
 		const t = scope("@test/ns");
 		expect(t("greeting", "fallback")).toBe("Hi");


### PR DESCRIPTION
## Summary

Add four new built-in locales to `SUPPORTED_LOCALES` so the `/languages` picker and `registerLocalesFromDir` auto-loader recognize them.

| Code | Language | Endonym |
|------|----------|---------|
| `ja` | Japanese | 日本語 |
| `ko` | Korean | 한국어 |
| `zh-Hant` | Traditional Chinese (BCP 47) | 繁體中文 |
| `lzh` | Classical Chinese | 文言（華夏） |

## Motivation

The existing built-in locale list covers European languages and Simplified Chinese. These four additions extend coverage to East Asian languages commonly used in the developer community and include a Classical Chinese easter egg.

## Notes

- Entries are placed in alphabetical order by code (matching the existing convention).
- `lzh` (ISO 639-3 for Literary Chinese) is an easter egg inspired by Minecrafts official `文言（華夏）` translation, added by the community and adopted by Mojang in Java Edition 1.17.1 pre2.
- `zh-Hant` follows BCP 47 — it denotes Traditional Chinese script without binding to a specific region (unlike `zh-TW` or `zh-HK`).
- CI was skipped locally due to a Node.js v24 + vitest SIGBUS issue on this machine.