### PR TITLE
feat(ask-user-question): render questionnaire in RPC mode (VSCode pendant)

### DIFF
--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -99,6 +99,22 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 			// Emit event for external listeners (e.g., notification plugins)
 			emitAskUserPromptEvent(pi, typed);
 
+			// RPC fallback (e.g. the VSCode pendant embeds pi via RPC):
+			// ctx.ui.custom() renders a TUI overlay that needs a real terminal;
+			// in RPC mode it returns undefined, which buildQuestionnaireResponse
+			// collapses into DECLINE_MESSAGE ("User declined to answer questions")
+			// without ever showing the user a prompt. ctx.ui.select()/input() ARE
+			// functional in RPC via the extension_ui_request/response sub-protocol,
+			// so walk the questions with those and reuse the shared envelope.
+			// Positive `=== "rpc"` guard: in TUI mode ctx.mode is "tui" (use custom()),
+			// and on pi versions/tests where ctx.mode is unset we stay on the custom()
+			// path rather than mis-routing. See ./rpc-fallback.ts for the rationale.
+			if ((ctx as { mode?: string }).mode === "rpc") {
+				const { runRpcQuestionnaire } = await import("./rpc-fallback.js");
+				const rpcResult = await runRpcQuestionnaire(ctx, typed);
+				return buildQuestionnaireResponse(rpcResult, typed);
+			}
+
 			const itemsByTab: WrappingSelectItem[][] = typed.questions.map((q) => buildItemsForQuestion(q));
 
 			// Lazy — QuestionnaireSession pulls the ~560ms view/TUI render graph;

