### PR TITLE
fix(rpiv-ask-user-question,rpiv-pi): align custom-answer guidance

### DIFF
--- a/packages/rpiv-ask-user-question/README.md
+++ b/packages/rpiv-ask-user-question/README.md
@@ -19,9 +19,8 @@ Let the model ask you structured clarifying questions instead of guessing. `rpiv
 - **Per-option notes** - press `n` on a previewed option to attach a free-text note that travels back with the answer.
 - **Multi-select questions** - checkboxes with `Space` to toggle, Enter-as-toggle on rows, a `Next` sentinel to advance, and toggles persisted across tab switches.
 - **Submit tab** - review every answer before submitting; warns about unanswered questions and offers a Submit picker.
-- **Chat row on every tab** - redirect the conversation without leaving the dialog.
+- **Custom-answer row** - choose the automatically appended **"Type something."** row to enter a custom answer when no authored option fits; available on every single- and multi-select question, including preview mode.
 - **Terminal-row-aware overflow scroll** - when the dialog is taller than the terminal, the body scrolls between a sticky heading and sticky hints/border; overflow indicators (↑ / ↓ / ↕) show what's clipped.
-- **"Other" free-text fallback** - type a custom answer when no option fits; available on every single-select question, even in preview mode (the input expands to the full pane width while typing).
 - **Localized UI** - sentinel rows, hints, submit/cancel labels, review pane, and notes affordance display in the user's chosen language via `@juicesharp/rpiv-i18n`. Ships Deutsch / English / Español / Français / Português (PT) / Português (BR) / Русский / Українська; switch with `/languages` or `pi --locale <code>`. LLM-facing copy (tool description, schemas, errors) stays English by design.
 
 ## Screens
@@ -42,7 +41,7 @@ Then restart your Pi session.
 
 ### Optional: localization
 
-`rpiv-ask-user-question` works standalone - install only this package and you get the full English UI. Install `@juicesharp/rpiv-i18n` alongside it to flip sentinel labels, dialog hints, review-tab heading, and chat-summary lines to your active locale:
+`rpiv-ask-user-question` works standalone - install only this package and you get the full English UI. Install `@juicesharp/rpiv-i18n` alongside it to flip sentinel labels, dialog hints, and review-tab heading to your active locale:
 
 ```bash
 pi install npm:@juicesharp/rpiv-i18n
@@ -52,7 +51,7 @@ With the SDK present, locale resolves from `--locale <code>` → `~/.config/rpiv
 
 ## Tool
 
-- **`ask_user_question`** - present one or more structured questions, each with 2+ options, optional `multiSelect`, optional per-option `preview`, and a free-text "Other" fallback available on every single-select question (even with previews). Returns the user's selection(s) plus any notes. See the tool's `promptGuidelines` for usage policy.
+- **`ask_user_question`** - present one or more structured questions, each with 2+ options, optional `multiSelect`, optional per-option `preview`, and an automatically appended **"Type something."** custom-answer row on every question. Returns the user's selection(s) plus any notes. See the tool's `promptGuidelines` for usage policy.
 
 ### Schema
 
@@ -77,7 +76,7 @@ ask_user_question({
 })
 ```
 
-Reserved option labels (rejected at validation): `"Other"`, plus the runtime sentinels (`"Type something."`, `"Chat about this"`, `"Next →"`).
+Reserved option labels (rejected at validation): `"Other"` (reserved for compatibility), plus the runtime sentinels (`"Type something."`, `"Next"`).
 
 Returns:
 
@@ -88,15 +87,16 @@ Returns:
     answers: Array<{
       questionIndex: number,
       question: string,
-      kind: "option" | "custom" | "chat" | "multi",
+      kind: "option" | "custom" | "multi",
       answer: string | null,
       selected?: string[],         // present for multi-select
       notes?: string,              // free-text note, when typed
       preview?: string,            // echoed back when option carried a preview
     }>,
     cancelled: boolean,
