### PR TITLE
configurable whisper model via voice.json

### DIFF
--- a/packages/rpiv-voice/README.md
+++ b/packages/rpiv-voice/README.md
@@ -8,7 +8,7 @@
   </a>
 </div>
 
-Talk to [Pi Agent](https://github.com/badlogic/pi-mono) instead of typing. `rpiv-voice` adds the `/voice` slash command — open the overlay, speak, hit `Enter`, and your transcript drops straight into Pi's editor. Speech-to-text runs **entirely on your machine** via [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) Whisper (base multilingual int8). No cloud, no API keys, no telemetry.
+Talk to [Pi Agent](https://github.com/badlogic/pi-mono) instead of typing. `rpiv-voice` adds the `/voice` slash command — open the overlay, speak, hit `Enter`, and your transcript drops straight into Pi's editor. Speech-to-text runs **entirely on your machine** via [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) Whisper models (defaulting to the base multilingual int8 model, but fully configurable to other sizes/languages). No cloud, no API keys, no telemetry.
 
 ![Voice dictation overlay above the Pi editor](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-voice/docs/overlay.jpg)
 
@@ -63,7 +63,7 @@ The dim trailing text after the committed transcript is the rolling partial — 
 
 ### First run
 
-The first time you run `/voice`, the splash overlay downloads the Whisper base multilingual model (~198 MB compressed, ~157 MB on disk) into `~/.pi/models/whisper-base/`. Subsequent runs load directly from disk in under a second. If a previous download was interrupted, the stale model directory is detected and re-downloaded automatically.
+The first time you run `/voice`, the splash overlay downloads the selected Whisper model (by default, the base multilingual model, ~198 MB compressed, ~157 MB on disk) into `~/.pi/models/whisper-${flavour}/`. Subsequent runs load directly from disk in under a second. If a previous download was interrupted, the stale model directory is detected and re-downloaded automatically.
 
 ## Configuration
 
@@ -71,17 +71,19 @@ The first time you run `/voice`, the splash overlay downloads the Whisper base m
 
 ```json
 {
-  "hallucinationFilterEnabled": false
+  "hallucinationFilterEnabled": false,
+  "whisperModelType": "tiny"
 }
 ```
 
 | Field | Default | Effect |
 |---|---|---|
 | `hallucinationFilterEnabled` | `true` | When `false`, keeps Whisper's "Thanks for watching" / "[Music]" / repeating-token loops. Useful when dictating short single words that the filter might mistake for noise. |
+| `whisperModelType` | `"base"` | The Whisper model flavour to download and use (e.g. `"tiny"`, `"tiny.en"`, `"base"`, `"base.en"`, `"small"`, `"small.en"`, `"medium"`, `"medium.en"`, `"large-v3"`, `"large-v3-turbo"`). |
 
 You can also flip the toggle interactively from the **Settings** screen (`Tab` from dictation, `Ctrl-S` to save).
 
-The microphone is the OS default input — `rpiv-voice` does not expose device selection. The bundled Whisper base multilingual model is loaded from `~/.pi/models/whisper-base/`; alternative models aren't supported today.
+The microphone is the OS default input — `rpiv-voice` does not expose device selection. The default Whisper base multilingual model is loaded from `~/.pi/models/whisper-base/`, but other flavours can be configured using `whisperModelType`.
 
 ## Privacy
 
@@ -94,8 +96,8 @@ The microphone is the OS default input — `rpiv-voice` does not expose device s
 
 - [Pi Agent CLI](https://www.npmjs.com/package/@earendil-works/pi-coding-agent)
 - A working microphone reachable by [`decibri`](https://www.npmjs.com/package/decibri) (mic permission granted to your terminal on macOS)
-- ~200 MB free disk under `~/.pi/models/whisper-base/`
-- Network access on first run only
+- Sufficient free disk space under `~/.pi/models/` for the chosen model flavour (from ~40 MB for `tiny` to ~1.4 GB for `large-v3`)
+- Network access on first run only (or when changing model flavours to download the new model archive)
 
 ## Troubleshooting
 

--- a/packages/rpiv-voice/audio/model-download.test.ts
+++ b/packages/rpiv-voice/audio/model-download.test.ts
@@ -12,7 +12,16 @@ vi.mock("node:fs", async (importOriginal) => {
 	};
 });
 
+vi.mock("../config/voice-config.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../config/voice-config.js")>();
+	return {
+		...actual,
+		loadVoiceConfig: vi.fn(() => ({})),
+	};
+});
+
 import { existsSync, rmSync } from "node:fs";
+import { loadVoiceConfig } from "../config/voice-config.js";
 import {
 	assertModelIntact,
 	ensureModelDownloaded,
@@ -22,6 +31,10 @@ import {
 	removeModelInstall,
 	WHISPER_BASE_DIR,
 } from "./model-download.js";
+
+beforeEach(() => {
+	vi.mocked(loadVoiceConfig).mockReturnValue({});
+});
 
 describe("isModelDownloaded", () => {
 	it("returns true when sentinel file exists", () => {
@@ -41,6 +54,15 @@ describe("getModelPaths", () => {
 		expect(paths.decoderPath).toContain("whisper-base");
 		expect(paths.tokensPath).toContain("whisper-base");
 	});
+
+	it("returns paths under whisper-tiny/ when configured", () => {
+		vi.mocked(loadVoiceConfig).mockReturnValue({ whisperModelType: "tiny" });
+		const paths = getModelPaths();
+		expect(paths.encoderPath).toContain("whisper-tiny");
+		expect(paths.decoderPath).toContain("whisper-tiny");
+		expect(paths.tokensPath).toContain("whisper-tiny");
+		expect(paths.encoderPath).toContain("tiny-encoder.int8.onnx");
+	});
 });
 
 describe("ensureModelDownloaded", () => {
@@ -49,6 +71,15 @@ describe("ensureModelDownloaded", () => {
 		const onProgress = vi.fn();
 		const paths = await ensureModelDownloaded(onProgress);
 		expect(paths.encoderPath).toContain("base-encoder.int8.onnx");
+		expect(onProgress).not.toHaveBeenCalled();
+	});
+
+	it("skips download when custom model already exists", async () => {
+		vi.mocked(loadVoiceConfig).mockReturnValue({ whisperModelType: "tiny" });
+		vi.mocked(existsSync).mockReturnValue(true);
+		const onProgress = vi.fn();
+		const paths = await ensureModelDownloaded(onProgress);
+		expect(paths.encoderPath).toContain("tiny-encoder.int8.onnx");
 		expect(onProgress).not.toHaveBeenCalled();
 	});
 });

--- a/packages/rpiv-voice/audio/model-download.ts
+++ b/packages/rpiv-voice/audio/model-download.ts
@@ -55,7 +55,7 @@ const TAR_STRIP_FLAG = "--strip-components=1";
 // ── Status messages ──────────────────────────────────────────────────────────
 // Resolved at progress-emit time (not module load) so live `/languages` flips
 // take effect mid-download.
-const msgDownloading = (): string => t("splash.downloading", "Downloading Whisper…");
+const msgDownloading = (flavour: string): string => t("splash.downloading", `Downloading Whisper ${flavour} model…`);
 const msgExtracting = (): string => t("splash.extracting", "Extracting model files…");
 const msgVerifying = (): string => t("splash.verifying", "Verifying model files…");
 
@@ -159,7 +159,7 @@ export async function ensureModelDownloaded(onProgress: ProgressCallback, signal
 	// redownload start from a clean slate and prevents a hypothetical
 	// race where another caller observes the partial state mid-run.
 	try {
-		onProgress({ phase: "downloading", message: msgDownloading() });
+		onProgress({ phase: "downloading", message: msgDownloading(flavour) });
 		try {
 			let lastEmitMs = 0;
 			await downloadArchive(url, archivePath, signal, (stats) => {
@@ -173,7 +173,7 @@ export async function ensureModelDownloaded(onProgress: ProgressCallback, signal
 						: undefined;
 				onProgress({
 					phase: "downloading",
-					message: msgDownloading(),
+					message: msgDownloading(flavour),
 					percent,
 					bytesReceived: stats.bytesReceived,
 					totalBytes: stats.totalBytes,

--- a/packages/rpiv-voice/audio/model-download.ts
+++ b/packages/rpiv-voice/audio/model-download.ts
@@ -20,39 +20,35 @@ import { join } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
+import { loadVoiceConfig } from "../config/voice-config.js";
 import { t } from "../state/i18n-bridge.js";
 
 const execFileAsync = promisify(execFile);
 
 // ── Paths ────────────────────────────────────────────────────────────────────
-const MODEL_DIR_NAME = "whisper-base";
 export const MODELS_DIR = join(homedir(), ".pi", "models");
-export const WHISPER_BASE_DIR = join(MODELS_DIR, MODEL_DIR_NAME);
+export const WHISPER_BASE_DIR = join(MODELS_DIR, "whisper-base");
 export const SENTINEL_FILE = ".download-complete";
+
+export function getModelDir(flavour: string): string {
+	return join(MODELS_DIR, `whisper-${flavour}`);
+}
+
+function getWhisperFlavour(): string {
+	const config = loadVoiceConfig();
+	return config.whisperModelType || "base";
+}
 
 // ── Source archive ───────────────────────────────────────────────────────────
 // Approx archive size on the wire is ~198 MB; the splash now shows the exact
 // total once Content-Length is parsed, so we no longer encode the estimate
 // in any user-facing string. Kept here for documentation only.
 const MODEL_RELEASE_TAG = "asr-models";
-const MODEL_ARCHIVE_NAME = "sherpa-onnx-whisper-base.tar.bz2";
-const MODEL_URL = `https://github.com/k2-fsa/sherpa-onnx/releases/download/${MODEL_RELEASE_TAG}/${MODEL_ARCHIVE_NAME}`;
-
-// ── Files we keep (int8 quantized) ──────────────────────────────────────────
-const ENCODER_FILE = "base-encoder.int8.onnx";
-const DECODER_FILE = "base-decoder.int8.onnx";
-const TOKENS_FILE = "base-tokens.txt";
-const REQUIRED_FILES: readonly string[] = [ENCODER_FILE, DECODER_FILE, TOKENS_FILE];
-
-// ── Files we delete after extraction (fp32 dupes we don't need on CPU) ──────
-const FP32_ENCODER_FILE = "base-encoder.onnx";
-const FP32_DECODER_FILE = "base-decoder.onnx";
-const FP32_DUPLICATE_FILES: readonly string[] = [FP32_ENCODER_FILE, FP32_DECODER_FILE];
 
 // ── Tar invocation ───────────────────────────────────────────────────────────
 const TAR_BIN = "tar";
 // `--strip-components=1` flattens sherpa's top-level wrapper directory so the
-// REQUIRED_FILES land directly inside WHISPER_BASE_DIR.
+// REQUIRED_FILES land directly inside the model directory.
 const TAR_FLAGS: readonly string[] = ["-xjf"];
 const TAR_STRIP_FLAG = "--strip-components=1";
 
@@ -108,14 +104,17 @@ export class ModelInstallError extends Error {
 }
 
 export function isModelDownloaded(): boolean {
-	return existsSync(join(WHISPER_BASE_DIR, SENTINEL_FILE));
+	const flavour = getWhisperFlavour();
+	return existsSync(join(getModelDir(flavour), SENTINEL_FILE));
 }
 
 export function getModelPaths(): ModelPaths {
+	const flavour = getWhisperFlavour();
+	const modelDir = getModelDir(flavour);
 	return {
-		encoderPath: join(WHISPER_BASE_DIR, ENCODER_FILE),
-		decoderPath: join(WHISPER_BASE_DIR, DECODER_FILE),
-		tokensPath: join(WHISPER_BASE_DIR, TOKENS_FILE),
+		encoderPath: join(modelDir, `${flavour}-encoder.int8.onnx`),
+		decoderPath: join(modelDir, `${flavour}-decoder.int8.onnx`),
+		tokensPath: join(modelDir, `${flavour}-tokens.txt`),
 	};
 }
 
@@ -129,20 +128,29 @@ export function getModelPaths(): ModelPaths {
  * and on failure should `removeModelInstall()` so the next launch redownloads.
  */
 export function assertModelIntact(): void {
-	verifyModelFiles();
+	const flavour = getWhisperFlavour();
+	const modelDir = getModelDir(flavour);
+	verifyModelFiles(flavour, modelDir);
 }
 
 /** Wipe the entire model directory — used to recover from any partial /
  * corrupt install state. Idempotent and silent on missing dir. */
 export function removeModelInstall(): void {
-	rmSync(WHISPER_BASE_DIR, { recursive: true, force: true });
+	const flavour = getWhisperFlavour();
+	const modelDir = getModelDir(flavour);
+	rmSync(modelDir, { recursive: true, force: true });
 }
 
 export async function ensureModelDownloaded(onProgress: ProgressCallback, signal?: AbortSignal): Promise<ModelPaths> {
 	if (isModelDownloaded()) return getModelPaths();
 
-	mkdirSync(WHISPER_BASE_DIR, { recursive: true });
-	const archivePath = join(WHISPER_BASE_DIR, MODEL_ARCHIVE_NAME);
+	const flavour = getWhisperFlavour();
+	const modelDir = getModelDir(flavour);
+
+	mkdirSync(modelDir, { recursive: true });
+	const archiveName = `sherpa-onnx-whisper-${flavour}.tar.bz2`;
+	const archivePath = join(modelDir, archiveName);
+	const url = `https://github.com/k2-fsa/sherpa-onnx/releases/download/${MODEL_RELEASE_TAG}/${archiveName}`;
 
 	// Any failure between mkdir and writeSentinel leaves a half-populated
 	// directory (partial archive, partially-extracted .onnx, etc.) but no
@@ -154,7 +162,7 @@ export async function ensureModelDownloaded(onProgress: ProgressCallback, signal
 		onProgress({ phase: "downloading", message: msgDownloading() });
 		try {
 			let lastEmitMs = 0;
-			await downloadArchive(MODEL_URL, archivePath, signal, (stats) => {
+			await downloadArchive(url, archivePath, signal, (stats) => {
 				const now = Date.now();
 				const isFinal = stats.totalBytes !== undefined && stats.bytesReceived >= stats.totalBytes;
 				if (!isFinal && now - lastEmitMs < PROGRESS_THROTTLE_MS) return;
@@ -177,21 +185,21 @@ export async function ensureModelDownloaded(onProgress: ProgressCallback, signal
 
 		onProgress({ phase: "extracting", message: msgExtracting() });
 		try {
-			await extractArchive(archivePath, WHISPER_BASE_DIR);
+			await extractArchive(archivePath, modelDir);
 			rmSync(archivePath, { force: true });
-			pruneFp32Duplicates();
+			pruneFp32Duplicates(flavour, modelDir);
 		} catch (err) {
 			throw new ModelInstallError("extract", err);
 		}
 
 		onProgress({ phase: "verifying", message: msgVerifying() });
 		try {
-			verifyModelFiles();
+			verifyModelFiles(flavour, modelDir);
 		} catch (err) {
 			throw new ModelInstallError("verify", err);
 		}
 
-		writeSentinel();
+		writeSentinel(modelDir);
 		return getModelPaths();
 	} catch (err) {
 		removeModelInstall();
@@ -249,20 +257,22 @@ async function extractArchive(archivePath: string, destDir: string): Promise<voi
 
 // The Whisper archive ships fp32 + int8 side-by-side (~290 MB of fp32 we
 // don't use on CPU). Drop them so the install settles around ~157 MB.
-function pruneFp32Duplicates(): void {
-	for (const name of FP32_DUPLICATE_FILES) {
-		rmSync(join(WHISPER_BASE_DIR, name), { force: true });
+function pruneFp32Duplicates(flavour: string, modelDir: string): void {
+	const fp32Files = [`${flavour}-encoder.onnx`, `${flavour}-decoder.onnx`];
+	for (const name of fp32Files) {
+		rmSync(join(modelDir, name), { force: true });
 	}
 }
 
-function verifyModelFiles(): void {
-	for (const name of REQUIRED_FILES) {
-		if (!existsSync(join(WHISPER_BASE_DIR, name))) {
+function verifyModelFiles(flavour: string, modelDir: string): void {
+	const requiredFiles = [`${flavour}-encoder.int8.onnx`, `${flavour}-decoder.int8.onnx`, `${flavour}-tokens.txt`];
+	for (const name of requiredFiles) {
+		if (!existsSync(join(modelDir, name))) {
 			throw new Error(`Model verification failed: missing ${name}`);
 		}
 	}
 }
 
-function writeSentinel(): void {
-	writeFileSync(join(WHISPER_BASE_DIR, SENTINEL_FILE), "", "utf-8");
+function writeSentinel(modelDir: string): void {
+	writeFileSync(join(modelDir, SENTINEL_FILE), "", "utf-8");
 }

--- a/packages/rpiv-voice/command/voice-command.ts
+++ b/packages/rpiv-voice/command/voice-command.ts
@@ -58,7 +58,8 @@ function whisperLanguageForLocale(locale: string | undefined): string | undefine
 
 const SPLASH_INITIAL_ENGINE: SplashPhase = { kind: "loading_engine" };
 function splashInitialDownload(): SplashPhase {
-	return { kind: "downloading", message: t("splash.preparing", "Preparing model…") };
+	const modelType = loadVoiceConfig().whisperModelType || "base";
+	return { kind: "downloading", message: t("splash.preparing", `Preparing Whisper ${modelType} model…`) };
 }
 
 type PreflightStage = "download" | "extract" | "verify" | "stale_install" | "engine" | "mic";

--- a/packages/rpiv-voice/config/voice-config.test.ts
+++ b/packages/rpiv-voice/config/voice-config.test.ts
@@ -20,6 +20,11 @@ describe("loadVoiceConfig", () => {
 		const config = loadVoiceConfig();
 		expect(config.hallucinationFilterEnabled).toBe(false);
 	});
+	it("roundtrips whisperModelType", () => {
+		saveVoiceConfig({ whisperModelType: "tiny" });
+		const config = loadVoiceConfig();
+		expect(config.whisperModelType).toBe("tiny");
+	});
 });
 
 describe("saveVoiceConfig", () => {

--- a/packages/rpiv-voice/config/voice-config.ts
+++ b/packages/rpiv-voice/config/voice-config.ts
@@ -22,6 +22,7 @@ const VOICE_STATE_KEY = Symbol.for("rpiv-voice");
 export interface VoiceConfig {
 	readonly hallucinationFilterEnabled?: boolean;
 	readonly equalizerEnabled?: boolean;
+	readonly whisperModelType?: string;
 }
 
 /**


### PR DESCRIPTION
With local testing i found out that in my case it works better than the default one provided. (at the trade off of being more resource intensive).

And wanted to contribute back improvement to make model type download configurable via voice.json with `whisperModelType` configuration key.

Also with this PR then during first initialization of plugin it will show which type of model it will install as follows
` Downloading Whisper small.en model... `

Without configuration key the plugin still downloads the base model as originally the plugin does.