--- a/packages/rpiv-ask-user-question/package.json
+++ b/packages/rpiv-ask-user-question/package.json
@@ -31,6 +31,7 @@
 	},
 	"files": [
 		"ask-user-question.ts",
+		"rpc-fallback.ts",
 		"config.ts",
 		"events.ts",
 		"index.ts",

--- a/packages/rpiv-ask-user-question/rpc-fallback.test.ts
+++ b/packages/rpiv-ask-user-question/rpc-fallback.test.ts
@@ -1,0 +1,145 @@
+import { createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { registerAskUserQuestionTool } from "./ask-user-question.js";
+
+type SelectFn = (title: string, options: string[]) => Promise<string | undefined>;
+type InputFn = (title: string, placeholder?: string) => Promise<string | undefined>;
+
+function register() {
+	const { pi, captured } = createMockPi();
+	registerAskUserQuestionTool(pi);
+	return captured.tools.get("ask_user_question")!;
+}
+
+/**
+ * Build a mock ctx that looks like RPC mode: `mode === "rpc"` plus working
+ * `ui.select` / `ui.input`. `createMockCtx` doesn't set `ctx.mode`, and the
+ * production guard reads it via a structural cast — set it on the mock the
+ * same way so the `=== "rpc"` branch fires.
+ */
+function ctxRpc(opts: { select: SelectFn; input: InputFn }) {
+	const ctx = createMockCtx({
+		hasUI: true,
+		ui: { select: opts.select as never, input: opts.input as never } as never,
+	});
+	(ctx as { mode?: string }).mode = "rpc";
+	return ctx;
+}
+
+const SINGLE = {
+	questions: [
+		{
+			question: "Which?",
+			header: "Pick",
+			options: [
+				{ label: "A", description: "a" },
+				{ label: "B", description: "b" },
+			],
+		},
+	],
+};
+
+const MULTI = {
+	questions: [
+		{
+			question: "Pick colors?",
+			header: "Colors",
+			multiSelect: true,
+			options: [
+				{ label: "red", description: "r" },
+				{ label: "green", description: "g" },
+				{ label: "blue", description: "b" },
+			],
+		},
+	],
+};
+
+async function run(tool: ReturnType<typeof register>, params: unknown, ctx: unknown) {
+	return await tool.execute?.("tc", params as never, undefined as never, undefined as never, ctx as never);
+}
+
+describe("ask_user_question.execute — RPC fallback (ctx.mode === 'rpc')", () => {
+	it("single-select uses ctx.ui.select and returns the chosen label in the envelope", async () => {
+		const tool = register();
+		const select = vi.fn(async (_t: string, options: string[]) => options[1]); // "2. B — b"
+		const ctx = ctxRpc({ select, input: vi.fn(async () => "") });
+		const r = await run(tool, SINGLE, ctx);
+		expect(select).toHaveBeenCalledOnce();
+		expect(r?.details).toMatchObject({ cancelled: false });
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining('"Which?"="B"') });
+		expect(r?.content[0]).toMatchObject({ text: expect.stringMatching(/^User has answered your questions:/) });
+	});
+
+	it("does NOT call ctx.ui.custom in RPC mode", async () => {
+		const tool = register();
+		const custom = vi.fn(async () => ({ answers: [], cancelled: true }));
+		const ctx = createMockCtx({
+			hasUI: true,
+			ui: {
+				custom: custom as never,
+				select: vi.fn(async (_t: string, o: string[]) => o[0]) as never,
+				input: vi.fn(async () => "") as never,
+			} as never,
+		});
+		(ctx as { mode?: string }).mode = "rpc";
+		await run(tool, SINGLE, ctx);
+		expect(custom).not.toHaveBeenCalled();
+	});
+
+	it("multi-select uses ctx.ui.input and parses comma-separated indices into labels", async () => {
+		const tool = register();
+		const input = vi.fn(async () => "1,3"); // red, blue
+		const ctx = ctxRpc({ select: vi.fn(async () => ""), input });
+		const r = await run(tool, MULTI, ctx);
+		expect(input).toHaveBeenCalledOnce();
+		expect(r?.details).toMatchObject({ cancelled: false });
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining('"Pick colors?"="red, blue"') });
+	});
+
+	it("'Type something.' sentinel follows up with ctx.ui.input for custom text", async () => {
+		const tool = register();
+		const select = vi.fn(async (_t: string, options: string[]) => options[options.length - 2]); // "Type something."
+		const input = vi.fn(async () => "typed it");
+		const ctx = ctxRpc({ select, input });
+		const r = await run(tool, SINGLE, ctx);
+		expect(r?.details).toMatchObject({ cancelled: false });
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining('"Which?"="typed it"') });
+	});
+
+	it("'Chat about this.' sentinel records a chat answer (not declined)", async () => {
+		const tool = register();
+		const select = vi.fn(async (_t: string, options: string[]) => options[options.length - 1]); // "Chat about this."
+		const ctx = ctxRpc({ select, input: vi.fn(async () => "") });
+		const r = await run(tool, SINGLE, ctx);
+		expect(r?.details).toMatchObject({ cancelled: false });
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("User wants to chat about this") });
+	});
+
+	it("dismiss (select returns undefined) → decline envelope", async () => {
+		const tool = register();
+		const select = vi.fn(async () => undefined);
+		const ctx = ctxRpc({ select, input: vi.fn(async () => "") });
+		const r = await run(tool, SINGLE, ctx);
+		expect(r?.details).toMatchObject({ cancelled: true });
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("declined") });
+	});
+
+	it("stays on the custom() path when ctx.mode is unset (TUI / older pi / tests)", async () => {
+		// No mode set → guard (=== "rpc") is false → ctx.ui.custom is used, not select.
+		const tool = register();
+		const custom = vi.fn(async () => ({
+			cancelled: false,
+			answers: [{ questionIndex: 0, question: "Which?", kind: "option", answer: "A" }],
+		}));
+		const select = vi.fn(async () => "should-not-be-called");
+		const ctx = createMockCtx({
+			hasUI: true,
+			ui: { custom: custom as never, select: select as never } as never,
+		});
+		// deliberately NOT setting ctx.mode
+		const r = await run(tool, SINGLE, ctx);
+		expect(custom).toHaveBeenCalledOnce();
+		expect(select).not.toHaveBeenCalled();
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining('"Which?"="A"') });
+	});
+});