-    error?: "no_ui" | "no_questions" | "empty_options" | "too_many_questions"
-          | "duplicate_question" | "duplicate_option_label" | "reserved_label",
+    error?: "no_ui" | "no_custom_ui" | "no_questions" | "empty_options" | "too_many_questions"
+          | "duplicate_question" | "duplicate_option_label" | "reserved_label"
+          | "session_load_failed" | "stale_module_cache",
   }
 }
 ```

--- a/packages/rpiv-ask-user-question/ask-user-question.guidance.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.guidance.test.ts
@@ -17,14 +17,21 @@ beforeEach(() => {
 	// test/setup.ts rmSyncs CONFIG_PATH in shared beforeEach
 });
 
-describe("DEFAULT_PROMPT_GUIDELINES — Phase 2 prompt copy", () => {
-	it("describes the 'Type something.' row as appended to EVERY question (no suppress clause)", () => {
+describe("DEFAULT_PROMPT_GUIDELINES — custom-answer contract", () => {
+	it("describes the Type something row as appended to every question without stale fallback terms", () => {
 		const joined = DEFAULT_PROMPT_GUIDELINES.join("\n");
-		expect(joined).toContain("appended automatically to every question");
-		expect(joined).not.toContain('suppresses the "Type something." row');
-		// Phase 1 already swapped the abandon clause to "Esc to abandon".
+		expect(joined).toContain('automatically appended "Type something." row on every question');
 		expect(joined).toContain("Esc to abandon");
+		expect(joined).not.toContain('"Other" free-text fallback');
+		expect(joined).not.toContain("Chat about this");
 	});
+});
+it("describes the all-question custom-answer contract in the registered tool", () => {
+	const { pi, captured } = createMockPi();
+	registerAskUserQuestionTool(pi);
+	const tool = captured.tools.get(TOOL_NAME)!;
+	expect(tool.description).toContain('automatically appended "Type something." row on every question');
+	expect(tool.description).toContain("reserved labels are rejected at runtime");
 });
 
 describe("registerAskUserQuestionTool — guidance overrides", () => {

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -105,8 +105,8 @@ export function buildItemsForQuestion(question: QuestionData): WrappingSelectIte
 export const DEFAULT_PROMPT_SNIPPET = `Ask the user up to ${MAX_QUESTIONS} structured questions (${MIN_OPTIONS}-${MAX_OPTIONS} options each) when requirements are ambiguous`;
 export const DEFAULT_PROMPT_GUIDELINES: string[] = [
 	`Use ask_user_question whenever the user's request is underspecified and you cannot proceed without concrete decisions — you can ask up to ${MAX_QUESTIONS} questions per invocation.`,
-	`Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer ("Type something." row is appended automatically to every question) or press Esc to abandon the questionnaire.`,
-	`Set multiSelect: true when multiple answers are valid. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. The "Type something." row is appended to every single-select question regardless of whether any option carries a preview; in preview mode it expands to the full pane width while typing so the custom answer is not cramped into the narrow options column. If you recommend a specific option, make it the first option and append "(Recommended)" to its label.`,
+	`Each question MUST have ${MIN_OPTIONS}-${MAX_OPTIONS} options. Every option requires a concise label (1-5 words) and a description explaining what the choice means or its trade-offs. The user can additionally type a custom answer via the automatically appended "Type something." row on every question, or press Esc to abandon the questionnaire. Do NOT author "Other" or "Type something." labels yourself — reserved labels are rejected at runtime.`,
+	`Set multiSelect: true when multiple answers are valid. Provide an options[].preview markdown string when an option benefits from richer side-by-side context (mockups, code snippets, diagrams, configs) — single-select only. The "Type something." row is appended to every question; in preview mode it expands to the full pane width while typing so the custom answer is not cramped into the narrow options column. If you recommend a specific option, make that the first option and append "(Recommended)" to its label.`,
 	"Do not stack multiple ask_user_question calls back-to-back — group all clarifying questions into one invocation.",
 ];
 
@@ -122,8 +122,8 @@ export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 4. Offer choices to the user about what direction to take
 
 Usage notes:
