### PR TITLE
fix(rpiv-todo): refresh overlay theme and status hierarchy

### DIFF
--- a/packages/rpiv-todo/todo-overlay.lifecycle.test.ts
+++ b/packages/rpiv-todo/todo-overlay.lifecycle.test.ts
@@ -185,11 +185,18 @@ describe("TodoOverlay — lifecycle", () => {
 		expect(setWidget).toHaveBeenCalledTimes(2);
 	});
 
-	it("factory invalidate() forces re-registration on next update()", async () => {
+	it("uses the current UI theme after invalidation without re-registering", async () => {
 		const { captured } = registerTool();
 		await seed(captured, [{ action: "create", subject: "a" }]);
 		const overlay = new TodoOverlay();
-		const ui = makeCtx();
+		const colorTheme = (label: string) => ({
+			...identityTheme,
+			fg: (color: string, text: string) => `<${label}:${color}>${text}</${label}:${color}>`,
+		});
+		const initialTheme = colorTheme("initial");
+		const factoryTheme = colorTheme("factory");
+		const switchedTheme = colorTheme("switched");
+		const ui = createMockUI({ theme: initialTheme as never }) as unknown as ExtensionUIContext;
 		overlay.setUICtx(ui);
 		overlay.update();
 		const setWidget = ui.setWidget as ReturnType<typeof vi.fn>;
@@ -197,11 +204,20 @@ describe("TodoOverlay — lifecycle", () => {
 			tui: { requestRender: () => void },
 			theme: typeof identityTheme,
 		) => { render: (w: number) => string[]; invalidate: () => void };
-		const widget = factory({ requestRender: vi.fn() }, identityTheme);
+		const requestRender = vi.fn();
+		const widget = factory({ requestRender }, factoryTheme);
+
+		expect(widget.render(200).join("\n")).toContain("<initial:accent>");
+		expect(widget.render(200).join("\n")).not.toContain("<factory:");
+
+		Object.assign(ui, { theme: switchedTheme });
 		widget.invalidate();
+		expect(widget.render(200).join("\n")).toContain("<switched:accent>");
+		expect(overlay.isRegistered()).toBe(true);
+
 		overlay.update();
-		expect(setWidget).toHaveBeenCalledTimes(2);
-		expect(typeof setWidget.mock.calls[1][1]).toBe("function");
+		expect(setWidget).toHaveBeenCalledTimes(1);
+		expect(requestRender).toHaveBeenCalledTimes(1);
 	});
 
 	it("resetCompletedDisplayState() lets replayed completed tasks be shown once again", async () => {

--- a/packages/rpiv-todo/todo-overlay.ts
+++ b/packages/rpiv-todo/todo-overlay.ts
@@ -64,13 +64,13 @@ export class TodoOverlay {
 		if (!this.widgetRegistered) {
 			this.uiCtx.setWidget(
 				WIDGET_KEY,
-				(tui, theme) => {
+				(tui, factoryTheme) => {
 					this.tui = tui;
 					return {
-						render: (width: number) => this.renderWidget(theme, width),
+						render: (width: number) => this.renderWidget(this.uiCtx?.theme ?? factoryTheme, width),
 						invalidate: () => {
-							this.widgetRegistered = false;
-							this.tui = undefined;
+							// No rendered strings are cached. Pi invalidates on theme changes;
+							// the next render reads uiCtx.theme.
 						},
 					};
 				},

--- a/packages/rpiv-todo/view/format.test.ts
+++ b/packages/rpiv-todo/view/format.test.ts
@@ -1,0 +1,44 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { Task } from "../tool/types.js";
+import { formatOverlayTaskLine } from "./format.js";
+
+const recordingTheme = {
+	fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
+	strikethrough: (text: string) => `<strike>${text}</strike>`,
+} as unknown as Theme;
+
+function task(overrides: Partial<Task> = {}): Task {
+	return {
+		id: 1,
+		subject: "quiet task",
+		status: "pending",
+		...overrides,
+	};
+}
+
+describe("formatOverlayTaskLine — semantic color hierarchy", () => {
+	it("keeps pending subjects primary while rendering IDs quietly", () => {
+		expect(formatOverlayTaskLine(task(), recordingTheme, true)).toBe(
+			"<dim>○</dim> <dim>#1</dim> <text>quiet task</text>",
+		);
+	});
+
+	it("emphasizes the current task while muting its supporting metadata", () => {
+		expect(
+			formatOverlayTaskLine(
+				task({ status: "in_progress", activeForm: "Working", blockedBy: [2, 3] }),
+				recordingTheme,
+				true,
+			),
+		).toBe(
+			"<warning>◐</warning> <dim>#1</dim> <accent>quiet task</accent> <muted>(Working)</muted> <muted>⛓ #2,#3</muted>",
+		);
+	});
+
+	it("mutes and strikes completed subjects", () => {
+		expect(formatOverlayTaskLine(task({ status: "completed" }), recordingTheme, false)).toBe(
+			"<success>✓</success> <strike><muted>quiet task</muted></strike>",
+		);
+	});
+});

--- a/packages/rpiv-todo/view/format.ts
+++ b/packages/rpiv-todo/view/format.ts
@@ -65,24 +65,25 @@ export function overlayStatusGlyph(status: TaskStatus, theme: Theme): string {
 }
 
 /**
- * Format a single task for the overlay (with theme + glyph + dep suffix).
- * Used by `TodoOverlay.formatTaskLine` post-refactor; behavior is unchanged.
+ * Format a single task row for the persistent overlay. The subject color
+ * reflects task state while IDs and supporting metadata stay visually quiet.
  */
 export function formatOverlayTaskLine(t: Task, theme: Theme, showId: boolean): string {
 	const glyph = overlayStatusGlyph(t.status, theme);
-	const subjectColor = t.status === "completed" || t.status === "deleted" ? "dim" : "text";
+	const subjectColor =
+		t.status === "in_progress" ? "accent" : t.status === "completed" || t.status === "deleted" ? "muted" : "text";
 	let subject = theme.fg(subjectColor, t.subject);
 	if (t.status === "completed" || t.status === "deleted") {
 		subject = theme.strikethrough(subject);
 	}
 	let line = `${glyph}`;
-	if (showId) line += ` ${theme.fg("accent", `#${t.id}`)}`;
+	if (showId) line += ` ${theme.fg("dim", `#${t.id}`)}`;
 	line += ` ${subject}`;
 	if (t.status === "in_progress" && t.activeForm) {
-		line += ` ${theme.fg("dim", `(${t.activeForm})`)}`;
+		line += ` ${theme.fg("muted", `(${t.activeForm})`)}`;
 	}
 	if (t.blockedBy && t.blockedBy.length > 0) {
-		line += ` ${theme.fg("dim", `⛓ ${t.blockedBy.map((id) => `#${id}`).join(",")}`)}`;
+		line += ` ${theme.fg("muted", `⛓ ${t.blockedBy.map((id) => `#${id}`).join(",")}`)}`;
 	}
 	return line;
 }


### PR DESCRIPTION
## Summary

- Render the todo overlay with the current `uiCtx.theme`, while keeping factory invalidation registration-neutral.
- Apply a quiet semantic hierarchy: emphasize in-progress subjects and mute IDs, completed subjects, and supporting metadata.
- Add focused tests for semantic tokens, theme switching, and invalidation registration neutrality.

## Test Plan

- `bunx vitest run --root ../.. packages/rpiv-todo`
- `bunx biome check --error-on-warnings packages/rpiv-todo/view/format.ts packages/rpiv-todo/view/format.test.ts packages/rpiv-todo/todo-overlay.ts packages/rpiv-todo/todo-overlay.lifecycle.test.ts`
- `bunx tsc --noEmit -p tsconfig.base.json`