--- a/packages/rpiv-ask-user-question/rpc-fallback.ts
+++ b/packages/rpiv-ask-user-question/rpc-fallback.ts
@@ -1,0 +1,176 @@
+/**
+ * RPC / non-TUI fallback for `ask_user_question`.
+ *
+ * Why this exists: the canonical TUI path (`ctx.ui.custom()`) renders an
+ * interactive tabbed overlay dialog that requires a real terminal. In RPC
+ * mode (e.g. the VSCode pendant embeds pi via the JSON-over-stdio protocol),
+ * `ctx.hasUI` is `true` but `ctx.ui.custom()` returns `undefined` (see
+ * pi-coding-agent docs/rpc.md → "Extension UI Protocol"), which the shared
+ * `buildQuestionnaireResponse` collapses into DECLINE_MESSAGE — so the model
+ * saw "User declined to answer questions" even though the user was never
+ * shown a prompt.
+ *
+ * This fallback uses `ctx.ui.select()` / `ctx.ui.input()`, which ARE
+ * functional in RPC mode via the `extension_ui_request` /
+ * `extension_ui_response` sub-protocol (the pendant renders them natively).
+ * It walks the questions sequentially and builds a `QuestionnaireResult`
+ * with the same answer shapes the TUI produces, so the shared
+ * `buildQuestionnaireResponse` envelope is identical.
+ *
+ * Trade-off vs the TUI: no side-by-side preview pane and no multi-tab
+ * review — option descriptions and previews are folded into the prompt
+ * title, and multi-select is a single free-text "comma-separated numbers"
+ * input. Single-select keeps a real native dropdown.
+ */
+
+import type { QuestionAnswer, QuestionnaireResult, QuestionParams } from "./tool/types.js";
+
+/** Sentinel labels — must match `state/row-intent.ts` `other.label` / `chat.label`. */
+const TYPE_SOMETHING = "Type something.";
+const CHAT_ABOUT_THIS = "Chat about this.";
+
+/**
+ * Minimal structural slice of ExtensionContext we need. Kept structural so
+ * this module has no hard type dependency on the pi package's ctx shape
+ * (jiti transpiles without type-checking; this only documents intent).
+ */
+type RpcCtx = {
+	ui: {
+		select: (title: string, options: string[]) => Promise<string | undefined>;
+		input: (title: string, placeholder?: string) => Promise<string | undefined>;
+	};
+};
+
+/** Parse the leading "N." index from a formatted option string. Returns 0-based index or null. */
+function parseLeadingIndex(value: string | undefined | null, count: number): number | null {
+	if (!value) return null;
+	const m = value.match(/^\s*(\d+)/);
+	if (!m) return null;
+	const i = parseInt(m[1], 10) - 1;
+	return i >= 0 && i < count ? i : null;
+}
+
+/** Build the single-select option strings: "N. label — description" plus the two sentinels. */
+function buildSingleSelectOptions(question: QuestionParams["questions"][number]): { options: string[]; nReal: number } {
+	const options = question.options.map((o, i) => `${i + 1}. ${o.label} — ${o.description}`);
+	const nReal = question.options.length;
+	options.push(`${nReal + 1}. ${TYPE_SOMETHING}`);
+	options.push(`${nReal + 2}. ${CHAT_ABOUT_THIS}`);
+	return { options, nReal };
+}
+
+/** Compact preview block appended to the title so the user can still read previews in RPC. */
+function buildPreviewBlock(question: QuestionParams["questions"][number]): string {
+	const withPreview = question.options.filter((o) => typeof o.preview === "string" && o.preview.length > 0);
+	if (withPreview.length === 0) return "";
+	const blocks = question.options
+		.map((o, i) =>
+			typeof o.preview === "string" && o.preview.length > 0
+				? `--- ${i + 1}. ${o.label} preview ---\n${o.preview.slice(0, 600)}`
+				: "",
+		)
+		.filter(Boolean);
+	return blocks.length ? `\n\n${blocks.join("\n\n")}` : "";
+}
+
+/**
+ * Run the questionnaire in RPC / non-TUI mode. Sequential; returns the
+ * collected answers. `cancelled: true` only on dismissal or "Chat about this"
+ * is NOT set — chat records a `kind: "chat"` answer (matching TUI semantics
+ * so the envelope emits the chat-continuation message, not DECLINE).
+ */
+export async function runRpcQuestionnaire(ctx: RpcCtx, params: QuestionParams): Promise<QuestionnaireResult> {
+	const answers: QuestionAnswer[] = [];
+
+	for (let qi = 0; qi < params.questions.length; qi++) {
+		const q = params.questions[qi];
+		const header = q.header ? `[${q.header}] ` : "";
+
+		if (q.multiSelect) {
+			// multi-select: no native multi-pick in RPC; use free-text input.
+			const list = q.options.map((o, i) => `${i + 1}. ${o.label} — ${o.description}`).join("\n");
+			const title =
+				`${header}${q.question}\n\n${list}\n\n` +
+				`Enter the numbers of all that apply, comma-separated (e.g. "1,3"). ` +
+				`Type "chat" to talk it over instead.`;
+			const val = await ctx.ui.input(title, "1,3");
+			if (val == null) {
+				// dismissed / cancelled mid-questionnaire
+				return { answers, cancelled: true };
+			}
+			const trimmed = val.trim();
+			if (/^chat\b/i.test(trimmed) || trimmed.toLowerCase() === "chat") {
+				answers.push({
+					questionIndex: qi,
+					question: q.question,
+					kind: "chat",
+					answer: CHAT_ABOUT_THIS,
+				});
+				return { answers, cancelled: false };
+			}
+			const selected: string[] = [];
+			for (const part of trimmed.split(/[,\s]+/)) {
+				const idx = parseLeadingIndex(part, q.options.length);
+				if (idx != null) {
+					const label = q.options[idx].label;
+					if (!selected.includes(label)) selected.push(label);
+				}
+			}
+			answers.push({
+				questionIndex: qi,
+				question: q.question,
+				kind: "multi",
+				answer: null,
+				selected,
+			});
+			continue;
+		}
+
+		// single-select: native dropdown via ctx.ui.select()
+		const { options: selectOpts, nReal } = buildSingleSelectOptions(q);
+		const title = `${header}${q.question}${buildPreviewBlock(q)}`;
+		const val = await ctx.ui.select(title, selectOpts);
+		if (val == null) {
+			// dismissed / cancelled mid-questionnaire
+			return { answers, cancelled: true };
+		}
+		const idx = parseLeadingIndex(val, nReal + 2);
+		if (idx == null) {
+			// unexpected value — treat as dismissed
+			return { answers, cancelled: true };
+		}
+		if (idx < nReal) {
+			const o = q.options[idx];
+			answers.push({
+				questionIndex: qi,
+				question: q.question,
+				kind: "option",
+				answer: o.label,
+				preview: typeof o.preview === "string" && o.preview.length > 0 ? o.preview : undefined,
+			});
+		} else if (idx === nReal) {
+			// "Type something." → free-text follow-up
+			const custom = await ctx.ui.input(`${header}${q.question}\n\nType your answer:`, "");
+			if (custom == null) {
+				return { answers, cancelled: true };
+			}
+			answers.push({
+				questionIndex: qi,
+				question: q.question,
+				kind: "custom",
+				answer: custom,
+			});
+		} else {
+			// "Chat about this." → record chat answer, stop (abandon to free-form chat)
+			answers.push({
+				questionIndex: qi,
+				question: q.question,
+				kind: "chat",
+				answer: CHAT_ABOUT_THIS,
+			});
+			return { answers, cancelled: false };
+		}
+	}
+
+	return { answers, cancelled: false };
+}