-- Users will always be able to type a custom answer ("Type something." row is appended automatically to every question) or press Esc to abandon the questionnaire. Do NOT author "Other" / "Type something." labels yourself — duplicates are rejected at runtime.
-- Use multiSelect: true to allow multiple answers to be selected for a question. It is always available on every question (even when options carry a \`preview\`), expanding to the full pane width while typing so the custom answer is not cramped into the narrow options column.
+- Users can type a custom answer via the automatically appended "Type something." row on every question or press Esc to abandon the questionnaire. Do NOT author "Other" or "Type something." labels yourself — reserved labels are rejected at runtime.
+- Use multiSelect: true when multiple answers are valid. The "Type something." row is available on every question, including when options carry a \`preview\`; in preview mode it expands to the full pane width while typing so the custom answer is not cramped into the narrow options column.
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label.
 
 Preview feature:

--- a/packages/rpiv-ask-user-question/index.ts
+++ b/packages/rpiv-ask-user-question/index.ts
@@ -1,6 +1,7 @@
 /**
  * rpiv-ask-user-question — Pi extension. Registers the `ask_user_question`
- * tool: a structured option selector with a free-text "Other" fallback.
+ * tool: a structured option selector with an automatically appended
+ * `Type something.` custom-answer row.
  *
  * Sentinel labels and TUI chrome strings localize at render time via the i18n
  * bridge. Strings are registered with rpiv-i18n here, once, at module init —

--- a/packages/rpiv-ask-user-question/tool/types.ts
+++ b/packages/rpiv-ask-user-question/tool/types.ts
@@ -27,8 +27,8 @@ export type SentinelLabel = (typeof SENTINEL_LABELS)[SentinelKind];
  * "Other" in CC; we reject it so the runtime sentinel is the single source
  * of truth) and has no runtime kind.
  *
- * Reserved unconditionally — multiSelect questions also reject these labels
- * even though the runtime sentinel is suppressed there.
+ * Reserved unconditionally — every question mode rejects these labels, even
+ * when a given runtime sentinel is not appended in that mode.
  *
  * Order is pinned by `types.test.ts:292` — keep the explicit
  * `["Other", other, next]` literal so consumers using

--- a/packages/rpiv-pi/skills/annotate-guidance/SKILL.md
+++ b/packages/rpiv-pi/skills/annotate-guidance/SKILL.md
@@ -140,10 +140,8 @@ You are tasked with generating architecture guidance files for a brownfield proj
 
    **Choosing question format:**
 
-   - **`ask_user_question` tool** — when your question has 2-4 concrete options from code analysis (pattern conflicts, integration choices, scope boundaries, priority overrides). The user can always pick "Other" for free-text. Example: Use the `ask_user_question` tool with the question "Found 2 mapping approaches — which should new code follow?". Options: "Manual mapping (Recommended)" (Used in OrderService (src/services/OrderService.ts:45) — 8 occurrences); "AutoMapper" (Used in UserService (src/services/UserService.ts:12) — 2 occurrences).
+   - **`ask_user_question` tool** — use `ask_user_question` with 2-4 concrete hypotheses. State observed behavior, `file:line` evidence, impact, and the decision; the automatic `Type something.` row accepts unexpected detail.
 
-   - **Free-text with ❓ Question: prefix** — when the question is open-ended and options can't be predicted (discovery, "what am I missing?", corrections). Example:
-     "❓ Question: Integration scanner found no background job registration for this area. Is that expected, or is there async processing I'm not seeing?"
 
    **Batching**: When you have 2-4 independent questions (answers don't depend on each other), you MAY batch them in a single `ask_user_question` call. Keep dependent questions sequential.
 

--- a/packages/rpiv-pi/skills/annotate-inline/SKILL.md
+++ b/packages/rpiv-pi/skills/annotate-inline/SKILL.md
@@ -138,10 +138,8 @@ You are tasked with generating CLAUDE.md files across a brownfield project. You 
 
    **Choosing question format:**
 
-   - **`ask_user_question` tool** — when your question has 2-4 concrete options from code analysis (pattern conflicts, integration choices, scope boundaries, priority overrides). The user can always pick "Other" for free-text. Example: Use the `ask_user_question` tool with the question "Found 2 mapping approaches — which should new code follow?". Options: "Manual mapping (Recommended)" (Used in OrderService (src/services/OrderService.ts:45) — 8 occurrences); "AutoMapper" (Used in UserService (src/services/UserService.ts:12) — 2 occurrences).
+   - **`ask_user_question` tool** — use `ask_user_question` with 2-4 concrete hypotheses. State observed behavior, `file:line` evidence, impact, and the decision; the automatic `Type something.` row accepts unexpected detail.
 
-   - **Free-text with ❓ Question: prefix** — when the question is open-ended and options can't be predicted (discovery, "what am I missing?", corrections). Example:
-     "❓ Question: Integration scanner found no background job registration for this area. Is that expected, or is there async processing I'm not seeing?"
 
    **Batching**: When you have 2-4 independent questions (answers don't depend on each other), you MAY batch them in a single `ask_user_question` call. Keep dependent questions sequential.
 

--- a/packages/rpiv-pi/skills/architecture-review/SKILL.md
+++ b/packages/rpiv-pi/skills/architecture-review/SKILL.md
@@ -68,7 +68,7 @@ The final artifact is blueprint-consumable per phase.
 
 ### Step 1: Identify the Target
 
-1. **Argument is empty:** use the `ask_user_question` tool with the following question: "What are we reviewing?". Header: "Target". Options: "Single module" (one package / project / crate / namespace directory); "Single subdirectory" (a subtree inside a module); "Single file" (deep review of one large file); "Other" (developer specifies path).
+1. **Argument is empty:** use the `ask_user_question` tool with the following question: "What are we reviewing?". Header: "Target". Options: "Single module" (one package / project / crate / namespace directory); "Single subdirectory" (a subtree inside a module); "Single file" (deep review of one large file). The automatic `Type something.` row accepts a custom target.
 
 2. **Validate the target exists**. Use `ls` via the Bash tool on the resolved path. If missing, ask for a corrected path.
 
@@ -235,7 +235,7 @@ Layers mirror dependency direction. Higher layers consume lower-layer vocabulary
    {One paragraph: what unifies these findings, what the theme thread delivers when implemented, what the closing finding is if any.}
    ```
 
-3. **Confirm grouping** via the `ask_user_question` tool: "{N} cross-cutting themes: {T1 — name; T2 — name; ...}. Approve grouping or adjust?". Header: "Themes". Options: "Approve grouping (Recommended)"; "Merge themes" (developer names which); "Split a theme" (developer names which); "Other".
+3. **Confirm grouping** via the `ask_user_question` tool: "{N} cross-cutting themes: {T1 — name; T2 — name; ...}. Approve grouping or adjust?". Header: "Themes". Options: "Approve grouping (Recommended)"; "Merge themes" (developer names which); "Split a theme" (developer names which). The automatic `Type something.` row captures another grouping request.
 
 ### Step 8: Consolidated Polish Plan
 
@@ -275,7 +275,7 @@ Phases are agent-driven: each one will be handed to `blueprint` → `implement`.
        Phase 6 (Public-API)
    ```
 
-6. **Confirm the plan + flip status.** Use the `ask_user_question` tool: "{N} phases ({F} findings across {Files} files). Approve or adjust?". Header: "Plan". Options: "Approve (Recommended)" (**rebuild the `phases:` frontmatter array from the `### Phase N — name` headings** — one `{ n, title, depends_on, blast_radius, effort }` entry per heading, in body order: `depends_on` from the dependency graph (Step 5, earlier phases only), `blast_radius` the phase's widest of `internal`/`public-API`/`on-disk`/`cross-module` (Step 3), `effort` `S`/`M`/`L`; e.g. `phases: [{ n: 1, title: Foundation, depends_on: [], blast_radius: internal, effort: S }, { n: 2, title: Vocabulary, depends_on: [1], blast_radius: internal, effort: M }]`; then Edit frontmatter `status: in-progress` → `status: ready`, proceed to Step 9); "Adjust phase boundaries" (describe); "Resequence phases" (describe); "Other".
+6. **Confirm the plan + flip status.** Use the `ask_user_question` tool: "{N} phases ({F} findings across {Files} files). Approve or adjust?". Header: "Plan". Options: "Approve (Recommended)" (**rebuild the `phases:` frontmatter array from the `### Phase N — name` headings** — one `{ n, title, depends_on, blast_radius, effort }` entry per heading, in body order: `depends_on` from the dependency graph (Step 5, earlier phases only), `blast_radius` the phase's widest of `internal`/`public-API`/`on-disk`/`cross-module` (Step 3), `effort` `S`/`M`/`L`; e.g. `phases: [{ n: 1, title: Foundation, depends_on: [], blast_radius: internal, effort: S }, { n: 2, title: Vocabulary, depends_on: [1], blast_radius: internal, effort: M }]`; then Edit frontmatter `status: in-progress` → `status: ready`, proceed to Step 9); "Adjust phase boundaries" (describe); "Resequence phases" (describe). The automatic `Type something.` row captures another adjustment.
 
 ### Step 9: Present and Chain
 
@@ -332,7 +332,7 @@ Spawn multiple agents in parallel when they're searching for different things. E
 
 ## Important Notes
 
-- **All checkpoints are `ask_user_question`** — no prose "ask the user". The tool always offers free-text via "Other"; don't author free-text prompts.
+- **All checkpoints are `ask_user_question`** — no prose "ask the user". The tool automatically appends the `Type something.` free-text row; do not author `Other` as an option.
 - **Read all in-scope files FULLY** in Step 5.1 — no limit/offset on the Read tool. Selective reads bias findings toward what you happened to load.
 - **Edit the artifact progressively in Step 5.4** — never batch all findings into one final write. The artifact is the durable checkpoint between sessions.
 - **Critical ordering:**

--- a/packages/rpiv-pi/skills/blueprint/SKILL.md
+++ b/packages/rpiv-pi/skills/blueprint/SKILL.md
@@ -170,13 +170,15 @@ Use the grounded-questions-one-at-a-time pattern. Use a **❓ Question:** prefix
 - Lead with the most architecturally significant ambiguity.
 - Every answer becomes a FIXED decision — no revisiting unless the developer explicitly asks.
 
+- Every ambiguity checkpoint MUST be self-contained: state observed behavior, at least one `file:line` evidence reference, why the decision matters, and 2-4 concrete decision options in the question or option descriptions.
+
 **Choosing question format:**
 
-- **`ask_user_question` tool** — when your question has 2-4 concrete options from code analysis (pattern conflicts, integration choices, scope boundaries, priority overrides). The user can always pick "Other" for free-text. Example:
+- **`ask_user_question` tool** — concrete options include evidence and trade-offs in every description. The user can type a custom answer through the automatically appended `Type something.` row; do not author `Other`. Example:
 
   > Use the `ask_user_question` tool with the following question: "Found 2 mapping approaches — which should new code follow?". Header: "Pattern". Options: "Manual mapping (Recommended)" (Used in OrderService (src/services/OrderService.ts:45) — 8 occurrences); "AutoMapper" (Used in UserService (src/services/UserService.ts:12) — 2 occurrences).
 
-- **Open-ended** (discovery, "what am I missing?", corrections) — still `ask_user_question`; offer your best 1-2 guesses and let "Other" carry the unpredictable answer.
+- **Open-ended** — still use `ask_user_question`; supply 2-4 concrete hypotheses with behavior, `file:line` evidence, impact, and decision context, then let the automatic `Type something.` row capture unanticipated detail.
 
 **Batching**: When you have 2-4 independent questions (answers don't depend on each other), you MAY batch them in a single `ask_user_question` call. Keep dependent questions sequential.
 

--- a/packages/rpiv-pi/skills/design-review/SKILL.md
+++ b/packages/rpiv-pi/skills/design-review/SKILL.md
@@ -54,7 +54,7 @@ The first tab-separated field is `<iso>` (use as `last_updated` when you edit a 
 
    Lead with the data types and interface surface — that is the contract the developer is signing off on.
 
-3. **Ask the developer to accept or adjust** with the `ask_user_question` tool. Question: "Proposed design across {N} slices ({F} files). Accept, or adjust a slice?". Header: "Design". Options: "Accept (Recommended)" (Proceed to synthesis — merge the per-slice designs into the plan); "Adjust a slice" (Change a slice's approach, interfaces, data types, or scope before synthesis — describe which slice and what). The developer's "Other"/adjust answer names the slice(s) and the change.
+3. **Ask the developer to accept or adjust** with the `ask_user_question` tool. Question: "Proposed design across {N} slices ({F} files). Accept, or adjust a slice?". Header: "Design". Options: "Accept (Recommended)" (Proceed to synthesis — merge the per-slice designs into the plan); "Adjust a slice" (Change a slice's approach, interfaces, data types, or scope before synthesis — describe which slice and what). The developer may use the automatically appended `Type something.` row to provide an unanticipated adjustment; do not author an `Other` option.
 
 4. **On Adjust — apply surgically and cascade, then re-present (loop back to Step 2).** Classify the change:
 

--- a/packages/rpiv-pi/skills/design/SKILL.md
+++ b/packages/rpiv-pi/skills/design/SKILL.md
@@ -156,13 +156,15 @@ Use the grounded-questions-one-at-a-time pattern. Use a **❓ Question:** prefix
 - Lead with the most architecturally significant ambiguity.
 - Every answer becomes a FIXED decision — no revisiting unless the developer explicitly asks.
 
+- Every ambiguity checkpoint MUST be self-contained: state observed behavior, at least one `file:line` evidence reference, why the decision matters, and 2-4 concrete decision options in the question or option descriptions.
+
 **Choosing question format:**
 
-- **`ask_user_question` tool** — when your question has 2-4 concrete options from code analysis (pattern conflicts, integration choices, scope boundaries, priority overrides). The user can always pick "Other" for free-text. Example:
+- **`ask_user_question` tool** — concrete options include evidence and trade-offs in every description. The user can type a custom answer through the automatically appended `Type something.` row; do not author `Other`. Example:
 
   > Use the `ask_user_question` tool with the following question: "Found 2 mapping approaches — which should new code follow?". Header: "Pattern". Options: "Manual mapping (Recommended)" (Used in OrderService (src/services/OrderService.ts:45) — 8 occurrences); "AutoMapper" (Used in UserService (src/services/UserService.ts:12) — 2 occurrences).
 
-- **Open-ended** (discovery, "what am I missing?", corrections) — still `ask_user_question`; offer your best 1-2 guesses and let "Other" carry the unpredictable answer.
+- **Open-ended** — still use `ask_user_question`; supply 2-4 concrete hypotheses with behavior, `file:line` evidence, impact, and decision context, then let the automatic `Type something.` row capture unanticipated detail.
 
 **Batching**: When you have 2-4 independent questions (answers don't depend on each other), you MAY batch them in a single `ask_user_question` call. Keep dependent questions sequential.
 

--- a/packages/rpiv-pi/skills/discover/SKILL.md
+++ b/packages/rpiv-pi/skills/discover/SKILL.md
@@ -55,7 +55,7 @@ The final artifact is research-compatible — its Decisions block is translated 
 
 2. **Detect input shape** — parse the input:
    - If the argument is an existing file path (resolves to a readable `.md` under `.rpiv/artifacts/`, or any path the user mentions for refinement context), read it FULLY using the Read tool WITHOUT limit/offset. Treat its content as baseline context — the interview surfaces gaps, missing requirements, and unstated assumptions relative to what's already documented.
-   - Otherwise → fresh-feature mode: the entire argument is the free-text feature description.
+   - Plain free-text input → fresh-feature mode: the entire argument is the free-text feature description.
 
 3. **Read any other files mentioned** in the prompt (tickets, docs, related artifacts, explicit `path:line` references) FULLY before proceeding.
 
@@ -71,8 +71,7 @@ Before any codebase probe, ask the foundational intent question. This is purely 
    - Frame: "What problem are you solving and who hits it?" / "What does success look like for the person experiencing this today?" — phrase it for the specific feature.
    - **No `(Recommended)` option.** The developer should generate the framing, not pick from a proposal.
    - **No `file:line` citations** — codebase has nothing to say about intent.
-   - Options should be open shapes (e.g., "End user / maintainer / operator / Other") that route the answer, not solution shapes.
-   - Always offer "Other" so the developer can free-text the real framing.
+   - Options should be open shapes (for example, "End user", "Maintainer", or "Operator") that route the answer, not solution shapes. The automatically appended `Type something.` row lets the developer supply a different framing; do not author an `Other` option.
 
 2. **Capture the answer in the developer's own words.** This text feeds into the FRD's Problem & Intent section verbatim — do not paraphrase into agent prose.
 
@@ -132,7 +131,7 @@ Walk the lazy tree depth-first, parent before child. Expand the next layer (buil
 
 2. **Recommended answer** (`scope` / `shape` / `detail`): derive from intent + Step 3 evidence + project conventions. Every non-intent question carries a recommendation labeled `(Recommended)`.
 
-3. **Ask via `ask_user_question`.** Lead with the recommended option. The "Other" option is automatic and handles open-ended answers.
+3. **Ask via `ask_user_question`.** Lead with the recommended authored option. The automatic `Type something.` custom-answer row handles open-ended answers; do not author an `Other` option.
 
 4. **Critical rules**:
    - Ask ONE question at a time. Wait for the answer before asking the next.

--- a/packages/rpiv-pi/skills/research/SKILL.md
+++ b/packages/rpiv-pi/skills/research/SKILL.md
@@ -144,7 +144,8 @@ Findings go into Precedents & Lessons. Otherwise skip and note "git history unav
 
 2. **Developer checkpoint — grounded questions one at a time:**
 
-   Start with grounded questions referencing real findings with file:line evidence. Ask ONE question at a time, waiting for the answer before the next. Use a **❓ Question:** prefix. Each question must pull NEW information from the developer — not confirm what you already found:
+   - Every ambiguity checkpoint MUST be self-contained: state observed behavior, at least one `file:line` evidence reference, why the decision matters, and 2-4 concrete decision options in the question or option descriptions.
+   Start with grounded questions referencing real findings with `file:line` evidence. Ask ONE question at a time, waiting for the answer before the next. Use a **❓ Question:** prefix. Each question must pull NEW information from the developer — not confirm what you already found:
 
    Every question MUST embed at least one `file:line` reference in the question text — not just in surrounding context. Examples:
 
@@ -162,15 +163,15 @@ Findings go into Precedents & Lessons. Otherwise skip and note "git history unav
    - **Pattern conflict**: "Found 2 implementations of {X} — which is canonical?" with options citing `file:line` + occurrence count
    - **Scope boundary**: "Question {N} references files {A,B,C} but analysis shows {D} is the real integration point. Extend scope?" with yes/no + "describe what I missed"
    - **Priority override**: "Questions Q1 and Q2 have competing implications for {area}. Which is load-bearing?" with options
-   - **Integration ambiguity**: "Found no connection between {X} and {Y}. Is there an indirect path?" — `ask_user_question`, "Other" carries the answer
+   - **Integration ambiguity**: "Found no connection between {X} and {Y} at `file:line`. This leaves {impact}. Should the feature wire through {A} or {B}?" — use `ask_user_question`; the automatically appended `Type something.` row captures unexpected custom input.
 
    **Choosing question format:**
 
-   - **`ask_user_question` tool** — when your question has 2-4 concrete options from code analysis (pattern conflicts, integration choices, scope boundaries, priority overrides). The user can always pick "Other" for free-text. Example:
+   - **`ask_user_question` tool** — when your question has 2-4 concrete options from code analysis (pattern conflicts, integration choices, scope boundaries, priority overrides). The automatically appended `Type something.` row captures custom input. Example:
 
      > Use the `ask_user_question` tool with the following question: "Found 2 patterns for retry logic — which is canonical?". Header: "Pattern". Options: "Event-sourced retry (Recommended)" (`src/events/orders.ts:45-67` — 3 hooks, matches precedent commit `abc123`); "Direct retry loop" (`src/services/OrderService.ts:112` — single use, no event traceability).
 
-   - **Open-ended** (discovery, "what am I missing?", corrections) — still `ask_user_question`; offer your best 1-2 guesses and let "Other" carry the unpredictable answer.
+   - **Open-ended** (discovery, "what am I missing?", corrections) — still use `ask_user_question`; supply 2-4 concrete hypotheses with behavior, `file:line` evidence, impact, and decision context, then let the automatic `Type something.` row capture unanticipated detail.
 
    **Anti-pattern** — do NOT dump a verbose paragraph mixing analysis with a trailing question:
 

--- a/packages/rpiv-pi/skills/resume-handoff/SKILL.md
+++ b/packages/rpiv-pi/skills/resume-handoff/SKILL.md
@@ -49,7 +49,7 @@ When this command is invoked:
 2. **If no parameters provided**, branch on the `recent handoffs:` listing in the Metadata block:
    - **Empty** — no handoffs exist; tell the user and ask for a path in prose.
    - **Exactly one entry** — confirm with `ask_user_question`: "Resume this handoff?" with options "Resume `<filename>` (Recommended)" and "Pick a different path". Do NOT call `ask_user_question` with a single option (the tool requires ≥2).
-   - **Two or more entries** — present the top 4 filenames as `ask_user_question` options (a free-text "Other" row is appended automatically by the tool; do not list it manually).
+   - **Two or more entries** — present the top 4 filenames as `ask_user_question` options. The tool automatically appends a `Type something.` free-text row; do not list it manually.
 
    Direct invocation alternative: `/skill:resume-handoff .rpiv/artifacts/handoffs/<filename>`
 

--- a/packages/rpiv-pi/skills/validate/SKILL.md
+++ b/packages/rpiv-pi/skills/validate/SKILL.md
@@ -62,7 +62,7 @@ When invoked:
    - Otherwise, branch on the `recent plans:` listing in the Metadata block:
      - **Empty** — no plans under `.rpiv/artifacts/plans/`; ask the user for a path in prose.
      - **Exactly one entry** — confirm with `ask_user_question`: "Validate this plan?" with options "Validate `<filename>` (Recommended)" and "Pick a different path".
-     - **Two or more entries** — present the top 4 filenames as `ask_user_question` options (a free-text "Other" row is appended automatically).
+     - **Two or more entries** — present the top 4 filenames as `ask_user_question` options. The tool automatically appends a `Type something.` free-text row; do not list it manually.
 
 3. **Read the implementation plan** completely
 


### PR DESCRIPTION
## Summary

- Align tool and README guidance with the automatic `Type something.` custom-answer row.
- Remove stale authored-`Other` guidance from active skills.
- Require grounded, self-contained questionnaire choices in planning guidance.
- Preserve questionnaire runtime behavior.

## Verification

- `npm test -- packages/rpiv-ask-user-question/ask-user-question.guidance.test.ts`
- `npm run check`
- `npm test`
- `! rg -n 'Other.*(automatic|free-text)|Chat about this|kind: "chat"' packages/rpiv-pi/skills packages/rpiv-ask-user-question/README.md`

Effect is that it greatly improved readability at gates.

<img width="1882" height="588" alt="image" src="https://github.com/user-attachments/assets/23eb9bc5-a56c-45ac-a888-999f822c228c" />

And multi-select working! Yey!

<img width="1046" height="435" alt="image" src="https://github.com/user-attachments/assets/d8a9d796-7315-4468-8435-3d5782d10f7d" />

