### PR TITLE
perf(rpiv-todo): Improve startup time - lazy-load the todo overlay

### DIFF
--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -19,7 +19,7 @@
  * correctly after upgrade.
  */
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
 import { COLLAPSE_KEY_OFF, resolveCollapseKey } from "./config.js";
 import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
@@ -28,12 +28,13 @@ import {
 	clearActiveRenderSession,
 	evictSession,
 	getActiveRenderSession,
+	getRenderState,
 	replaceState,
 	setActiveRenderSession,
 	sid,
 } from "./state/store.js";
 import { registerTodosCommand, registerTodoTool, TOOL_NAME } from "./todo.js";
-import { TodoOverlay } from "./todo-overlay.js";
+import type { TodoOverlay } from "./todo-overlay.js";
 
 type I18nLoader = {
 	registerLocalesFromDir: (namespace: string, packageUrl: string, options?: { label?: string }) => void;
@@ -61,8 +62,27 @@ function isStaleCtxError(e: unknown): boolean {
 }
 
 export default function (pi: ExtensionAPI) {
-	// Todo overlay widget — constructed lazily at the first session_start with UI.
 	let todoOverlay: TodoOverlay | undefined;
+	let todoOverlayModule: Promise<typeof import("./todo-overlay.js")> | undefined;
+	let uiCtx: ExtensionUIContext | undefined;
+	let lifecycleGeneration = 0;
+
+	async function updateTodoOverlay(
+		resetCompletedDisplayState = false,
+		generation = lifecycleGeneration,
+	): Promise<void> {
+		const hasVisibleTasks = getRenderState().tasks.some((task) => task.status !== "deleted");
+		if (!uiCtx || (!todoOverlay && !hasVisibleTasks)) return;
+
+		todoOverlayModule ??= import("./todo-overlay.js");
+		const { TodoOverlay } = await todoOverlayModule;
+		if (generation !== lifecycleGeneration || !uiCtx) return;
+
+		todoOverlay ??= new TodoOverlay();
+		todoOverlay.setUICtx(uiCtx);
+		if (resetCompletedDisplayState) todoOverlay.resetCompletedDisplayState();
+		todoOverlay.update();
+	}
 
 	registerTodoTool(pi);
 	registerTodosCommand(pi);
@@ -71,10 +91,10 @@ export default function (pi: ExtensionAPI) {
 	// factory scope from config (register-once contract: a config change needs
 	// `/reload` to re-bind, same as lane-switcher's env hotkey) and the binding is
 	// skipped entirely when collapseKey is "off". The handler closes over the
-	// closure-local `todoOverlay` by reference and re-reads it at fire time, so a
-	// session_start that (re)creates the overlay is picked up. No-op in headless
-	// mode, when the overlay hasn't been created yet, or when the widget isn't
-	// currently registered (auto-hidden on an empty list).
+	// closure-local `todoOverlay` by reference and re-reads it at fire time, so an
+	// overlay loaded after shortcut registration is picked up. No-op in headless
+	// mode, before the overlay has loaded, or when the widget isn't currently
+	// registered (auto-hidden on an empty list).
 	const collapseKey = resolveCollapseKey();
 	if (collapseKey !== COLLAPSE_KEY_OFF) {
 		pi.registerShortcut(collapseKey as KeyId, {
@@ -94,7 +114,9 @@ export default function (pi: ExtensionAPI) {
 	// the replacement session's session_start replays it. Other errors are real replay
 	// bugs and must propagate. The render is sid-gated so a child never refreshes the
 	// foreground overlay.
-	const replayAndRefresh = (ctx: Parameters<typeof sid>[0] & Parameters<typeof replayFromBranch>[0]): void => {
+	const replayAndRefresh = async (
+		ctx: Parameters<typeof sid>[0] & Parameters<typeof replayFromBranch>[0],
+	): Promise<void> => {
 		let isForeground = false;
 		try {
 			const id = sid(ctx);
@@ -103,10 +125,7 @@ export default function (pi: ExtensionAPI) {
 		} catch (e) {
 			if (!isStaleCtxError(e)) throw e;
 		}
-		if (isForeground) {
-			todoOverlay?.resetCompletedDisplayState();
-			todoOverlay?.update();
-		}
+		if (isForeground) await updateTodoOverlay(true);
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -124,23 +143,23 @@ export default function (pi: ExtensionAPI) {
 		}
 		if (!ctx.hasUI) return;
 		// First UI-bearing session_start claims the foreground (the interactive
-		// launcher, by spawn-ordering). A child hitting a live overlay cannot
-		// clobber the pointer — `todoOverlay` is already set.
-		if (todoOverlay === undefined) {
-			todoOverlay = new TodoOverlay();
-			setActiveRenderSession(id);
-		}
+		// launcher, by spawn-ordering) without eagerly loading the overlay.
+		if (getActiveRenderSession() === "") setActiveRenderSession(id);
 		// Only the foreground re-binds/refreshes the shared overlay. A child
 		// (distinct sid) is skipped — does not rebind to a relay/stale ui.
 		if (id !== getActiveRenderSession()) return;
-		todoOverlay.setUICtx(ctx.ui);
-		todoOverlay.resetCompletedDisplayState();
-		todoOverlay.update();
+		const generation = ++lifecycleGeneration;
+		uiCtx = ctx.ui;
+		await updateTodoOverlay(true, generation);
 	});
 
-	pi.on("session_compact", async (_event, ctx) => replayAndRefresh(ctx));
+	pi.on("session_compact", async (_event, ctx) => {
+		await replayAndRefresh(ctx);
+	});
 
-	pi.on("session_tree", async (_event, ctx) => replayAndRefresh(ctx));
+	pi.on("session_tree", async (_event, ctx) => {
+		await replayAndRefresh(ctx);
+	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		// Best-effort sid: disposal can race a stale ctx (like compact). An
@@ -159,6 +178,10 @@ export default function (pi: ExtensionAPI) {
 		// dispose the foreground's overlay. Only the foreground's own shutdown
 		// (or an unknown/stale sid) tears it down and clears the pointer.
 		if (s === "" || s === getActiveRenderSession()) {
+			// Invalidate pending imports before clearing the foreground binding so a
+			// replaced session cannot inherit the stale overlay or UI context.
+			lifecycleGeneration++;
+			uiCtx = undefined;
 			// `dispose()`'s first act is setWidget(KEY, undefined) on a possibly-stale
 			// ui proxy, which can throw. evictSession(s) above already deleted this
 			// slot, so leaving `activeRenderSession` pointing at it would resolve
@@ -177,7 +200,7 @@ export default function (pi: ExtensionAPI) {
 	// (branch is stale — message_end runs after tool_execution_end).
 	pi.on("tool_execution_end", async (event) => {
 		if (event.toolName !== TOOL_NAME || event.isError) return;
-		todoOverlay?.update();
+		await updateTodoOverlay();
 	});
 
 	pi.on("agent_start", async () => {

--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -40,6 +40,40 @@ type I18nLoader = {
 	registerLocalesFromDir: (namespace: string, packageUrl: string, options?: { label?: string }) => void;
 };
 
+/** Delay the overlay graph pre-warm until Pi's startup work has settled. */
+export const PREWARM_DELAY_MS = 2000;
+
+type TodoOverlayModule = typeof import("./todo-overlay.js");
+type TodoOverlayImporter = () => Promise<TodoOverlayModule>;
+
+/**
+ * Memoize the overlay graph after a successful load, but drop a rejected
+ * promise so a failed pre-warm does not permanently replay the same rejection.
+ * The export guard turns jiti's poisoned-namespace failure into a useful restart
+ * error instead of a bare "TodoOverlay is not a constructor" TypeError.
+ */
+export function makeTodoOverlayLoader(
+	importOverlay: TodoOverlayImporter = () => import("./todo-overlay.js"),
+): TodoOverlayImporter {
+	let memo: Promise<TodoOverlayModule> | undefined;
+
+	return async (): Promise<TodoOverlayModule> => {
+		memo ??= importOverlay();
+		let mod: TodoOverlayModule;
+		try {
+			mod = await memo;
+		} catch (error) {
+			memo = undefined;
+			throw error;
+		}
+		if (typeof mod.TodoOverlay !== "function") {
+			const keys = JSON.stringify(Object.keys(mod));
+			throw new Error(`Todo overlay module cache is stale; restart Pi (resolved namespace keys: ${keys})`);
+		}
+		return mod;
+	};
+}
+
 // Dynamic import keeps `@juicesharp/rpiv-i18n` a soft optional peer: when the
 // SDK is installed alongside this package the strings register and
 // `/languages` flips them live; when it isn't, the import rejects here, we
@@ -61,9 +95,9 @@ function isStaleCtxError(e: unknown): boolean {
 	return /stale after session replacement/.test(String(e));
 }
 
-export default function (pi: ExtensionAPI) {
+export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = () => import("./todo-overlay.js")) {
 	let todoOverlay: TodoOverlay | undefined;
-	let todoOverlayModule: Promise<typeof import("./todo-overlay.js")> | undefined;
+	const loadTodoOverlay = makeTodoOverlayLoader(importOverlay);
 	let uiCtx: ExtensionUIContext | undefined;
 	let lifecycleGeneration = 0;
 
@@ -74,8 +108,7 @@ export default function (pi: ExtensionAPI) {
 		const hasVisibleTasks = getRenderState().tasks.some((task) => task.status !== "deleted");
 		if (!uiCtx || (!todoOverlay && !hasVisibleTasks)) return;
 
-		todoOverlayModule ??= import("./todo-overlay.js");
-		const { TodoOverlay } = await todoOverlayModule;
+		const { TodoOverlay } = await loadTodoOverlay();
 		if (generation !== lifecycleGeneration || !uiCtx) return;
 
 		todoOverlay ??= new TodoOverlay();
@@ -202,6 +235,14 @@ export default function (pi: ExtensionAPI) {
 		if (event.toolName !== TOOL_NAME || event.isError) return;
 		await updateTodoOverlay();
 	});
+
+	// Evaluate the lazy graph after startup while Pi's boot-time dependency paths
+	// are still stable. This loads no widget and constructs no overlay; those stay
+	// deferred until a foreground session has visible tasks. A rejected pre-warm
+	// is intentionally swallowed after loadTodoOverlay clears its memo, allowing
+	// the first real update to retry. unref avoids holding an embedder open.
+	const prewarmTimer = setTimeout(() => void loadTodoOverlay().catch(() => undefined), PREWARM_DELAY_MS);
+	prewarmTimer.unref?.();
 
 	pi.on("agent_start", async () => {
 		todoOverlay?.hideCompletedTasksFromPreviousTurn();

--- a/packages/rpiv-todo/lazy-overlay.regression.test.ts
+++ b/packages/rpiv-todo/lazy-overlay.regression.test.ts
@@ -1,0 +1,106 @@
+import { buildSessionEntries, createMockCtx, createMockPi, makeTodoToolResult } from "@juicesharp/rpiv-test-utils";
+import { beforeEach, expect, it, vi } from "vitest";
+
+const overlayMock = vi.hoisted(() => ({
+	importGate: undefined as Promise<void> | undefined,
+	moduleLoads: 0,
+}));
+
+vi.mock("./todo-overlay.js", async (importOriginal) => {
+	overlayMock.moduleLoads++;
+	await overlayMock.importGate;
+	return importOriginal<typeof import("./todo-overlay.js")>();
+});
+
+function resumedBranch(subject: string) {
+	return buildSessionEntries([
+		makeTodoToolResult({
+			action: "create",
+			params: { subject },
+			tasks: [{ id: 1, subject, status: "pending" }],
+			nextId: 2,
+		}),
+	]);
+}
+
+async function setup() {
+	const { default: registerTodo } = await import("./index.js");
+	const { pi, captured } = createMockPi();
+	registerTodo(pi);
+	const start = captured.events.get("session_start")?.[0];
+	const shutdown = captured.events.get("session_shutdown")?.[0];
+	const toolEnd = captured.events.get("tool_execution_end")?.[0];
+	const tool = captured.tools.get("todo");
+	if (!start || !shutdown || !toolEnd || !tool) throw new Error("todo lifecycle was not registered");
+	return { shutdown, start, tool, toolEnd };
+}
+
+beforeEach(() => {
+	vi.resetModules();
+	overlayMock.importGate = undefined;
+	overlayMock.moduleLoads = 0;
+});
+
+it("loads the overlay only when tasks need rendering and ignores stale imports", async () => {
+	let releaseImport!: () => void;
+	overlayMock.importGate = new Promise<void>((resolve) => {
+		releaseImport = resolve;
+	});
+	const staleLifecycle = await setup();
+	const staleCtx = createMockCtx({ hasUI: true, sessionId: "stale" });
+
+	// Registering the extension and starting an empty session must not evaluate
+	// the overlay module or touch the widget API.
+	expect(overlayMock.moduleLoads).toBe(0);
+	await staleLifecycle.start({} as never, staleCtx as never);
+	expect(overlayMock.moduleLoads).toBe(0);
+	expect(staleCtx.ui.setWidget as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+
+	// The first successful mutation starts the lazy import. Replace the session
+	// while that import is pending, and resume the replacement with persisted work.
+	await staleLifecycle.tool.execute?.(
+		"tc",
+		{ action: "create", subject: "stale task" } as never,
+		undefined as never,
+		undefined as never,
+		staleCtx as never,
+	);
+	const staleUpdate = staleLifecycle.toolEnd({ toolName: "todo", isError: false } as never, staleCtx as never);
+	await vi.waitFor(() => expect(overlayMock.moduleLoads).toBe(1));
+	await staleLifecycle.shutdown({} as never, staleCtx as never);
+
+	const replacementCtx = createMockCtx({
+		branch: resumedBranch("replacement task"),
+		hasUI: true,
+		sessionId: "replacement",
+	});
+	const replacementStart = staleLifecycle.start({} as never, replacementCtx as never);
+	releaseImport();
+	await Promise.all([staleUpdate, replacementStart]);
+
+	expect(staleCtx.ui.setWidget as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+	expect(replacementCtx.ui.setWidget as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+
+	// A clean empty session still renders immediately after its first successful
+	// mutation, even when the module itself is already cached.
+	await staleLifecycle.shutdown({} as never, replacementCtx as never);
+	overlayMock.importGate = undefined;
+	const currentLifecycle = await setup();
+	const currentCtx = createMockCtx({ hasUI: true, sessionId: "current" });
+	await currentLifecycle.start({} as never, currentCtx as never);
+	expect(currentCtx.ui.setWidget as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+	await currentLifecycle.tool.execute?.(
+		"tc",
+		{ action: "create", subject: "first" } as never,
+		undefined as never,
+		undefined as never,
+		currentCtx as never,
+	);
+	await currentLifecycle.toolEnd({ toolName: "todo", isError: false } as never, currentCtx as never);
+
+	expect(currentCtx.ui.setWidget as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+		"rpiv-todos",
+		expect.any(Function),
+		{ placement: "aboveEditor" },
+	);
+});

--- a/packages/rpiv-todo/lazy-overlay.regression.test.ts
+++ b/packages/rpiv-todo/lazy-overlay.regression.test.ts
@@ -1,5 +1,5 @@
 import { buildSessionEntries, createMockCtx, createMockPi, makeTodoToolResult } from "@juicesharp/rpiv-test-utils";
-import { beforeEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 const overlayMock = vi.hoisted(() => ({
 	importGate: undefined as Promise<void> | undefined,
@@ -23,10 +23,10 @@ function resumedBranch(subject: string) {
 	]);
 }
 
-async function setup() {
+async function setup(importOverlay?: () => Promise<typeof import("./todo-overlay.js")>) {
 	const { default: registerTodo } = await import("./index.js");
 	const { pi, captured } = createMockPi();
-	registerTodo(pi);
+	registerTodo(pi, importOverlay);
 	const start = captured.events.get("session_start")?.[0];
 	const shutdown = captured.events.get("session_shutdown")?.[0];
 	const toolEnd = captured.events.get("tool_execution_end")?.[0];
@@ -41,7 +41,13 @@ beforeEach(() => {
 	overlayMock.moduleLoads = 0;
 });
 
-it("loads the overlay only when tasks need rendering and ignores stale imports", async () => {
+afterEach(() => {
+	if (vi.isFakeTimers()) vi.clearAllTimers();
+	vi.useRealTimers();
+});
+
+it("keeps overlay construction task-gated and ignores stale imports", async () => {
+	vi.useFakeTimers();
 	let releaseImport!: () => void;
 	overlayMock.importGate = new Promise<void>((resolve) => {
 		releaseImport = resolve;
@@ -49,8 +55,8 @@ it("loads the overlay only when tasks need rendering and ignores stale imports",
 	const staleLifecycle = await setup();
 	const staleCtx = createMockCtx({ hasUI: true, sessionId: "stale" });
 
-	// Registering the extension and starting an empty session must not evaluate
-	// the overlay module or touch the widget API.
+	// Registration and session start stay off the overlay graph's startup path
+	// and do not touch the widget API.
 	expect(overlayMock.moduleLoads).toBe(0);
 	await staleLifecycle.start({} as never, staleCtx as never);
 	expect(overlayMock.moduleLoads).toBe(0);
@@ -103,4 +109,89 @@ it("loads the overlay only when tasks need rendering and ignores stale imports",
 		expect.any(Function),
 		{ placement: "aboveEditor" },
 	);
+});
+
+it("drops a rejected overlay import memo so the next load retries", async () => {
+	const { makeTodoOverlayLoader } = await import("./index.js");
+	const healthyModule = { TodoOverlay: class {} } as unknown as typeof import("./todo-overlay.js");
+	let shouldFail = true;
+	const importer = vi.fn(async () => {
+		if (shouldFail) {
+			shouldFail = false;
+			throw new Error("transient overlay load failure");
+		}
+		return healthyModule;
+	});
+	const load = makeTodoOverlayLoader(importer);
+
+	await expect(load()).rejects.toThrow("transient overlay load failure");
+	await expect(load()).resolves.toBe(healthyModule);
+	expect(importer).toHaveBeenCalledTimes(2);
+});
+
+it("reports jiti's poisoned namespace shape instead of constructing undefined", async () => {
+	const { makeTodoOverlayLoader } = await import("./index.js");
+	const staleModule = { TodoOverlay: undefined } as unknown as typeof import("./todo-overlay.js");
+	const load = makeTodoOverlayLoader(async () => staleModule);
+
+	await expect(load()).rejects.toThrow("module cache is stale; restart Pi");
+});
+
+it("schedules the overlay pre-warm after startup", async () => {
+	vi.useFakeTimers();
+	const { PREWARM_DELAY_MS } = await import("./index.js");
+	const healthyModule = { TodoOverlay: class {} } as unknown as typeof import("./todo-overlay.js");
+	const importer = vi.fn(async () => healthyModule);
+	const lifecycle = await setup(importer);
+
+	expect(importer).not.toHaveBeenCalled();
+	await vi.advanceTimersByTimeAsync(PREWARM_DELAY_MS - 1);
+	expect(importer).not.toHaveBeenCalled();
+	await vi.advanceTimersByTimeAsync(1);
+	expect(importer).toHaveBeenCalledTimes(1);
+
+	const ctx = createMockCtx({ hasUI: true, sessionId: "empty" });
+	await lifecycle.start({} as never, ctx as never);
+	expect(ctx.ui.setWidget as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+});
+
+it("swallows a failed pre-warm, then retries on the first real update", async () => {
+	vi.useFakeTimers();
+	const { PREWARM_DELAY_MS } = await import("./index.js");
+	let shouldFail = true;
+	const overlayUpdate = vi.fn();
+	const healthyModule = {
+		TodoOverlay: class {
+			setUICtx(): void {}
+			resetCompletedDisplayState(): void {}
+			update(): void {
+				overlayUpdate();
+			}
+		},
+	} as unknown as typeof import("./todo-overlay.js");
+	const importer = vi.fn(async (): Promise<typeof import("./todo-overlay.js")> => {
+		if (shouldFail) {
+			shouldFail = false;
+			throw new Error("pre-warm load failure");
+		}
+		return healthyModule;
+	});
+	const lifecycle = await setup(importer);
+
+	await vi.advanceTimersByTimeAsync(PREWARM_DELAY_MS);
+	expect(importer).toHaveBeenCalledTimes(1);
+
+	const ctx = createMockCtx({ hasUI: true, sessionId: "retry" });
+	await lifecycle.start({} as never, ctx as never);
+	await lifecycle.tool.execute?.(
+		"tc",
+		{ action: "create", subject: "retry task" } as never,
+		undefined as never,
+		undefined as never,
+		ctx as never,
+	);
+	await lifecycle.toolEnd({ toolName: "todo", isError: false } as never, ctx as never);
+
+	expect(importer).toHaveBeenCalledTimes(2);
+	expect(overlayUpdate).toHaveBeenCalledTimes(1);
 });

--- a/packages/rpiv-todo/state/store.ts
+++ b/packages/rpiv-todo/state/store.ts
@@ -13,9 +13,9 @@ const sessions = new Map<string, TaskState>();
 
 /**
  * Ctx-less render pointer: which slot do the ctx-free readers (the overlay's
- * `getSnapshot()`, the tool's `renderCall()`) render? Set once at overlay
- * creation by the session that first built the overlay (creator-ownership —
- * see `index.ts`). A *distinct* concept from the three task-state mutation
+ * `getSnapshot()`, the tool's `renderCall()`) render? Set when the first UI
+ * session claims the foreground, before the overlay is loaded (creator-ownership
+ * — see `index.ts`). A *distinct* concept from the three task-state mutation
  * seams; it is not a 4th writer of task state.
  */
 let activeRenderSession = "";
@@ -91,7 +91,7 @@ export function getRenderState(): TaskState {
 	return slotFor(activeRenderSession);
 }
 
-/** Set the ctx-less render pointer (called at overlay creation in `index.ts`). */
+/** Set the ctx-less render pointer when the first UI session claims foreground. */
 export function setActiveRenderSession(sessionId: string): void {
 	activeRenderSession = sessionId;
 }

--- a/packages/rpiv-todo/todo-overlay.shortcut.test.ts
+++ b/packages/rpiv-todo/todo-overlay.shortcut.test.ts
@@ -19,8 +19,8 @@ function removeConfigFile(): void {
 // shortcut registration and handler guard ladder. registerTodo() builds a fresh
 // closure each call, so isolation is automatic given __resetState() clears the
 // store. The shortcut handler closes over the closure-local `todoOverlay` and
-// re-reads it at fire time — the session_start event is what (lazily) constructs
-// that overlay, so driving the event is what makes the toggle path reachable.
+// re-reads it at fire time. A successful mutation lazily constructs the overlay,
+// so driving session_start and tool_execution_end makes the toggle path reachable.
 function setup() {
 	__resetState();
 	const { pi, captured } = createMockPi();
@@ -84,16 +84,16 @@ describe("rpiv-todo — collapse/expand shortcut registration", () => {
 		expect(ctx.ui.setWidget as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
 	});
 
-	it("handler is a no-op when the overlay exists but the widget is not registered (!isRegistered, empty list)", async () => {
+	it("handler is a no-op when an empty session has not loaded the overlay", async () => {
 		const { captured, sessionStart } = setup();
-		// A UI-bearing session_start constructs the overlay, but with no tasks the
-		// widget never registers (auto-hide on empty) → isRegistered() is false.
+		// A UI-bearing empty session records the foreground binding without loading
+		// or registering the overlay.
 		const ctx = createMockCtx({ sessionId: "s1", hasUI: true });
 		await sessionStart?.({} as never, ctx as never);
 		expect(ctx.ui.setWidget as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
 
 		await captured.shortcuts.get("ctrl+shift+t")?.handler?.(ctx as never);
-		// Still unregistered — toggle never fired.
+		// Still unloaded and unregistered — toggle never fired.
 		expect(ctx.ui.setWidget as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
 	});
 

--- a/packages/rpiv-todo/todo.session-isolation.test.ts
+++ b/packages/rpiv-todo/todo.session-isolation.test.ts
@@ -116,9 +116,9 @@ describe("rpiv-todo — per-session todo store isolation (Phase 1 baseline)", ()
 			child as never,
 		);
 
-		// Creator-ownership: the render slot is still the parent's. (Phase 1 sets
-		// the pointer once at overlay creation; a child hits the !todoOverlay guard
-		// and cannot re-set it. NOTE: full child-rebind prevention is Phase 2.)
+		// Creator-ownership: the render slot is still the parent's. The first UI
+		// session claims the pointer before lazy overlay loading, and a child cannot
+		// re-set it. NOTE: full child-rebind prevention is Phase 2.
 		expect(getRenderState().tasks.map((t) => t.subject)).toEqual(["parent-task"]);
 		// Sanity: the child's task DID land in its own slot.
 		expect(getState("child").tasks.map((t) => t.subject)).toEqual(["child-task"]);


### PR DESCRIPTION
## Summary

- move the todo overlay and TUI graph off the synchronous extension startup path
- keep overlay construction and widget registration gated on visible foreground tasks
- pre-warm the module graph two seconds after registration while dependency paths are stable
- reset rejected imports, detect jiti's stale namespace shape, and preserve session-replacement guards

## Why

`rpiv-todo` previously imported the overlay during extension startup even though most sessions have no todos. Deferring that graph improves startup time. The delayed pre-warm closes the jiti cache-poisoning window without putting the graph back on the startup critical path.

## Before / After

Before, extension registration imported the overlay graph synchronously. A fully lazy import avoided that startup work, but one mid-session load failure could remain cached until Pi restarted.

After, registration remains lightweight, the graph pre-warms after startup, and rejected imports can retry. The overlay object and widget still do not exist until the foreground session has visible tasks.

## Performance

| Measurement | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Isolated overhead — Current | 95 ms | 78 ms | 17 ms (17.9%) |
| Isolated overhead — Home | 97 ms | 81 ms | 16 ms (16.5%) |
| Direct import | ~111 ms | ~89 ms | ~22 ms (19.8%) |

The hardening follow-up keeps the pre-warm outside startup. A five-run source-checkout comparison measured a `0 ms` median factory cost before and after the follow-up.

## Implementation

- the first UI-bearing session claims foreground ownership without constructing the overlay
- a lifecycle generation token prevents an import completed for a disposed session from binding stale UI state
- the loader memoizes successful imports, clears rejected promises, and reports a stale jiti namespace with restart guidance
- an unreferenced 2-second timer pre-warms only the module graph; it does not construct the overlay or register a widget

## Commit Notes

- `perf(rpiv-todo): lazy-load todo overlay`
  - Why: remove the overlay graph from synchronous extension startup
  - What changed: defer overlay loading and guard session replacement during an in-flight import
  - Implication: empty startup paths avoid overlay construction and widget work
- `fix(rpiv-todo): harden lazy overlay load`
  - Why: prevent jiti load failures from permanently poisoning the cached overlay promise
  - What changed: clear rejected imports, validate the loaded namespace, and pre-warm after startup
  - Implication: startup remains fast while mid-session dependency churn has a smaller failure window

## Testing

- `npm test -- --run packages/rpiv-todo` — 18 files, 218 tests passed
- `npx tsc --noEmit -p tsconfig.base.json`
- `npx biome check packages/rpiv-todo/index.ts packages/rpiv-todo/lazy-overlay.regression.test.ts`
- `npm run check:decision-codes`
