### PR TITLE
fix(todo): report "No change" for no-effect updates instead of "Updated #N"

### DIFF
--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- A no-effect `update` — `status` set to its current value, or any field re-sent unchanged — now reports `No change: #N …` instead of `Updated #N`, so it is no longer indistinguishable from a real mutation. This prevents a model from re-issuing the same no-op update in a loop.
 - Moved `typebox` from `peerDependencies` to `dependencies` (`^1.1.24`, matching the Pi host's range) so the tool's parameter schema resolves under installers that don't materialise peer deps. Fixes `ERR_MODULE_NOT_FOUND: typebox` on standalone consumer installs (#79).
 
 ## [1.20.0] - 2026-06-15

--- a/packages/rpiv-todo/state/state-reducer.test.ts
+++ b/packages/rpiv-todo/state/state-reducer.test.ts
@@ -66,8 +66,46 @@ describe("applyTaskMutation — update", () => {
 	it("allows completed → deleted transition", () => {
 		const state = stateWith(task({ id: 1, subject: "x", status: "completed" }));
 		const result = applyTaskMutation(state, "update", { id: 1, status: "deleted" });
-		expect(result.op).toEqual({ kind: "update", id: 1, fromStatus: "completed", toStatus: "deleted" });
+		expect(result.op).toEqual({ kind: "update", id: 1, fromStatus: "completed", toStatus: "deleted", changed: true });
 		expect(result.state.tasks[0].status).toBe("deleted");
+	});
+
+	it("flags a no-effect status update (status set to its current value) as changed:false", () => {
+		const state = stateWith(task({ id: 1, subject: "x", status: "pending" }));
+		const result = applyTaskMutation(state, "update", { id: 1, status: "pending" });
+		expect(result.op).toEqual({ kind: "update", id: 1, fromStatus: "pending", toStatus: "pending", changed: false });
+	});
+
+	it("flags a re-sent identical field as changed:false", () => {
+		const state = stateWith(task({ id: 1, subject: "x", description: "d" }));
+		const result = applyTaskMutation(state, "update", { id: 1, subject: "x", description: "d" });
+		expect(result.op).toMatchObject({ kind: "update", changed: false });
+	});
+
+	it("flags a blockedBy-only update as changed:true even when status is unchanged", () => {
+		const state = stateWith(task({ id: 1, subject: "a" }), task({ id: 2, subject: "b" }));
+		const result = applyTaskMutation(state, "update", { id: 1, addBlockedBy: [2] });
+		expect(result.op).toEqual({ kind: "update", id: 1, fromStatus: "pending", toStatus: "pending", changed: true });
+	});
+
+	it("flags a subject-only update on a task with existing deps as changed:true (blockedBy unchanged)", () => {
+		// Equal-length blockedBy on both sides — the changed signal comes from subject,
+		// not the dependency list, which round-trips identically.
+		const state = stateWith(task({ id: 1, subject: "old", blockedBy: [2] }), task({ id: 2, subject: "dep" }));
+		const result = applyTaskMutation(state, "update", { id: 1, subject: "new" });
+		expect(result.op).toEqual({ kind: "update", id: 1, fromStatus: "pending", toStatus: "pending", changed: true });
+		expect(result.state.tasks[0].blockedBy).toEqual([2]);
+	});
+
+	it("flags swapping one dependency for another (same length) as changed:true", () => {
+		const state = stateWith(
+			task({ id: 1, subject: "a", blockedBy: [2] }),
+			task({ id: 2, subject: "b" }),
+			task({ id: 3, subject: "c" }),
+		);
+		const result = applyTaskMutation(state, "update", { id: 1, removeBlockedBy: [2], addBlockedBy: [3] });
+		expect(result.op).toEqual({ kind: "update", id: 1, fromStatus: "pending", toStatus: "pending", changed: true });
+		expect(result.state.tasks[0].blockedBy).toEqual([3]);
 	});
 
 	it("rejects self-block via addBlockedBy", () => {

--- a/packages/rpiv-todo/state/state-reducer.ts
+++ b/packages/rpiv-todo/state/state-reducer.ts
@@ -14,7 +14,7 @@ import { detectCycle } from "./task-graph.js";
  */
 export type Op =
 	| { kind: "create"; taskId: number }
-	| { kind: "update"; id: number; fromStatus: TaskStatus; toStatus: TaskStatus }
+	| { kind: "update"; id: number; fromStatus: TaskStatus; toStatus: TaskStatus; changed: boolean }
 	| { kind: "delete"; id: number; subject: string }
 	| { kind: "list"; statusFilter?: TaskStatus; includeDeleted: boolean }
 	| { kind: "get"; task: Task }
@@ -28,6 +28,40 @@ export interface ApplyResult {
 
 function errorResult(state: TaskState, message: string): ApplyResult {
 	return { state, op: { kind: "error", message } };
+}
+
+function sameNumberList(a: number[] | undefined, b: number[] | undefined): boolean {
+	const x = a ?? [];
+	const y = b ?? [];
+	return x.length === y.length && x.every((v, i) => v === y[i]);
+}
+
+function sameRecord(a: Record<string, unknown> | undefined, b: Record<string, unknown> | undefined): boolean {
+	return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+/**
+ * Did this `update` change anything? Compares the task before/after the params
+ * are applied. A no-effect update — `status` set to its current value, or any
+ * field re-sent unchanged — returns false, letting the response envelope say
+ * "No change" instead of "Updated #N". Without this, a no-op update is
+ * indistinguishable from a real mutation, which can drive a model to re-issue
+ * the same call in a loop.
+ *
+ * blockedBy is order-sensitive (the reducer preserves insertion order);
+ * metadata round-trips through JSON persistence, so JSON-equality is the
+ * operative notion of "changed".
+ */
+function taskChanged(before: Task, after: Task): boolean {
+	return (
+		before.subject !== after.subject ||
+		before.status !== after.status ||
+		before.description !== after.description ||
+		before.activeForm !== after.activeForm ||
+		before.owner !== after.owner ||
+		!sameNumberList(before.blockedBy, after.blockedBy) ||
+		!sameRecord(before.metadata, after.metadata)
+	);
 }
 
 /**
@@ -139,7 +173,13 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 			newTasks[idx] = updated;
 			return {
 				state: { tasks: newTasks, nextId: state.nextId },
-				op: { kind: "update", id: updated.id, fromStatus: current.status, toStatus: newStatus },
+				op: {
+					kind: "update",
+					id: updated.id,
+					fromStatus: current.status,
+					toStatus: newStatus,
+					changed: taskChanged(current, updated),
+				},
 			};
 		}
 

--- a/packages/rpiv-todo/tool/response-envelope.test.ts
+++ b/packages/rpiv-todo/tool/response-envelope.test.ts
@@ -19,14 +19,20 @@ describe("formatContent", () => {
 
 	it("update — emits transition tuple when statuses differ", () => {
 		const state = stateWith(t({ id: 1, subject: "x", status: "in_progress" }));
-		const op: Op = { kind: "update", id: 1, fromStatus: "pending", toStatus: "in_progress" };
+		const op: Op = { kind: "update", id: 1, fromStatus: "pending", toStatus: "in_progress", changed: true };
 		expect(formatContent(op, state)).toBe("Updated #1 (pending → in_progress)");
 	});
 
-	it("update — omits transition when from === to (e.g. blockedBy-only update)", () => {
+	it("update — omits transition when from === to but fields changed (e.g. blockedBy-only update)", () => {
 		const state = stateWith(t({ id: 1, subject: "x" }));
-		const op: Op = { kind: "update", id: 1, fromStatus: "pending", toStatus: "pending" };
+		const op: Op = { kind: "update", id: 1, fromStatus: "pending", toStatus: "pending", changed: true };
 		expect(formatContent(op, state)).toBe("Updated #1");
+	});
+
+	it("update — reports 'No change' when changed is false (no-effect update)", () => {
+		const state = stateWith(t({ id: 1, subject: "x" }));
+		const op: Op = { kind: "update", id: 1, fromStatus: "pending", toStatus: "pending", changed: false };
+		expect(formatContent(op, state)).toBe("No change: #1 already matches the requested values (status: pending)");
 	});
 
 	it("delete — 'Deleted #id: subject'", () => {

--- a/packages/rpiv-todo/tool/response-envelope.ts
+++ b/packages/rpiv-todo/tool/response-envelope.ts
@@ -49,6 +49,9 @@ export function formatContent(op: Op, state: TaskState): string {
 			return `Created #${t.id}: ${t.subject} (pending)`;
 		}
 		case "update": {
+			if (!op.changed) {
+				return `No change: #${op.id} already matches the requested values (status: ${op.toStatus})`;
+			}
 			const transition = op.fromStatus !== op.toStatus ? ` (${op.fromStatus} → ${op.toStatus})` : "";
 			return `Updated #${op.id}${transition}`;
 		}


### PR DESCRIPTION
Closes #96.

## Problem

A `todo update` that doesn't change the task — `status` set to its current value, or any field re-sent unchanged — reported `Updated #N`, byte-identical to a real mutation. Because `isTransitionValid(from, to)` returns `true` for `from === to` (intentional idempotency), a same-status update is a successful no-op that nonetheless looks like a real change. With no signal that nothing happened, a model can re-issue the same no-op update in a loop, each call "succeeding".

## Fix

- The reducer computes whether the update actually changed the task by comparing it before/after the params are applied (`taskChanged`), across every mutable field (subject, status, description, activeForm, owner, blockedBy, metadata), carried as a new `changed: boolean` on the `update` `Op`.
- `formatContent` emits `No change: #N already matches the requested values (status: …)` when `changed` is false; otherwise the existing `Updated #N (from → to)`.

Idempotency is preserved — the update still succeeds and persists; only the reported text differs. `blockedBy` is compared order-sensitively (the reducer preserves insertion order) and `metadata` by JSON-equality (it round-trips through JSON persistence), so a genuine `blockedBy`/`metadata`-only change with an unchanged status is still reported as `Updated #N`.

## Before / after

On an already-pending `#1`:

```
before:  Updated #1
after:   No change: #1 already matches the requested values (status: pending)
```

## Tests

- **reducer:** no-effect status update & re-sent identical field → `changed: false`; blockedBy-only, subject-only-with-existing-deps, and dependency-swap (same length) → `changed: true`; the existing `completed → deleted` case asserts `changed: true`.
- **envelope:** `changed: false` → `No change: …`; `changed: true` with `from === to` → `Updated #N` (no transition).

## Verification

- `npm run test` — all green (3516 tests)
- `npm run check` (biome + tsc) — clean
- `npm run coverage` — meets all thresholds (statements 94.97 ≥ 94, branches 89.75 ≥ 87, functions 94.67 ≥ 93, lines 96.39 ≥ 95)

## Scope note

The other no-op shape — an `update` with no mutable fields at all — already errors with `update requires at least one mutable field` and is intentionally left unchanged.
