### PR TITLE
fix(rpiv-ask-user-question): guard missing collapseKey after in-process package update

### DIFF
--- a/packages/rpiv-ask-user-question/state/key-router.test.ts
+++ b/packages/rpiv-ask-user-question/state/key-router.test.ts
@@ -742,4 +742,17 @@ describe("routeKey — collapse/expand (Ctrl+] toggle + collapsed-mode lockout)"
 		const runtime = makeRuntime({ collapseKey: "off" });
 		expect(routeKey(BYTE_CTRL_RBRACKET, makeState(), runtime)).not.toEqual({ kind: "toggle_collapsed" });
 	});
+
+	it("treats a missing collapseKey as disabled instead of throwing after an in-process package update", () => {
+		// A Pi process can retain the pre-collapse outer module while a package update
+		// replaces the lazily imported QuestionnaireSession graph on disk. The old
+		// constructor call has no collapseKey field, so runtime receives undefined at
+		// runtime despite the TypeScript contract. Never pass that value to matchesKey:
+		// pi-tui's parseKeyId calls toLowerCase() and would terminate the whole process.
+		const runtime = makeRuntime() as unknown as { collapseKey?: string };
+		delete runtime.collapseKey;
+
+		expect(() => routeKey(BYTE_CTRL_RBRACKET, makeState(), runtime as QuestionnaireRuntime)).not.toThrow();
+		expect(routeKey(BYTE_CTRL_RBRACKET, makeState(), runtime as QuestionnaireRuntime)).toEqual({ kind: "ignore" });
+	});
 });

--- a/packages/rpiv-ask-user-question/state/key-router.ts
+++ b/packages/rpiv-ask-user-question/state/key-router.ts
@@ -142,7 +142,17 @@ export function routeKey(data: string, state: QuestionnaireState, runtime: Quest
 	// in-process. It is, however, awkward on keyboard layouts where `]` is on the
 	// shifted layer (Latin American `es-AR`/`es-MX` require `Ctrl+Shift+}` for `Ctrl+]`)
 	// — use the `collapseKey` config field to override.
-	if (runtime.collapseKey !== "off" && matchesKey(data, runtime.collapseKey as Parameters<typeof matchesKey>[1])) {
+	// Treat a missing/non-string key as disabled. This can occur at runtime when
+	// a long-lived Pi process retains an older outer module while a package update
+	// replaces the lazily imported QuestionnaireSession graph on disk. Passing
+	// undefined into matchesKey reaches parseKeyId().toLowerCase() and crashes the
+	// entire host process, so keep the runtime boundary defensive even though the
+	// TypeScript contract requires a string.
+	if (
+		typeof runtime.collapseKey === "string" &&
+		runtime.collapseKey !== "off" &&
+		matchesKey(data, runtime.collapseKey as Parameters<typeof matchesKey>[1])
+	) {
 		return { kind: "toggle_collapsed" };
 	}
 


### PR DESCRIPTION
## Summary

Guard the questionnaire key router against a missing/non-string `collapseKey` before calling `pi-tui`'s `matchesKey`.

## Root cause

A long-lived Pi process can keep the pre-collapse `ask-user-question.ts` module in memory while an on-disk package update replaces the lazily imported `QuestionnaireSession` graph. The older constructor call omits `collapseKey`, so the newer router receives `undefined` at runtime. Passing that into `matchesKey` reaches `parseKeyId(undefined).toLowerCase()` and terminates the entire Pi process on the first keypress.

The TypeScript contract cannot prevent this cross-version runtime state, so the routing boundary needs a runtime type guard.

## Tests

- Added a regression test that deletes `collapseKey` from the runtime object and verifies Ctrl+] does not throw and falls through as ignored.
- `npx vitest run packages/rpiv-ask-user-question` — 560 passing
- `npx tsc --noEmit -p tsconfig.base.json` — clean
- `./node_modules/.bin/biome check packages/rpiv-ask-user-question/state/key-router.ts packages/rpiv-ask-user-question/state/key-router.test.ts` — clean
