### PR TITLE
fix(rpiv-web-tools): raise Exa fetch limit to 1M chars to match live API max

### DIFF
--- a/packages/rpiv-web-tools/providers/exa.ts
+++ b/packages/rpiv-web-tools/providers/exa.ts
@@ -10,7 +10,13 @@ export const EXA_PROVIDER_META = {
 	roles: ["search", "fetch"] as const,
 } as const;
 const EXA_MAX_SNIPPET_CHARACTERS = 300;
-const EXA_MAX_FETCH_CHARACTERS = 10000;
+// Exa's documented maximum is 10 000 characters (OpenAPI schema has
+// `maximum: 10000`), but the live API accepts up to 1 000 000.
+// Using the higher value lets rpiv-web-tools' own truncation
+// (DEFAULT_MAX_BYTES = 50 KiB) take over, which appends a
+// truncation footer and spills full content to a temp file so
+// the model can recover it with the read tool.
+const EXA_MAX_FETCH_CHARACTERS = 1_000_000;
 
 interface ExaRawResult {
 	title?: string;


### PR DESCRIPTION
## Problem

`EXA_MAX_FETCH_CHARACTERS` was 10,000, which matched Exa's documented OpenAPI schema (`maximum: 10000`). At this limit, Exa's `fetch()` returns ~10KB of content — well below `web_fetch`'s own `DEFAULT_MAX_BYTES` (50KB). Since `truncateHead()` never detects truncation, `truncation.truncated` is `false`, so:

- No `[Content truncated: ...]` footer is appended
- No temp file is created at `/tmp/rpiv-fetch-*/content.txt`
- The model sees ~10KB of silently truncated content with **no recovery path**

Every other provider path (Jina, Tavily, Firecrawl, Ollama, You.com, and the generic HTML fallback) either returns enough content to trigger truncation or fetches the full page directly. In all those cases the model gets a footer + temp file path, and can `read` the full content. Exa was the sole outlier: the model had no way to know content was truncated and no way to recover it. **`web_fetch` should always make the full fetched content available somewhere — either in the visible output (if it fits) or in a temp file (if it doesn't).**

## Fix

Raise to `1_000_000` — the live Exa API's actual maximum (rejects anything higher with `expected number to be <=1000000`). At 1M chars, Exa returns far more content than 50KB, so `truncateHead()` always triggers and the temp-file path is always surfaced.

**This does not bloat context.** `truncateHead()` still limits what the model sees to 50KB — exactly the same as every other provider. The extra content from Exa's API goes into the temp file, not into the context window.

## Empirical verification

| `maxCharacters` | Exa API | Footer? | Temp file? | Context impact |
|---|---|---|---|---|
| 10,000 (old) | Accepts, returns ~10KB | No | No | Same (10KB visible) |
| 1,000,000 | Accepts, returns ~98KB | Yes | Yes | Same (50KB visible) |

## Files changed

- `packages/rpiv-web-tools/providers/exa.ts` — 1 file, +7 −1