### PR TITLE
fix(rpiv-ask-user-question): Reduce token usage

### DIFF
--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -104,10 +104,9 @@ export function buildItemsForQuestion(question: QuestionData): WrappingSelectIte
 
 export const DEFAULT_PROMPT_SNIPPET = `Ask the user up to ${MAX_QUESTIONS} structured questions (${MIN_OPTIONS}-${MAX_OPTIONS} options each) when requirements are ambiguous`;
 export const DEFAULT_PROMPT_GUIDELINES: string[] = [
-	`Use ask_user_question whenever the user's request is underspecified and you cannot proceed without concrete decisions — you can ask up to ${MAX_QUESTIONS} questions per invocation.`,
-	`Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer ("Type something." row is appended automatically to every question) or press Esc to abandon the questionnaire.`,
-	`Set multiSelect: true when multiple answers are valid. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. The "Type something." row is appended to every single-select question regardless of whether any option carries a preview; in preview mode it expands to the full pane width while typing so the custom answer is not cramped into the narrow options column. If you recommend a specific option, make it the first option and append "(Recommended)" to its label.`,
-	"Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
+	`Reach for ask_user_question when the user's request is underspecified and you cannot proceed without concrete decisions.`,
+	`Ask everything in one call (up to ${MAX_QUESTIONS}); don't stack ask_user_question calls back-to-back.`,
+	`Use multiSelect when several answers can be valid; add an option preview when a mockup, snippet, diagram, or config would make a choice clearer.`,
 ];
 
 export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
@@ -115,25 +114,13 @@ export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 	pi.registerTool({
 		name: ASK_USER_QUESTION_TOOL_NAME,
 		label: "Ask User Question",
-		description: `Ask the user one or more structured questions during execution. Use when you need to:
-1. Gather user preferences or requirements
-2. Clarify ambiguous instructions
-3. Get decisions on implementation choices as you work
-4. Offer choices to the user about what direction to take
+		description: `Ask the user one or more structured questions during execution - preferences, requirements, ambiguities, implementation or direction decisions.
 
-Usage notes:
-- Users will always be able to type a custom answer ("Type something." row is appended automatically to every question) or press Esc to abandon the questionnaire. Do NOT author "Other" / "Type something." labels yourself — duplicates are rejected at runtime.
-- Use multiSelect: true to allow multiple answers to be selected for a question. It is always available on every question (even when options carry a \`preview\`), expanding to the full pane width while typing so the custom answer is not cramped into the narrow options column.
-- If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label.
+Each question takes ${MIN_OPTIONS}-${MAX_OPTIONS} options; each needs a label (1-5 words) and a description of the choice or its trade-offs. A "Type something." row and Esc-to-abandon are added to every question automatically — never author "Other" / "Type something." options (duplicates are rejected).
 
-Preview feature:
-Use the optional \`preview\` field on options when presenting concrete artifacts that users need to visually compare:
-- ASCII mockups of UI layouts or components
-- Code snippets showing different implementations
-- Diagram variations
-- Configuration examples
-
-Preview content is rendered as markdown in a monospace box. Multi-line text with newlines is supported. When any option has a preview, the UI switches to a side-by-side layout with a vertical option list on the left and preview on the right. Do not use previews for simple preference questions where labels and descriptions suffice. Note: previews are only supported for single-select questions (not multiSelect).`,
+- multiSelect: true allows selecting multiple options; available on every question, including ones with a \`preview\`.
+- To recommend an option, put it first and append "(Recommended)" to its label.
+- \`preview\` (single-select only): optional per-option markdown, rendered in a monospace box (multi-line ok), for artifacts the user must compare — ASCII mockups, code snippets, diagram variations, configs. Any option setting it switches the UI to a side-by-side layout (options left, preview right) that expands to full width while a custom answer is typed. Skip it when labels and descriptions suffice.`,
 		promptSnippet: guidance.promptSnippet ?? DEFAULT_PROMPT_SNIPPET,
 		promptGuidelines: guidance.promptGuidelines ?? DEFAULT_PROMPT_GUIDELINES,
 		parameters: QuestionParamsSchema,


### PR DESCRIPTION
The `description` and `promptGuidelines` previously restated each other. They serve different jobs - the description is "call it correctly" and rides in the tool schema on every request, while the guidelines are "choose it correctly" and land in a shared system-prompt list next to every other tool's guidelines.

This change:

* Moves the mechanical specs (option counts, label length, etc.) to live only in the description.
* Trim the guidelines down to just things needed for decision-making.

Savings:

* `guidelines`: ~70% (229 -> 69 tokens)
* `description`: ~40% (338 -> 209 tokens)