### PR DESCRIPTION
## Problem
In RPC mode (e.g. the VSCode pendant embeds pi via the JSON-over-stdio protocol) `ctx.hasUI` is `true` but `ctx.ui.custom()` returns `undefined` (per pi's rpc.md → "Extension UI Protocol"). `buildQuestionnaireResponse` collapses that into `DECLINE_MESSAGE` ("User declined to answer questions") **without ever showing the user a prompt** — so from the model's side the tool always "fails" in that host, and it learns to avoid `ask_user_question` there.

## Root cause
`ctx.ui.custom()` renders a TUI overlay that needs a real terminal; RPC has no such surface. But `ctx.ui.select()` / `ctx.ui.input()` / `confirm()` / `editor()` **are** functional in RPC via the `extension_ui_request` / `extension_ui_response` sub-protocol (the pendant renders them natively). The tool only used the TUI-only `custom()` path.

## Fix
Add a positive `ctx.mode === "rpc"` guard before the `custom()` call that walks the questions with the RPC-supported dialogs and reuses the **same** `QuestionnaireResult` shapes + `buildQuestionnaireResponse` envelope:
- single-select → `ctx.ui.select()` (native dropdown); options formatted as `N. label — description`, sentinels `Type something.` / `Chat about this.` appended as numbered options
- multi-select → `ctx.ui.input()` (comma-separated indices, parsed to labels)
- `Type something.` → follow-up `input()` → `kind: "custom"`
- `Chat about this.` → `kind: "chat"` (matches TUI semantics — envelope emits the chat-continuation message, not DECLINE)
- dismiss (`select` returns `undefined`) → `cancelled` → DECLINE
- option `preview` is folded into the prompt title (no side-by-side pane in RPC) and still echoed as `selected preview:` in the envelope

The TUI `custom()` path is **untouched**. The guard is deliberately positive (`=== "rpc"`) rather than `!== "tui"` so that when `ctx.mode` is unset (older pi versions, unit-test mocks) it stays on the `custom()` path instead of mis-routing — this also keeps the existing 514 tests green.

## Trade-offs
RPC has no multi-tab surface, so multi-question is **sequential** (one dialog per question) rather than a single tabbed dialog. No side-by-side preview pane; multi-select is one free-text input instead of checkboxes. Single-select keeps a real native dropdown. These are inherent to the `select()`/`input()` API surface.

## Compatibility
Targets pi versions where RPC mode has `hasUI === true` + the extension UI sub-protocol (0.80.x, where this was live-verified in the VSCode pendant). On older pi where RPC `hasUI` is `false`, the existing `!ctx.hasUI → ERROR_NO_UI` early-return still applies (unchanged) — no regression.

## Testing
- 7 new vitest tests in `rpc-fallback.test.ts` (single/multi/custom/chat/dismiss/mode-unset-stays-on-custom/does-not-call-custom)
- `npm run check` (biome + tsc --noEmit) clean
- full suite: 521 passed (514 existing + 7 new), 0 regressions
- live-verified in the VSCode pendant: single-select, multi-select, and preview-carry-through all render and return real answers
