### PR TITLE
fix(rpiv-ask-user-question): preserve in-flight note when reopening the notes editor

### DIFF
--- a/packages/rpiv-ask-user-question/CHANGELOG.md
+++ b/packages/rpiv-ask-user-question/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Emit `rpiv:ask-user:blocked` (`{ active: boolean }`) while the questionnaire awaits input (TUI `ui.custom` and RPC dialog walker), and clear it in `finally` so external listeners (e.g. Herdr, after they subscribe) can show `blocked` instead of `working`.
 
 ### Fixed
+- The notes editor no longer discards an in-progress note when it is reopened before the option is confirmed.
 - Collapse toggles now ignore Kitty keyboard repeat and release events, preventing a tap from immediately reopening the questionnaire or a held key from toggling it rapidly in terminals such as cmux/Ghostty.
 
 ## [2.0.0] - 2026-07-21

--- a/packages/rpiv-ask-user-question/state/state-reducer.test.ts
+++ b/packages/rpiv-ask-user-question/state/state-reducer.test.ts
@@ -171,6 +171,32 @@ describe("reduce — notes_enter / notes_exit / notes_forward", () => {
 		]);
 	});
 
+	it("notes_enter seeds notesDraft from notesByTab when the option is not yet confirmed (regression: reopening cleared the note)", () => {
+		// User typed a note and pressed Enter (notes_exit) BEFORE confirming the option, so the
+		// note lives only in notesByTab — answers has no entry yet. Reopening the editor must
+		// rehydrate from notesByTab, not start empty (which would delete the note on next close).
+		const state = makeState({ notesByTab: new Map([[0, "pending note"]]) });
+		const r = reduce(state, { kind: "notes_enter" }, makeCtx());
+		expect(r.state.notesVisible).toBe(true);
+		expect(r.state.notesDraft).toBe("pending note");
+		expect(r.effects).toEqual([
+			{ kind: "set_notes_value", value: "pending note" },
+			{ kind: "set_notes_focused", focused: true },
+		]);
+	});
+
+	it("notes_enter prefers notesByTab over a committed answer.notes", () => {
+		const answers = new Map<number, QuestionAnswer>([
+			[0, { questionIndex: 0, question: "q", kind: "option", answer: "A", notes: "committed" }],
+		]);
+		const r = reduce(
+			makeState({ answers, notesByTab: new Map([[0, "in-flight edit"]]) }),
+			{ kind: "notes_enter" },
+			makeCtx(),
+		);
+		expect(r.state.notesDraft).toBe("in-flight edit");
+	});
+
 	it("notes_exit with empty notesDraft clears notesByTab + strips answer.notes", () => {
 		const answers = new Map<number, QuestionAnswer>([
 			[0, { questionIndex: 0, question: "q", kind: "option", answer: "A", notes: "old note" }],

--- a/packages/rpiv-ask-user-question/state/state-reducer.ts
+++ b/packages/rpiv-ask-user-question/state/state-reducer.ts
@@ -199,7 +199,11 @@ const multiConfirmHandler: Handler<"multi_confirm"> = (state, action, ctx) => {
 };
 
 const notesEnterHandler: Handler<"notes_enter"> = (state, _action, _ctx) => {
-	const value = state.answers.get(state.currentTab)?.notes ?? "";
+	// Prefer the in-flight side-band note (`notesByTab`) over the committed answer's note.
+	// Before the option is confirmed the note lives ONLY in `notesByTab`, so reading solely
+	// from `answers` made a second open of the editor start empty and silently drop the note
+	// on the next close. Mirrors the precedence already used by `switchTabResult`.
+	const value = state.notesByTab.get(state.currentTab) ?? state.answers.get(state.currentTab)?.notes ?? "";
 	return {
 		state: { ...state, notesVisible: true, notesDraft: value },
 		effects: [


### PR DESCRIPTION
Hi! Small fix for a note-loss edge case in the notes editor.

**What happens:** on a single-select question, press `n` on an option, type a note, Enter to close — then press `n` again *before confirming the option*. The editor comes up empty, and closing it deletes the note you just typed.

**Why:** `notesEnterHandler` seeds the editor only from `answers[tab].notes`, but before the option is confirmed the note lives only in `notesByTab`. Once a tab has a confirmed answer the bug is masked (`notes_exit` mirrors the note into the answer), which makes it easy to miss — it typically shows on a not-yet-answered tab in a multi-question dialog.

**Fix:** one line — read `notesByTab` first, the same precedence `switchTabResult` already uses:

```ts
const value = state.notesByTab.get(state.currentTab) ?? state.answers.get(state.currentTab)?.notes ?? "";
```

Includes two regression tests (fail on `main`, pass with the fix) and a CHANGELOG entry. Full package suite passes (550 tests), `biome check` and `tsc --noEmit` clean.

Thanks for the extension — the notes feature is exactly the "pick this option, but also…" affordance I was missing. 🙏
