### PR TITLE
fix(rpiv-voice): avoid DynamicBorder global theme crash

### DIFF
--- a/packages/rpiv-voice/package.json
+++ b/packages/rpiv-voice/package.json
@@ -57,6 +57,7 @@
 		"state/status-intent.ts",
 		"state/voice-session.ts",
 		"view/component-binding.ts",
+		"view/components/accent-divider.ts",
 		"view/components/equalizer-view.ts",
 		"view/components/settings-field-view.ts",
 		"view/components/settings-form-view.ts",

--- a/packages/rpiv-voice/state/voice-session.test.ts
+++ b/packages/rpiv-voice/state/voice-session.test.ts
@@ -18,10 +18,13 @@ vi.mock("../config/voice-config.js", async (importOriginal) => {
 	return { ...orig, saveVoiceConfig: vi.fn(() => true) };
 });
 
-const theme = makeTheme({
-	fg: (_c: string, t: string) => t,
-	bold: (t: string) => t,
-}) as unknown as Theme;
+const theme = {
+	...makeTheme({
+		fg: (_c: string, t: string) => t,
+		bold: (t: string) => t,
+	}),
+	boxSharp: { horizontal: "─" },
+} as unknown as Theme;
 
 function makeDeps() {
 	return {

--- a/packages/rpiv-voice/state/voice-session.ts
+++ b/packages/rpiv-voice/state/voice-session.ts
@@ -1,8 +1,9 @@
-import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import { getKeybindings } from "@earendil-works/pi-tui";
 import type { VoiceConfig } from "../config/voice-config.js";
 import { saveVoiceConfig } from "../config/voice-config.js";
 import { globalBinding } from "../view/component-binding.js";
+import { AccentDivider } from "../view/components/accent-divider.js";
 import { EqualizerView } from "../view/components/equalizer-view.js";
 import { SettingsFieldView } from "../view/components/settings-field-view.js";
 import { SettingsFormView } from "../view/components/settings-form-view.js";
@@ -68,7 +69,7 @@ export class VoiceSession {
 		this.state = initialVoiceState(draftFromConfig(config.persistedConfig));
 
 		const transcript = new TranscriptView(config.theme);
-		const divider = new DynamicBorder((s) => config.theme.fg("accent", s));
+		const divider = new AccentDivider(config.theme);
 		const equalizer = new EqualizerView(config.theme);
 		const statusBar = new StatusBarView(config.theme);
 		this.statusBar = statusBar;

--- a/packages/rpiv-voice/view/components/accent-divider.test.ts
+++ b/packages/rpiv-voice/view/components/accent-divider.test.ts
@@ -1,0 +1,26 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { makeTheme } from "@juicesharp/rpiv-test-utils";
+import { describe, expect, it } from "vitest";
+
+import { AccentDivider } from "./accent-divider.js";
+
+const theme = {
+	...makeTheme({ fg: (color: string, text: string) => `<${color}>${text}</${color}>` }),
+	boxSharp: { horizontal: "─" },
+} as unknown as Theme;
+
+describe("AccentDivider", () => {
+	it("renders an accent-colored divider from the injected theme", () => {
+		const divider = new AccentDivider(theme);
+
+		expect(divider.render(3)).toEqual(["<accent>───</accent>"]);
+	});
+
+	it("invalidates cached width-aware output", () => {
+		const divider = new AccentDivider(theme);
+
+		expect(divider.render(2)).toEqual(["<accent>──</accent>"]);
+		divider.invalidate();
+		expect(divider.render(4)).toEqual(["<accent>────</accent>"]);
+	});
+});

--- a/packages/rpiv-voice/view/components/accent-divider.ts
+++ b/packages/rpiv-voice/view/components/accent-divider.ts
@@ -1,0 +1,30 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+
+const COLOR_ACCENT = "accent";
+
+const HORIZONTAL_RULE = "─";
+
+/** Renders the shared voice overlay divider without reading Pi's global theme singleton. */
+export class AccentDivider implements Component {
+	#cachedWidth = -1;
+	#cachedLines: string[] | undefined;
+
+	constructor(private readonly theme: Theme) {}
+
+	invalidate(): void {
+		this.#cachedWidth = -1;
+		this.#cachedLines = undefined;
+	}
+
+	render(width: number): string[] {
+		if (this.#cachedLines && this.#cachedWidth === width) {
+			return this.#cachedLines;
+		}
+
+		const lines = [this.theme.fg(COLOR_ACCENT, HORIZONTAL_RULE.repeat(Math.max(1, width)))];
+		this.#cachedWidth = width;
+		this.#cachedLines = lines;
+		return lines;
+	}
+}

--- a/packages/rpiv-voice/view/components/splash-view.test.ts
+++ b/packages/rpiv-voice/view/components/splash-view.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from "vitest";
 
 import { SplashView } from "./splash-view.js";
 
-const tagged = makeTheme({
-	fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
-}) as unknown as Theme;
+const tagged = {
+	...makeTheme({
+		fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+	}),
+	boxSharp: { horizontal: "─" },
+} as unknown as Theme;
 const WIDTH = 80;
 
 function renderLast(view: SplashView): string {

--- a/packages/rpiv-voice/view/components/splash-view.ts
+++ b/packages/rpiv-voice/view/components/splash-view.ts
@@ -1,7 +1,8 @@
-import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import { t } from "../../state/i18n-bridge.js";
 import type { StatefulView } from "../stateful-view.js";
+import { AccentDivider } from "./accent-divider.js";
 
 export const SPLASH_FRAMES = ["⠴", "⠦", "⠖", "⠲"] as const;
 export const SPLASH_FRAME_INTERVAL_MS = 160;
@@ -73,11 +74,11 @@ function appendDownloadProgress(
  * the dictation/settings chrome rather than a separate widget.
  */
 export class SplashView implements StatefulView<SplashViewProps> {
-	private readonly divider: DynamicBorder;
+	private readonly divider: AccentDivider;
 	private props: SplashViewProps = { phase: { kind: "loading_engine" }, frame: 0 };
 
 	constructor(private readonly theme: Theme) {
-		this.divider = new DynamicBorder((s) => theme.fg(COLOR_ACCENT, s));
+		this.divider = new AccentDivider(theme);
 	}
 
 	setProps(props: SplashViewProps): void {


### PR DESCRIPTION
## Issue

The `/voice` command is crashing in oh-my-pi  (omp) with an error: 

```
/voice
 ─╯
 [Uncaught Exception] TypeError: undefined is not an object (evaluating 'theme.boxSharp')
 █
     at render
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/src/modes/com
 ponents/dynamic-border.ts:29:30)ion_override rotation mode if not already set.     │
     at render
 (/Users/dmytro.l/.omp/plugins/node_modules/@juicesharp/rpiv-voice/view/components/splash-
 view.ts:96:27)his conversation.                                                    │
     at render
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 187:50803)CONTEXT.md and the decisions in docs/adr/. Use when the user wants to    │
     at render
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 187:54746)ed modules, or make a codebase more testable and AI-navigable.           │
     at #I0
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 188:7167)
     at <anonymous>
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 188:2868)

 [Uncaught Exception] TypeError: undefined is not an object (evaluating 'theme.boxSharp')
     at render
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/src/modes/com
 ponents/dynamic-border.ts:29:30)
     at render
 (/Users/dmytro.l/.omp/plugins/node_modules/@juicesharp/rpiv-voice/view/components/splash-
 view.ts:96:27)
     at render
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 187:50803)
     at render
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 187:54746)
     at #I0
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 188:7167)
     at <anonymous>
 (/Users/dmytro.l/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js:2
 188:2868)
```

While [oh-my-pi](https://omp.sh/) may not be a targeted support of this plugin, pi and omp are very close in their setup.

## Fix

Fixes `/voice` crashing in OMP when rendering the splash/overlay divider.
`DynamicBorder` can read the host global theme singleton during render. 

In OMP extension loading, that global theme may be unavailable, causing:
```txt
TypeError: undefined is not an object (evaluating 'theme.boxSharp')
```

 I replaced DynamicBorder usage in rpiv-voice with a local AccentDivider that uses the injected Theme instance only.