### PR TITLE
fix(rpiv-ask-user-question): ignore repeated collapse events

### DIFF
--- a/packages/rpiv-ask-user-question/CHANGELOG.md
+++ b/packages/rpiv-ask-user-question/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Collapse toggles now ignore Kitty keyboard repeat and release events, preventing a tap from immediately reopening the questionnaire or a held key from toggling it rapidly in terminals such as cmux/Ghostty.
+
 ## [2.0.0] - 2026-07-21
 
 ### Added

--- a/packages/rpiv-ask-user-question/ask-user-question.listener.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.listener.test.ts
@@ -20,7 +20,10 @@ const identityTheme = {
 	strikethrough: (s: string) => s,
 };
 
-const CTRL_RBRACKET = "\x1d"; // GS byte — what terminals send for Ctrl+]
+const CTRL_RBRACKET = "\x1d"; // GS byte — what legacy terminals send for Ctrl+]
+const KITTY_CTRL_RBRACKET_PRESS = "\x1b[93;5u";
+const KITTY_CTRL_RBRACKET_REPEAT = "\x1b[93;5:2u";
+const KITTY_CTRL_RBRACKET_RELEASE = "\x1b[93;5:3u";
 const ALT_O = "\x1bo"; // ESC-prefixed 'o' — legacy encoding for Alt+O
 
 const params = {
@@ -140,6 +143,27 @@ describe("ask_user_question — raw terminal collapse listener", () => {
 		await tool.execute?.("tc", params as never, undefined as never, undefined as never, ctx);
 		// execute's finally must tear the raw listener down once the tool resolves.
 		expect(removeListener).toHaveBeenCalledTimes(1);
+	});
+
+	it("toggles once for Kitty keyboard press, repeat, and release events", async () => {
+		const tool = register();
+		const handle = makeHandle();
+		const { ctx, listenerRef } = driveWithListener(handle, (done) => {
+			expect(listenerRef.current?.(KITTY_CTRL_RBRACKET_PRESS)).toEqual({ consume: true });
+			expect(handle.isHidden()).toBe(true);
+
+			// Repeat and release still belong to the collapse binding, so consume them
+			// without toggling or leaking them into the newly focused chat editor.
+			expect(listenerRef.current?.(KITTY_CTRL_RBRACKET_REPEAT)).toEqual({ consume: true });
+			expect(handle.isHidden()).toBe(true);
+			expect(listenerRef.current?.(KITTY_CTRL_RBRACKET_RELEASE)).toEqual({ consume: true });
+			expect(handle.isHidden()).toBe(true);
+
+			expect(listenerRef.current?.(KITTY_CTRL_RBRACKET_PRESS)).toEqual({ consume: true });
+			expect(handle.isHidden()).toBe(false);
+			done({ answers: [], cancelled: true });
+		});
+		await tool.execute?.("tc", params as never, undefined as never, undefined as never, ctx);
 	});
 
 	it("ignores non-matching keys", async () => {

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { matchesKey } from "@earendil-works/pi-tui";
+import { isKeyRelease, isKeyRepeat, matchesKey } from "@earendil-works/pi-tui";
 import { loadConfig, resolveCollapseKey, validateGuidanceFields } from "./config.js";
 import { ASK_USER_PROMPT_EVENT, type AskUserPromptEventPayload } from "./events.js";
 // Static import is fine — rpc-fallback pulls only types + the i18n bridge,
@@ -202,6 +202,10 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 					// toggling the questionnaire from underneath it.
 					if (!handle.isHidden() && !handle.isFocused()) return undefined;
 					if (!matchesKey(data, collapseKey as Parameters<typeof matchesKey>[1])) return undefined;
+					// Kitty-protocol terminals report press, repeat, and release separately.
+					// Toggle only on the initial press so a tap does not immediately reopen
+					// the overlay and a held key does not toggle it repeatedly.
+					if (isKeyRelease(data) || isKeyRepeat(data)) return { consume: true };
 					sessionRef.current?.toggleCollapsedExternal();
 					if (handle.isHidden() && !hasAnnouncedHide) {
 						hasAnnouncedHide = true;


### PR DESCRIPTION
## Summary

- Ignore Kitty keyboard repeat and release events in the raw collapse listener.
- Consume those matching events so they do not leak into the chat editor after the overlay hides.
- Add regression coverage for press/repeat/release sequences and document the fix in the changelog.

## Why

Terminals such as cmux/Ghostty support Kitty keyboard event reporting, so a single `Ctrl+]` interaction arrives as separate press, repeat, and release events. `matchesKey` matches all of them, while Pi's normal key-release filtering happens after raw terminal listeners. The questionnaire therefore hid on press and immediately reopened on release; holding the key toggled it repeatedly.

This keeps the existing overlay design and makes the collapse workaround reliable in enhanced-keyboard-protocol terminals.

Related to #47.

## Verification

- `npm run check`
- `npx vitest run packages/rpiv-ask-user-question` — 30 files, 559 tests passed
- Pre-push full coverage suite — 241 files, 4,376 tests passed
- Manually confirmed the equivalent local patch in cmux 0.64.20
