### PR TITLE
Emit blocked state while questionnaire awaits input

### DIFF
--- a/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
@@ -286,8 +286,16 @@ describe("ask_user_question.execute — event emission", () => {
 			],
 		});
 
-		// Verify event is emitted BEFORE the dialog is shown
+		expect(mockEmit).toHaveBeenNthCalledWith(2, "herdr:blocked", {
+			active: true,
+			label: "Waiting for user response",
+		});
+		expect(mockEmit).toHaveBeenNthCalledWith(3, "herdr:blocked", { active: false });
+
+		// Both start events are emitted before the dialog; the clear follows it.
 		expect(mockEmit.mock.invocationCallOrder[0]).toBeLessThan(custom.mock.invocationCallOrder[0]);
+		expect(mockEmit.mock.invocationCallOrder[1]).toBeLessThan(custom.mock.invocationCallOrder[0]);
+		expect(mockEmit.mock.invocationCallOrder[2]).toBeGreaterThan(custom.mock.invocationCallOrder[0]);
 	});
 
 	it("does NOT emit event when UI is unavailable", async () => {

--- a/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
@@ -298,6 +298,43 @@ describe("ask_user_question.execute — event emission", () => {
 		expect(mockEmit.mock.invocationCallOrder[2]).toBeGreaterThan(custom.mock.invocationCallOrder[0]);
 	});
 
+	it("clears Herdr blocked lifecycle after cancellation and UI rejection", async () => {
+		const mockEmit = vi.fn();
+		const { pi, captured } = createMockPi({
+			events: { emit: mockEmit, on: vi.fn(() => () => {}) },
+		});
+		registerAskUserQuestionTool(pi);
+		const tool = captured.tools.get("ask_user_question")!;
+
+		const cancelled = await tool.execute?.(
+			"tc",
+			validParams() as never,
+			undefined as never,
+			undefined as never,
+			ctxWithCustom({ answers: [], cancelled: true }) as never,
+		);
+		expect(cancelled?.details).toMatchObject({ cancelled: true });
+
+		const rejected = createMockCtx({
+			hasUI: true,
+			ui: {
+				custom: vi.fn(async () => {
+					throw new Error("UI failed");
+				}),
+			} as never,
+		});
+		await expect(
+			tool.execute?.("tc", validParams() as never, undefined as never, undefined as never, rejected as never),
+		).rejects.toThrow("UI failed");
+
+		expect(mockEmit.mock.calls.filter(([name]) => name === "herdr:blocked")).toEqual([
+			["herdr:blocked", { active: true, label: "Waiting for user response" }],
+			["herdr:blocked", { active: false }],
+			["herdr:blocked", { active: true, label: "Waiting for user response" }],
+			["herdr:blocked", { active: false }],
+		]);
+	});
+
 	it("does NOT emit event when UI is unavailable", async () => {
 		const { pi, captured } = createMockPi();
 		registerAskUserQuestionTool(pi);

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -211,6 +211,7 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 				});
 			}
 
+			pi.events.emit("herdr:blocked", { active: true, label: "Waiting for user response" });
 			try {
 				const result = await ctx.ui.custom<QuestionnaireResult>(
 					(tui, theme, _kb, done) => {
@@ -256,6 +257,7 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 				return buildQuestionnaireResponse(result, typed);
 			} finally {
 				removeOverlayInputListener?.();
+				pi.events.emit("herdr:blocked", { active: false });
 			}
 		},
 	});


### PR DESCRIPTION
## Summary
- emit `herdr:blocked` while `ask_user_question` waits in its custom UI
- clear state in `finally`, including cancellation and errors
- cover lifecycle ordering with an execution test

Herdr\u2019s Pi integration already consumes this event, reporting `blocked` rather than `working` while a questionnaire needs human input. Installations without Herdr have no listener, so behavior is unchanged.

## Test
- `npx vitest run packages/rpiv-ask-user-question/ask-user-question.execute.test.ts`
- `./node_modules/.bin/biome check packages/rpiv-ask-user-question/ask-user-question.ts packages/rpiv-ask-user-question/ask-user-question.execute.test.ts`

## Note
Repository-wide coverage pre-push hook has 5 unrelated setup timeouts in this clone; targeted test passes.