### PR TITLE
feat(rpiv-advisor): fallbackModels — retry the advisor on failure/refusal

### DIFF
--- a/packages/rpiv-advisor/CHANGELOG.md
+++ b/packages/rpiv-advisor/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `fallbackModels` config key: an ordered list of `"provider/modelId"` reviewers the advisor tries when the primary call fails or the model declines. A classifier refusal reaches the extension as `stopReason: "error"` (pi-ai collapses Anthropic's `"refusal"`), so refusals trigger the fallback along with auth failures, thrown errors, and other errors. Intentional aborts do not consume a fallback; if every model fails the last failure is returned. Result `details` gain `fellBackFrom` (the primary) when a fallback served. Config-file driven and preserved across `/advisor` saves. See rpiv-mono#135.
+
 ## [2.1.0] - 2026-07-23
 
 ### Changed

--- a/packages/rpiv-advisor/CHANGELOG.md
+++ b/packages/rpiv-advisor/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- `fallbackModels` config key: an ordered list of `"provider/modelId"` reviewers the advisor tries when the primary call fails or the model declines. A classifier refusal reaches the extension as `stopReason: "error"` (pi-ai collapses Anthropic's `"refusal"`), so refusals trigger the fallback along with auth failures, thrown errors, and other errors. Intentional aborts do not consume a fallback; if every model fails the last failure is returned. Result `details` gain `fellBackFrom` (the primary) when a fallback served. Config-file driven and preserved across `/advisor` saves. See rpiv-mono#135.
+- `fallbackModels` config key: an ordered list of `"provider/modelId"` reviewers the advisor tries when the primary call fails or the model declines. A classifier refusal reaches the extension as `stopReason: "error"` (pi-ai collapses Anthropic's `"refusal"`), so refusals trigger the fallback along with auth failures, thrown errors, and other errors. Intentional aborts do not consume a fallback; if every model fails the last failure is returned. Result `details` gain `fellBackFrom` (the primary) whenever a fallback was attempted. The chain is resolved at session start and re-resolved on every `/advisor` primary change, deduped on the canonical key so legacy colon-form entries cannot smuggle in the primary. Config-file driven and preserved across `/advisor` saves. See rpiv-mono#135.
 
 ## [2.1.0] - 2026-07-23
 

--- a/packages/rpiv-advisor/README.md
+++ b/packages/rpiv-advisor/README.md
@@ -106,15 +106,17 @@ refuses again — you want a different model. `fallbackModels` is an ordered lis
 of reviewers the advisor tries, in order, when the primary call fails or the
 model declines:
 
-- Each entry is resolved to a model at session start; unknown or duplicate
-  entries are skipped.
+- Each entry is resolved to a model at session start, and re-resolved whenever
+  the primary changes through `/advisor`; unknown or duplicate entries
+  (including the primary itself, in either key form) are skipped.
 - The chain advances on a hard failure of an attempt: an auth failure, a thrown
   error, or `stopReason: "error"`. Pi maps an Anthropic refusal to
   `stopReason: "error"`, so refusals trigger the fallback too.
 - An intentional abort (user cancel) stops immediately and does not consume a
   fallback. If every model fails, the last failure is returned.
-- The result's `details.advisorModel` names the model that answered, and
-  `details.fellBackFrom` names the primary when a fallback served.
+- The result's `details.advisorModel` names the model that served the call (on
+  failure, the last one attempted), and `details.fellBackFrom` names the
+  primary whenever a fallback was attempted.
 
 ## Reference
 

--- a/packages/rpiv-advisor/README.md
+++ b/packages/rpiv-advisor/README.md
@@ -80,11 +80,13 @@ write leaves your previous selection untouched and tells you so.
 | `modelKey` | The reviewer model, as `"provider/modelId"`. Written by `/advisor`. | absent — advisor off |
 | `effort` | Reasoning effort for the reviewer: `minimal`, `low`, `medium`, `high`, `xhigh`. Written by `/advisor`. | absent — no reasoning sent |
 | `disabledForModels` | Executor models the advisor is stripped for. Plain strings block at any effort; `{ "model": "…", "minEffort": "…" }` blocks only at or above that effort. | `[]` |
+| `fallbackModels` | Ordered `"provider/modelId"` reviewers tried when the primary call fails or the model declines. See below. | `[]` |
 
 ```json
 {
-  "modelKey": "anthropic/claude-opus-4-5",
+  "modelKey": "anthropic/claude-fable-5",
   "effort": "high",
+  "fallbackModels": ["anthropic/claude-opus-4-8"],
   "disabledForModels": [
     "anthropic/claude-opus-4-5",
     { "model": "openai/gpt-5.2", "minEffort": "high" }
@@ -93,7 +95,26 @@ write leaves your previous selection untouched and tells you so.
 ```
 
 `/advisor` only rewrites `modelKey` and `effort`, so hand-edited keys —
-`disabledForModels` and the `guidance` overrides — survive every save.
+`fallbackModels`, `disabledForModels`, and the `guidance` overrides — survive
+every save.
+
+### Fallback models
+
+Safety-tier reviewers (Claude Fable 5, Opus 5) can decline a request with a
+classifier refusal. A refusal is deterministic, so re-asking the same model
+refuses again — you want a different model. `fallbackModels` is an ordered list
+of reviewers the advisor tries, in order, when the primary call fails or the
+model declines:
+
+- Each entry is resolved to a model at session start; unknown or duplicate
+  entries are skipped.
+- The chain advances on a hard failure of an attempt: an auth failure, a thrown
+  error, or `stopReason: "error"`. Pi maps an Anthropic refusal to
+  `stopReason: "error"`, so refusals trigger the fallback too.
+- An intentional abort (user cancel) stops immediately and does not consume a
+  fallback. If every model fails, the last failure is returned.
+- The result's `details.advisorModel` names the model that answered, and
+  `details.fellBackFrom` names the primary when a fallback served.
 
 ## Reference
 

--- a/packages/rpiv-advisor/advisor.command.test.ts
+++ b/packages/rpiv-advisor/advisor.command.test.ts
@@ -10,12 +10,14 @@ vi.mock("./advisor-ui.js", () => ({
 import {
 	ADVISOR_TOOL_NAME,
 	getAdvisorEffort,
+	getAdvisorFallbacks,
 	getAdvisorModel,
 	registerAdvisorBeforeAgentStart,
 	registerAdvisorCommand,
 	registerModelSelectHandler,
 	registerThinkingLevelSelectHandler,
 	restoreAdvisorState,
+	setAdvisorFallbacks,
 	setAdvisorModel,
 	setDisabledForModels,
 } from "./advisor/index.js";
@@ -657,5 +659,37 @@ describe("restoreAdvisorState — effort-aware blocklist", () => {
 		restoreAdvisorState(ctx as never, pi);
 		expect(getAdvisorModel()).toBe(modelA);
 		expect(pi.setActiveTools).toHaveBeenCalledWith(expect.arrayContaining([ADVISOR_TOOL_NAME]));
+	});
+});
+
+describe("/advisor — fallback chain maintenance", () => {
+	async function writeConfig(contents: object) {
+		const { writeFileSync, mkdirSync } = await import("node:fs");
+		const { dirname, join } = await import("node:path");
+		const configPath = join(process.env.HOME!, ".config", "rpiv-advisor", "advisor.json");
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(configPath, JSON.stringify(contents));
+	}
+
+	it("re-resolves fallbacks on enable, excluding the new primary", async () => {
+		// The chain resolved at session_start excluded the then-current primary.
+		// Picking a model that is itself listed in fallbackModels must not leave
+		// it in its own chain, and the remaining entries must be re-resolved.
+		await writeConfig({ modelKey: "x/y", fallbackModels: ["anthropic/opus", "anthropic/sonnet"] });
+		vi.mocked(showAdvisorPicker).mockResolvedValueOnce("anthropic/opus");
+		const { captured } = register();
+		const ctx = createMockCtx({ hasUI: true, models: [modelA, modelBlocked] });
+		await captured.commands.get("advisor")?.handler("", ctx as never);
+		expect(getAdvisorModel()).toEqual(modelA);
+		expect(getAdvisorFallbacks()).toEqual([modelBlocked]);
+	});
+
+	it("clears the fallback chain on disable", async () => {
+		setAdvisorFallbacks([modelBlocked] as never);
+		vi.mocked(showAdvisorPicker).mockResolvedValueOnce("__no_advisor__");
+		const { captured } = register();
+		const ctx = createMockCtx({ hasUI: true, models: [modelA] });
+		await captured.commands.get("advisor")?.handler("", ctx as never);
+		expect(getAdvisorFallbacks()).toEqual([]);
 	});
 });

--- a/packages/rpiv-advisor/advisor.config.test.ts
+++ b/packages/rpiv-advisor/advisor.config.test.ts
@@ -1,7 +1,7 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
-import { validateDisabledForModels } from "./advisor/config.js";
+import { validateDisabledForModels, validateFallbackModels } from "./advisor/config.js";
 import { loadAdvisorConfig, saveAdvisorConfig } from "./advisor/index.js";
 
 const CONFIG_PATH = join(process.env.HOME!, ".config", "rpiv-advisor", "advisor.json");
@@ -121,5 +121,22 @@ describe("validateDisabledForModels", () => {
 				"openai:gpt",
 			]),
 		).toEqual(["anthropic:opus", { model: "anthropic:sonnet", minEffort: "high" }, "openai:gpt"]);
+	});
+});
+
+describe("validateFallbackModels", () => {
+	it("returns [] for non-array input", () => {
+		expect(validateFallbackModels(undefined)).toEqual([]);
+		expect(validateFallbackModels(null)).toEqual([]);
+		expect(validateFallbackModels("a/m")).toEqual([]);
+		expect(validateFallbackModels({ 0: "a/m" })).toEqual([]);
+	});
+
+	it("drops empty-string and non-string entries", () => {
+		expect(validateFallbackModels(["", 42, null, undefined, { model: "a/m" }, true])).toEqual([]);
+	});
+
+	it("preserves order of valid entries while dropping invalid", () => {
+		expect(validateFallbackModels(["a/m", "", "b:n", 7, "c/o"])).toEqual(["a/m", "b:n", "c/o"]);
 	});
 });

--- a/packages/rpiv-advisor/advisor.execute.test.ts
+++ b/packages/rpiv-advisor/advisor.execute.test.ts
@@ -309,3 +309,41 @@ describe("executeAdvisor — fallback chain", () => {
 		expect(completeSimple).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe("executeAdvisor — fallback chain, auth failures", () => {
+	it("advances past a primary auth failure to a fallback", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		setAdvisorFallbacks([{ provider: "b", id: "n" }] as never);
+		vi.mocked(completeSimple).mockResolvedValueOnce(resp({ text: "fallback advice" }) as never);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		(ctx.modelRegistry.getApiKeyAndHeaders as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+			ok: false,
+			error: "bad config",
+		});
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+		expect(r?.content[0]).toMatchObject({ type: "text", text: "fallback advice" });
+		expect(r?.details).toMatchObject({ advisorModel: "b:n", fellBackFrom: "a:m" });
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns the fallback's auth failure when every model fails auth", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		setAdvisorFallbacks([{ provider: "b", id: "n" }] as never);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		(ctx.modelRegistry.getApiKeyAndHeaders as ReturnType<typeof vi.fn>)
+			.mockResolvedValueOnce({ ok: false, error: "primary bad" })
+			.mockResolvedValueOnce({ ok: true, apiKey: undefined, headers: {} });
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("no API key") });
+		expect(r?.details).toMatchObject({
+			errorMessage: "no API key for b",
+			advisorModel: "b:n",
+			fellBackFrom: "a:m",
+		});
+		expect(completeSimple).not.toHaveBeenCalled();
+	});
+});

--- a/packages/rpiv-advisor/advisor.execute.test.ts
+++ b/packages/rpiv-advisor/advisor.execute.test.ts
@@ -34,7 +34,7 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
 
 import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext } from "@earendil-works/pi-coding-agent";
-import { registerAdvisorTool, setAdvisorModel } from "./advisor/index.js";
+import { registerAdvisorTool, setAdvisorFallbacks, setAdvisorModel } from "./advisor/index.js";
 
 function resp(input: { text?: string; stopReason?: "done" | "aborted" | "error" | "toolUse"; errorMessage?: string }) {
 	return {
@@ -230,5 +230,82 @@ describe("executeAdvisor — auth envelopes", () => {
 		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
 		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("no API key") });
 		expect(r?.details).toMatchObject({ errorMessage: "no API key for a", advisorModel: "a:m" });
+	});
+});
+
+describe("executeAdvisor — fallback chain", () => {
+	it("falls back to the next model when the primary declines (refusal maps to error)", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		setAdvisorFallbacks([{ provider: "b", id: "n" }] as never);
+		vi.mocked(completeSimple)
+			.mockResolvedValueOnce(resp({ stopReason: "error", errorMessage: "This request was declined" }) as never)
+			.mockResolvedValueOnce(resp({ text: "fallback advice" }) as never);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+		expect(r?.content[0]).toMatchObject({ type: "text", text: "fallback advice" });
+		expect(r?.details).toMatchObject({ advisorModel: "b:n", fellBackFrom: "a:m" });
+		expect(completeSimple).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns the last failure envelope when every model declines", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		setAdvisorFallbacks([{ provider: "b", id: "n" }] as never);
+		vi.mocked(completeSimple)
+			.mockResolvedValueOnce(resp({ stopReason: "error", errorMessage: "primary refused" }) as never)
+			.mockResolvedValueOnce(resp({ stopReason: "error", errorMessage: "fallback refused" }) as never);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("fallback refused") });
+		expect(r?.details).toMatchObject({
+			stopReason: "error",
+			errorMessage: "fallback refused",
+			advisorModel: "b:n",
+			fellBackFrom: "a:m",
+		});
+		expect(completeSimple).toHaveBeenCalledTimes(2);
+	});
+
+	it("falls back when the primary throws", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		setAdvisorFallbacks([{ provider: "b", id: "n" }] as never);
+		vi.mocked(completeSimple)
+			.mockRejectedValueOnce(new Error("network boom"))
+			.mockResolvedValueOnce(resp({ text: "recovered" }) as never);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+		expect(r?.content[0]).toMatchObject({ text: "recovered" });
+		expect(r?.details).toMatchObject({ advisorModel: "b:n", fellBackFrom: "a:m" });
+		expect(completeSimple).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not fall back on an intentional abort", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		setAdvisorFallbacks([{ provider: "b", id: "n" }] as never);
+		vi.mocked(completeSimple).mockResolvedValueOnce(resp({ stopReason: "aborted" }) as never);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+		expect(r?.details).toMatchObject({ stopReason: "aborted", errorMessage: "aborted" });
+		expect(completeSimple).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not consult fallbacks when the primary succeeds", async () => {
+		setAdvisorModel({ provider: "a", id: "m" } as never);
+		setAdvisorFallbacks([{ provider: "b", id: "n" }] as never);
+		vi.mocked(completeSimple).mockResolvedValueOnce(resp({ text: "primary advice" }) as never);
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+		expect(r?.content[0]).toMatchObject({ text: "primary advice" });
+		expect(r?.details).not.toHaveProperty("fellBackFrom");
+		expect(completeSimple).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/rpiv-advisor/advisor.restore.test.ts
+++ b/packages/rpiv-advisor/advisor.restore.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	__resetAdvisorAnnounced,
 	getAdvisorEffort,
+	getAdvisorFallbacks,
 	getAdvisorModel,
 	restoreAdvisorState,
 	setAdvisorEffort,
+	setAdvisorFallbacks,
 	setAdvisorModel,
 } from "./advisor/index.js";
 
@@ -219,5 +221,41 @@ describe("restoreAdvisorState", () => {
 
 			expect(notify).toHaveBeenCalledTimes(1);
 		});
+	});
+});
+
+describe("restoreAdvisorState — fallback resolution", () => {
+	const primary = { provider: "a", id: "m", name: "M" } as never;
+	const fallbackB = { provider: "b", id: "n", name: "N" } as never;
+	const fallbackC = { provider: "c", id: "o", name: "O" } as never;
+	const registryModels = [primary, fallbackB, fallbackC] as never[];
+
+	it("resolves fallback keys in order, skipping unknown and unparseable entries", () => {
+		writeConfig({ modelKey: "a/m", fallbackModels: ["b/n", "zz/unknown", "not-a-key", "c/o"] });
+		const { pi } = createMockPi();
+		restoreAdvisorState(createMockCtx({ models: registryModels }), pi);
+		expect(getAdvisorFallbacks()).toEqual([fallbackB, fallbackC]);
+	});
+
+	it("excludes the primary even when listed in the legacy colon form", () => {
+		writeConfig({ modelKey: "a/m", fallbackModels: ["a:m", "b/n"] });
+		const { pi } = createMockPi();
+		restoreAdvisorState(createMockCtx({ models: registryModels }), pi);
+		expect(getAdvisorFallbacks()).toEqual([fallbackB]);
+	});
+
+	it("dedups mixed slash/colon duplicates to a single chain entry", () => {
+		writeConfig({ modelKey: "a/m", fallbackModels: ["b/n", "b:n"] });
+		const { pi } = createMockPi();
+		restoreAdvisorState(createMockCtx({ models: registryModels }), pi);
+		expect(getAdvisorFallbacks()).toEqual([fallbackB]);
+	});
+
+	it("clears fallbacks on deactivate (no usable modelKey)", () => {
+		setAdvisorFallbacks([fallbackB] as never);
+		writeConfig({ effort: "high" });
+		const { pi } = createMockPi();
+		restoreAdvisorState(createMockCtx(), pi);
+		expect(getAdvisorFallbacks()).toEqual([]);
 	});
 });

--- a/packages/rpiv-advisor/advisor/command.ts
+++ b/packages/rpiv-advisor/advisor/command.ts
@@ -30,7 +30,8 @@ import {
 	XHIGH_EFFORT_LEVEL,
 } from "./messages.js";
 import { isExecutorBlocked } from "./policy.js";
-import { getAdvisorEffort, getAdvisorModel, setAdvisorEffort, setAdvisorModel } from "./state.js";
+import { resolveAdvisorFallbacks } from "./restore.js";
+import { getAdvisorEffort, getAdvisorModel, setAdvisorEffort, setAdvisorFallbacks, setAdvisorModel } from "./state.js";
 
 function buildModelItems(availableModels: Model<Api>[], currentKey: string | undefined): SelectItem[] {
 	const items: SelectItem[] = availableModels.map((m) => {
@@ -69,6 +70,10 @@ function applyDisable(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	}
 	setAdvisorModel(undefined);
 	setAdvisorEffort(undefined);
+	// Clear the fallback chain too — mirrors restore.ts deactivate(). Leaving it
+	// stale would hand the next applyEnable a chain resolved against a different
+	// primary.
+	setAdvisorFallbacks([]);
 	const active = pi.getActiveTools();
 	if (active.includes(ADVISOR_TOOL_NAME)) {
 		pi.setActiveTools(active.filter((n) => n !== ADVISOR_TOOL_NAME));
@@ -92,6 +97,12 @@ function applyEnable(
 	}
 	setAdvisorEffort(effort);
 	setAdvisorModel(picked);
+	// Re-resolve the fallback chain against the NEW primary. The chain resolved
+	// at session_start excluded the then-current primary — without this, picking
+	// a model that is itself listed in fallbackModels would put it in its own
+	// chain (retrying the very model that just refused), and the old primary
+	// would stay wrongly excluded until the next session start.
+	resolveAdvisorFallbacks(ctx, picked);
 
 	const blocked = isExecutorBlocked(ctx, pi.getThinkingLevel());
 	reconcileAdvisorTool(pi, ctx, { blocked });

--- a/packages/rpiv-advisor/advisor/config.ts
+++ b/packages/rpiv-advisor/advisor/config.ts
@@ -18,10 +18,20 @@ interface AdvisorConfig {
 	effort?: ThinkingLevel;
 	guidance?: GuidanceFields;
 	disabledForModels?: DisabledForModelsEntry[];
+	// Ordered list of provider/id keys tried when the primary advisor call fails
+	// or the model declines. Resolved to Model objects at session_start
+	// (restore.ts). Config-file driven; preserved across /advisor model changes
+	// because saveAdvisorConfig spreads the existing config.
+	fallbackModels?: string[];
 }
 
 export function loadAdvisorConfig(): AdvisorConfig {
 	return loadJsonConfigWithLegacyFallback<AdvisorConfig>("rpiv-advisor", "advisor.json");
+}
+
+export function validateFallbackModels(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 }
 
 export function validateDisabledForModels(value: unknown): DisabledForModelsEntry[] {

--- a/packages/rpiv-advisor/advisor/execute.ts
+++ b/packages/rpiv-advisor/advisor/execute.ts
@@ -29,11 +29,13 @@ import {
 	errMisconfigured,
 	errNoApiKey,
 	errNoApiKeyDetail,
+	msgAdvisorFellBack,
 	msgConsulting,
+	msgConsultingFallback,
 } from "./messages.js";
 import { getRuntimeCompleteSimple, loadCompleteSimple } from "./pi-compat.js";
 import { ADVISOR_SYSTEM_PROMPT } from "./prompt.js";
-import { getAdvisorEffort, getAdvisorModel } from "./state.js";
+import { getAdvisorEffort, getAdvisorFallbacks, getAdvisorModel } from "./state.js";
 
 interface AdvisorDetails {
 	advisorModel?: string;
@@ -41,6 +43,9 @@ interface AdvisorDetails {
 	usage?: Usage;
 	stopReason?: StopReason;
 	errorMessage?: string;
+	// Set when a fallback model served (or attempted) the call: the label of the
+	// originally-configured primary advisor it fell back from.
+	fellBackFrom?: string;
 }
 
 // Single result-envelope builder — every executeAdvisor branch and the pre-call
@@ -55,12 +60,14 @@ function buildAdvisorResult(opts: {
 	usage?: Usage;
 	stopReason?: StopReason;
 	errorMessage?: string;
+	fellBackFrom?: string;
 }): AgentToolResult<AdvisorDetails> {
 	const details: AdvisorDetails = { effort: opts.effort };
 	if (opts.advisorLabel !== undefined) details.advisorModel = opts.advisorLabel;
 	if (opts.usage !== undefined) details.usage = opts.usage;
 	if (opts.stopReason !== undefined) details.stopReason = opts.stopReason;
 	if (opts.errorMessage !== undefined) details.errorMessage = opts.errorMessage;
+	if (opts.fellBackFrom !== undefined) details.fellBackFrom = opts.fellBackFrom;
 	return { content: [{ type: "text", text: opts.text }], details };
 }
 
@@ -83,26 +90,24 @@ export async function executeAdvisor(
 	// itself use this same value so a concurrent setAdvisorEffort() during the
 	// await window cannot desync details.effort from the `reasoning` actually sent.
 	const effort = getAdvisorEffort();
-	const advisor = getAdvisorModel();
-	if (!advisor) {
+	const primary = getAdvisorModel();
+	if (!primary) {
 		return buildErrorResult(undefined, effort, ERR_NO_MODEL, ERR_NO_MODEL_SELECTED);
 	}
-	const advisorLabel = `${advisor.provider}:${advisor.id}`;
+	// Ordered attempt chain: the configured advisor, then its fallback models.
+	// A refusal reaches us as stopReason "error" (pi-ai's anthropic-messages
+	// mapStopReason collapses Anthropic's "refusal" into "error"), so falling
+	// back on "error" covers both classifier refusals and transient failures.
+	const chain = [primary, ...getAdvisorFallbacks()];
+	const primaryLabel = `${primary.provider}:${primary.id}`;
 
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(advisor);
-	if (!auth.ok) {
-		return buildErrorResult(advisorLabel, effort, errMisconfigured(advisorLabel, auth.error), auth.error);
-	}
-	if (!auth.apiKey) {
-		return buildErrorResult(advisorLabel, effort, errNoApiKey(advisorLabel), errNoApiKeyDetail(advisor.provider));
-	}
-
-	// Live-read every call — advisor runs mid-turn so any message_end snapshot
-	// is always one turn stale. buildSessionContext() preserves Pi's resolved
-	// LLM context, including compaction summaries and branch summaries, instead
-	// of replaying raw pre-compaction branch messages. convertToLlm is
-	// pass-through for user/assistant/toolResult (messages.js:111-114), so
-	// element refs are stable across calls via the session store.
+	// Live-read once — advisor runs mid-turn so any message_end snapshot is always
+	// one turn stale. buildSessionContext() preserves Pi's resolved LLM context,
+	// including compaction summaries and branch summaries, instead of replaying
+	// raw pre-compaction branch messages. convertToLlm is pass-through for
+	// user/assistant/toolResult (messages.js:111-114), so element refs are stable
+	// across calls via the session store. The same request is re-sent to every
+	// model in the chain.
 	const { messages: sessionMessages } = buildSessionContext(
 		ctx.sessionManager.getEntries(),
 		ctx.sessionManager.getLeafId(),
@@ -111,78 +116,147 @@ export async function executeAdvisor(
 	const inventoryMessage = getInventoryMessage(pi.getAllTools());
 	const messages: Message[] = inventoryMessage ? [inventoryMessage, ...branchMessages] : branchMessages;
 
-	onUpdate?.({
-		content: [{ type: "text", text: msgConsulting(advisorLabel, effort) }],
-		details: { advisorModel: advisorLabel, effort },
-	});
+	// Prefer Pi's auth-aware runtime facade. Unlike the global compatibility
+	// function, it runs request preparation and applies credential-derived fields
+	// such as GitHub Copilot's OAuth-specific baseUrl. Do not pass the preflight
+	// key/headers to this path: explicit overrides would bypass that resolution
+	// and reintroduce the endpoint mismatch.
+	const runtimeCompleteSimple = getRuntimeCompleteSimple(ctx.modelRegistry);
+	const completeSimple = runtimeCompleteSimple ?? (await loadCompleteSimple());
 
-	try {
-		// Prefer Pi's auth-aware runtime facade. Unlike the global compatibility
-		// function, it runs request preparation and applies credential-derived
-		// fields such as GitHub Copilot's OAuth-specific baseUrl. Do not pass the
-		// preflight key/headers to this path: explicit overrides would bypass that
-		// resolution and reintroduce the endpoint mismatch.
-		const runtimeCompleteSimple = getRuntimeCompleteSimple(ctx.modelRegistry);
-		const completeSimple = runtimeCompleteSimple ?? (await loadCompleteSimple());
-		const requestOptions = runtimeCompleteSimple
-			? { signal, reasoning: effort }
-			: { apiKey: auth.apiKey, headers: auth.headers, signal, reasoning: effort };
-		const response = await completeSimple(
-			advisor,
-			// `tools: []` reaffirms the "never calls tools" contract even when
-			// `messages` contains prior toolCall/toolResult blocks (btw.ts:235).
-			{ systemPrompt: ADVISOR_SYSTEM_PROMPT, messages, tools: [] },
-			requestOptions,
-		);
+	// Retained across the loop so that when every model fails we return the last
+	// failure envelope rather than a generic error.
+	let lastFailure: AgentToolResult<AdvisorDetails> | undefined;
 
-		if (response.stopReason === "aborted") {
-			return buildAdvisorResult({
-				text: ERR_CALL_ABORTED,
-				effort,
-				advisorLabel,
-				usage: response.usage,
-				stopReason: response.stopReason,
-				errorMessage: response.errorMessage ?? ERR_ABORTED_DETAIL,
+	for (let i = 0; i < chain.length; i++) {
+		const advisor = chain[i];
+		const advisorLabel = `${advisor.provider}:${advisor.id}`;
+		const isFallback = i > 0;
+		const fellBackFrom = isFallback ? primaryLabel : undefined;
+		const nextModel = chain[i + 1];
+		const notifyFellBack = (): void => {
+			if (!nextModel) return;
+			onUpdate?.({
+				content: [
+					{ type: "text", text: msgAdvisorFellBack(advisorLabel, `${nextModel.provider}:${nextModel.id}`) },
+				],
+				details: { effort },
 			});
+		};
+
+		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(advisor);
+		if (!auth.ok) {
+			lastFailure = buildErrorResult(advisorLabel, effort, errMisconfigured(advisorLabel, auth.error), auth.error);
+			if (nextModel) {
+				notifyFellBack();
+				continue;
+			}
+			return lastFailure;
+		}
+		if (!auth.apiKey) {
+			lastFailure = buildErrorResult(
+				advisorLabel,
+				effort,
+				errNoApiKey(advisorLabel),
+				errNoApiKeyDetail(advisor.provider),
+			);
+			if (nextModel) {
+				notifyFellBack();
+				continue;
+			}
+			return lastFailure;
 		}
 
-		if (response.stopReason === "error") {
-			return buildAdvisorResult({
-				text: errCallFailed(response.errorMessage),
-				effort,
-				advisorLabel,
-				usage: response.usage,
-				stopReason: response.stopReason,
-				errorMessage: response.errorMessage,
-			});
-		}
-
-		const advisorText = response.content
-			.filter((c): c is { type: "text"; text: string } => c.type === "text")
-			.map((c) => c.text)
-			.join("\n")
-			.trim();
-
-		if (!advisorText) {
-			return buildAdvisorResult({
-				text: ERR_EMPTY_RESPONSE,
-				effort,
-				advisorLabel,
-				usage: response.usage,
-				stopReason: response.stopReason,
-				errorMessage: ERR_EMPTY_RESPONSE_DETAIL,
-			});
-		}
-
-		return buildAdvisorResult({
-			text: advisorText,
-			effort,
-			advisorLabel,
-			usage: response.usage,
-			stopReason: response.stopReason,
+		onUpdate?.({
+			content: [
+				{
+					type: "text",
+					text: isFallback ? msgConsultingFallback(advisorLabel, effort) : msgConsulting(advisorLabel, effort),
+				},
+			],
+			details: { advisorModel: advisorLabel, effort, ...(fellBackFrom ? { fellBackFrom } : {}) },
 		});
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return buildErrorResult(advisorLabel, effort, errCallThrew(message), message);
+
+		try {
+			const requestOptions = runtimeCompleteSimple
+				? { signal, reasoning: effort }
+				: { apiKey: auth.apiKey, headers: auth.headers, signal, reasoning: effort };
+			const response = await completeSimple(
+				advisor,
+				// `tools: []` reaffirms the "never calls tools" contract even when
+				// `messages` contains prior toolCall/toolResult blocks (btw.ts:235).
+				{ systemPrompt: ADVISOR_SYSTEM_PROMPT, messages, tools: [] },
+				requestOptions,
+			);
+
+			if (response.stopReason === "aborted") {
+				// User cancelled — an intentional abort must not burn fallback attempts.
+				return buildAdvisorResult({
+					text: ERR_CALL_ABORTED,
+					effort,
+					advisorLabel,
+					usage: response.usage,
+					stopReason: response.stopReason,
+					errorMessage: response.errorMessage ?? ERR_ABORTED_DETAIL,
+					fellBackFrom,
+				});
+			}
+
+			if (response.stopReason === "error") {
+				lastFailure = buildAdvisorResult({
+					text: errCallFailed(response.errorMessage),
+					effort,
+					advisorLabel,
+					usage: response.usage,
+					stopReason: response.stopReason,
+					errorMessage: response.errorMessage,
+					fellBackFrom,
+				});
+				if (nextModel) {
+					notifyFellBack();
+					continue;
+				}
+				return lastFailure;
+			}
+
+			const advisorText = response.content
+				.filter((c): c is { type: "text"; text: string } => c.type === "text")
+				.map((c) => c.text)
+				.join("\n")
+				.trim();
+
+			if (!advisorText) {
+				return buildAdvisorResult({
+					text: ERR_EMPTY_RESPONSE,
+					effort,
+					advisorLabel,
+					usage: response.usage,
+					stopReason: response.stopReason,
+					errorMessage: ERR_EMPTY_RESPONSE_DETAIL,
+					fellBackFrom,
+				});
+			}
+
+			return buildAdvisorResult({
+				text: advisorText,
+				effort,
+				advisorLabel,
+				usage: response.usage,
+				stopReason: response.stopReason,
+				fellBackFrom,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			lastFailure = buildErrorResult(advisorLabel, effort, errCallThrew(message), message);
+			if (nextModel) {
+				notifyFellBack();
+				continue;
+			}
+			return lastFailure;
+		}
 	}
+
+	// Unreachable while the chain is non-empty (primary is always present), but
+	// keeps the function total for the type checker and an empty-chain guard.
+	return lastFailure ?? buildErrorResult(undefined, effort, ERR_NO_MODEL, ERR_NO_MODEL_SELECTED);
 }

--- a/packages/rpiv-advisor/advisor/execute.ts
+++ b/packages/rpiv-advisor/advisor/execute.ts
@@ -76,8 +76,9 @@ function buildErrorResult(
 	effort: ThinkingLevel | undefined,
 	userText: string,
 	errorMessage: string,
+	fellBackFrom?: string,
 ): AgentToolResult<AdvisorDetails> {
-	return buildAdvisorResult({ text: userText, effort, advisorLabel, errorMessage });
+	return buildAdvisorResult({ text: userText, effort, advisorLabel, errorMessage, fellBackFrom });
 }
 
 export async function executeAdvisor(
@@ -146,7 +147,13 @@ export async function executeAdvisor(
 
 		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(advisor);
 		if (!auth.ok) {
-			lastFailure = buildErrorResult(advisorLabel, effort, errMisconfigured(advisorLabel, auth.error), auth.error);
+			lastFailure = buildErrorResult(
+				advisorLabel,
+				effort,
+				errMisconfigured(advisorLabel, auth.error),
+				auth.error,
+				fellBackFrom,
+			);
 			if (nextModel) {
 				notifyFellBack();
 				continue;
@@ -159,6 +166,7 @@ export async function executeAdvisor(
 				effort,
 				errNoApiKey(advisorLabel),
 				errNoApiKeyDetail(advisor.provider),
+				fellBackFrom,
 			);
 			if (nextModel) {
 				notifyFellBack();
@@ -247,7 +255,7 @@ export async function executeAdvisor(
 			});
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			lastFailure = buildErrorResult(advisorLabel, effort, errCallThrew(message), message);
+			lastFailure = buildErrorResult(advisorLabel, effort, errCallThrew(message), message, fellBackFrom);
 			if (nextModel) {
 				notifyFellBack();
 				continue;

--- a/packages/rpiv-advisor/advisor/index.ts
+++ b/packages/rpiv-advisor/advisor/index.ts
@@ -36,4 +36,11 @@ export { ADVISOR_TOOL_NAME } from "./messages.js";
 export { setDisabledForModels } from "./policy.js";
 export { DEFAULT_PROMPT_GUIDELINES, DEFAULT_PROMPT_SNIPPET, registerAdvisorTool } from "./register.js";
 export { __resetAdvisorAnnounced, registerAdvisorSessionStart, restoreAdvisorState } from "./restore.js";
-export { getAdvisorEffort, getAdvisorModel, setAdvisorEffort, setAdvisorModel } from "./state.js";
+export {
+	getAdvisorEffort,
+	getAdvisorFallbacks,
+	getAdvisorModel,
+	setAdvisorEffort,
+	setAdvisorFallbacks,
+	setAdvisorModel,
+} from "./state.js";

--- a/packages/rpiv-advisor/advisor/messages.ts
+++ b/packages/rpiv-advisor/advisor/messages.ts
@@ -57,3 +57,7 @@ export const msgAdvisorEnabledInactive = (label: string, effort: ThinkingLevel |
 	`Advisor: ${label}${effort ? `, ${effort}` : ""} (inactive for current executor)`;
 export const msgConsulting = (label: string, effort: ThinkingLevel | undefined) =>
 	`Consulting advisor (${label}${effort ? `, ${effort}` : ""})…`;
+export const msgConsultingFallback = (label: string, effort: ThinkingLevel | undefined) =>
+	`Consulting fallback advisor (${label}${effort ? `, ${effort}` : ""})…`;
+export const msgAdvisorFellBack = (fromLabel: string, toLabel: string) =>
+	`Advisor ${fromLabel} did not answer; falling back to ${toLabel}.`;

--- a/packages/rpiv-advisor/advisor/restore.ts
+++ b/packages/rpiv-advisor/advisor/restore.ts
@@ -4,13 +4,14 @@
  * announces once per process. Wired via registerAdvisorSessionStart.
  */
 
+import type { Api, Model } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { modelKey, parseModelKey } from "@juicesharp/rpiv-config";
-import { loadAdvisorConfig, validateDisabledForModels } from "./config.js";
+import { loadAdvisorConfig, validateDisabledForModels, validateFallbackModels } from "./config.js";
 import { reconcileAdvisorTool } from "./handlers.js";
 import { ADVISOR_TOOL_NAME, errModelUnavailable, msgAdvisorRestored, msgAdvisorRestoredInactive } from "./messages.js";
 import { isExecutorBlocked, setDisabledForModels } from "./policy.js";
-import { setAdvisorEffort, setAdvisorModel } from "./state.js";
+import { setAdvisorEffort, setAdvisorFallbacks, setAdvisorModel } from "./state.js";
 
 /**
  * Module-local "already announced" latch. Pi fires `session_start` for every
@@ -46,7 +47,26 @@ export function restoreAdvisorState(ctx: ExtensionContext, pi: ExtensionAPI): vo
 	const deactivate = (): void => {
 		setAdvisorModel(undefined);
 		setAdvisorEffort(undefined);
+		setAdvisorFallbacks([]);
 		reconcileAdvisorTool(pi, ctx, { blocked: true });
+	};
+
+	// Resolve config.fallbackModels (provider/id keys) to Model objects, dropping
+	// entries that don't parse, aren't in the registry, or duplicate the primary.
+	// Called after the primary model is set so the primary can be excluded.
+	const resolveFallbacks = (primary: Model<Api>): void => {
+		const seen = new Set<string>([modelKey(primary)]);
+		const resolved: Model<Api>[] = [];
+		for (const key of validateFallbackModels(config.fallbackModels)) {
+			if (seen.has(key)) continue;
+			const p = parseModelKey(key);
+			if (!p) continue;
+			const m = ctx.modelRegistry.find(p.provider, p.modelId);
+			if (!m) continue;
+			seen.add(key);
+			resolved.push(m);
+		}
+		setAdvisorFallbacks(resolved);
 	};
 
 	if (!config.modelKey) {
@@ -74,6 +94,7 @@ export function restoreAdvisorState(ctx: ExtensionContext, pi: ExtensionAPI): vo
 	}
 
 	setAdvisorModel(model);
+	resolveFallbacks(model);
 	if (config.effort) {
 		setAdvisorEffort(config.effort);
 	}

--- a/packages/rpiv-advisor/advisor/restore.ts
+++ b/packages/rpiv-advisor/advisor/restore.ts
@@ -29,6 +29,31 @@ export function __resetAdvisorAnnounced(): void {
 	restoreAnnounced = false;
 }
 
+/**
+ * Resolve config.fallbackModels (provider/id keys) to Model objects, dropping
+ * entries that don't parse, aren't in the registry, or duplicate the primary.
+ * Dedup happens on the canonical slash key AFTER parsing — parseModelKey also
+ * tolerates the legacy "provider:id" form, so comparing raw config strings
+ * would let a colon-form entry smuggle the primary (or a duplicate) into the
+ * chain. Reloads the config so it can run from any primary-change path:
+ * session restore below and the /advisor enable path (command.ts applyEnable).
+ */
+export function resolveAdvisorFallbacks(ctx: ExtensionContext, primary: Model<Api>): void {
+	const seen = new Set<string>([modelKey(primary)]);
+	const resolved: Model<Api>[] = [];
+	for (const key of validateFallbackModels(loadAdvisorConfig().fallbackModels)) {
+		const p = parseModelKey(key);
+		if (!p) continue;
+		const canonical = modelKey({ provider: p.provider, id: p.modelId });
+		if (seen.has(canonical)) continue;
+		const m = ctx.modelRegistry.find(p.provider, p.modelId);
+		if (!m) continue;
+		seen.add(canonical);
+		resolved.push(m);
+	}
+	setAdvisorFallbacks(resolved);
+}
+
 export function restoreAdvisorState(ctx: ExtensionContext, pi: ExtensionAPI): void {
 	const config = loadAdvisorConfig();
 
@@ -49,24 +74,6 @@ export function restoreAdvisorState(ctx: ExtensionContext, pi: ExtensionAPI): vo
 		setAdvisorEffort(undefined);
 		setAdvisorFallbacks([]);
 		reconcileAdvisorTool(pi, ctx, { blocked: true });
-	};
-
-	// Resolve config.fallbackModels (provider/id keys) to Model objects, dropping
-	// entries that don't parse, aren't in the registry, or duplicate the primary.
-	// Called after the primary model is set so the primary can be excluded.
-	const resolveFallbacks = (primary: Model<Api>): void => {
-		const seen = new Set<string>([modelKey(primary)]);
-		const resolved: Model<Api>[] = [];
-		for (const key of validateFallbackModels(config.fallbackModels)) {
-			if (seen.has(key)) continue;
-			const p = parseModelKey(key);
-			if (!p) continue;
-			const m = ctx.modelRegistry.find(p.provider, p.modelId);
-			if (!m) continue;
-			seen.add(key);
-			resolved.push(m);
-		}
-		setAdvisorFallbacks(resolved);
 	};
 
 	if (!config.modelKey) {
@@ -94,7 +101,7 @@ export function restoreAdvisorState(ctx: ExtensionContext, pi: ExtensionAPI): vo
 	}
 
 	setAdvisorModel(model);
-	resolveFallbacks(model);
+	resolveAdvisorFallbacks(ctx, model);
 	if (config.effort) {
 		setAdvisorEffort(config.effort);
 	}

--- a/packages/rpiv-advisor/advisor/state.ts
+++ b/packages/rpiv-advisor/advisor/state.ts
@@ -1,12 +1,17 @@
 /**
- * state — in-memory advisor selection (model + effort). Resets each session;
- * the persisted form lives in config.ts, the blocklist cache in policy.ts.
+ * state — in-memory advisor selection (model + effort + fallback chain).
+ * Resets each session; the persisted form lives in config.ts, the blocklist
+ * cache in policy.ts.
  */
 
 import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
 
 let selectedAdvisor: Model<Api> | undefined;
 let selectedAdvisorEffort: ThinkingLevel | undefined;
+// Ordered fallback chain, resolved from config.fallbackModels at session_start
+// (restore.ts). Tried in order when the primary advisor call fails or the model
+// declines (a refusal reaches execute.ts as stopReason "error"; see execute.ts).
+let selectedAdvisorFallbacks: Model<Api>[] = [];
 
 export function getAdvisorModel(): Model<Api> | undefined {
 	return selectedAdvisor;
@@ -22,4 +27,12 @@ export function getAdvisorEffort(): ThinkingLevel | undefined {
 
 export function setAdvisorEffort(effort: ThinkingLevel | undefined): void {
 	selectedAdvisorEffort = effort;
+}
+
+export function getAdvisorFallbacks(): Model<Api>[] {
+	return selectedAdvisorFallbacks;
+}
+
+export function setAdvisorFallbacks(models: Model<Api>[]): void {
+	selectedAdvisorFallbacks = models;
 }

--- a/packages/rpiv-advisor/docs/configuration.md
+++ b/packages/rpiv-advisor/docs/configuration.md
@@ -45,9 +45,11 @@ previous selection and the active tool list are left untouched.
 | `disabledForModels` | `(string \| { model, minEffort? })[]` | `[]` | hand-edited |
 | `guidance.promptSnippet` | `string` | built-in snippet | hand-edited |
 | `guidance.promptGuidelines` | `string[]` | six built-in guidelines | hand-edited |
+| `fallbackModels` | `string[]` — `"provider/modelId"` keys | `[]` | hand-edited |
 
-`/advisor` only ever writes `modelKey` and `effort`; `guidance` and
-`disabledForModels` are preserved across saves, so hand-edits survive.
+`/advisor` only ever writes `modelKey` and `effort`; `guidance`,
+`disabledForModels`, and `fallbackModels` are preserved across saves, so
+hand-edits survive.
 
 ### `modelKey`
 
@@ -65,6 +67,15 @@ deletes the key, and no `reasoning` parameter is sent with the advisor call.
 
 `EFFORT_ORDINAL`, lowest to highest, is `minimal`, `low`, `medium`, `high`,
 `xhigh`. This ordering is what `minEffort` compares against.
+
+### `fallbackModels`
+
+An ordered list of `"provider/modelId"` reviewer keys the advisor tries, in
+order, when the primary call fails or the model declines. Entries are resolved
+against the model registry at session start and re-resolved whenever the
+primary changes through `/advisor`; unknown, unparseable, or duplicate entries
+(including the primary itself, in either key form) are skipped. See the README
+for the full fallback semantics.
 
 ### `disabledForModels`
 
@@ -137,6 +148,8 @@ conflicting evidence with one more `advisor` call rather than silently switching
 | `Previously configured advisor model <key> is no longer available` | the saved model left Pi's registry |
 | `Failed to save advisor selection — selection not persisted` | the write to `advisor.json` failed |
 | `/advisor requires interactive mode` | `/advisor` ran without a TTY |
+| `Consulting fallback advisor (<label>[, <effort>])…` | a fallback model's attempt is in flight |
+| `Advisor <from> did not answer; falling back to <to>.` | an attempt failed and the chain is advancing |
 
 The `Advisor restored: …` announcement fires at most once per process, so
 programmatic session spawns (workflow stages, subagents) do not repeat it.

--- a/packages/rpiv-advisor/docs/tool-reference.md
+++ b/packages/rpiv-advisor/docs/tool-reference.md
@@ -39,7 +39,9 @@ guidance in its next visible reply, so the guidance is not left only in a
 collapsed tool card.
 
 While the call is in flight the executor streams
-`Consulting advisor (<label>[, <effort>])…`.
+`Consulting advisor (<label>[, <effort>])…` — or, for a fallback attempt,
+`Consulting fallback advisor (<label>[, <effort>])…`, preceded by
+`Advisor <from> did not answer; falling back to <to>.` when the chain advances.
 
 ## Result envelope
 
@@ -52,6 +54,7 @@ While the call is in flight the executor streams
     usage?: Usage,           // token usage from the side-call
     stopReason?: StopReason, // pi-ai stop reason
     errorMessage?: string,   // populated on the no-model/auth/abort/error/empty paths
+    fellBackFrom?: string,   // primary's label when a fallback model served (or was the last attempted)
   }
 }
 ```

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -68,6 +68,7 @@ beforeEach(async () => {
 	const advisor = await import("../packages/rpiv-advisor/advisor/index.js");
 	advisor.setAdvisorModel(undefined);
 	advisor.setAdvisorEffort(undefined);
+	advisor.setAdvisorFallbacks([]);
 	advisor.setDisabledForModels([]);
 	advisor.__resetAdvisorAnnounced();
 


### PR DESCRIPTION
Closes part of #135.

## What

Adds an optional ordered `fallbackModels` list to `advisor.json`. When the primary advisor call fails or the model declines, the advisor retries the same request on each fallback model in turn.

```json
{
  "modelKey": "anthropic/claude-fable-5",
  "effort": "high",
  "fallbackModels": ["anthropic/claude-opus-4-8"]
}
```

## Why

Safety-tier reviewers (Claude Fable 5, Opus 5) can decline with a classifier refusal. A refusal is deterministic, so re-asking the same model refuses again — you want a different model. The advisor, where you tend to run a safety-tier model on sensitive second opinions, is exactly where this bites.

Key detail I confirmed while implementing: pi-ai's `anthropic-messages` `mapStopReason` collapses Anthropic's `"refusal"` into `stopReason: "error"` (with the explanation in `errorMessage`). So a refusal already reaches `execute.ts` on the existing `stopReason === "error"` branch, indistinguishable from a transient error. Falling back on `error` therefore covers refusals **and** transient failures. For a second-opinion tool that's arguably the right default: you want an answer regardless of *why* the primary didn't give one. (I filed earendil-works/pi#7133 asking pi to surface refusals distinctly; if that lands, the trigger could be narrowed to refusal-only.)

## How

- **config**: `fallbackModels?: string[]` + `validateFallbackModels`. Preserved across `/advisor` saves via the existing spread (like `disabledForModels`/`guidance`).
- **state**: `getAdvisorFallbacks` / `setAdvisorFallbacks`.
- **restore**: `resolveAdvisorFallbacks` resolves keys → `Model[]` at `session_start` **and re-resolves on every `/advisor` primary change**, skipping unknown/unparseable entries and deduping on the canonical slash key (so legacy colon-form entries can't smuggle in the primary or a duplicate); cleared on deactivate and on `/advisor` disable.
- **execute**: attempt chain `[primary, ...fallbacks]`, built once and re-sent to each model. Advances on auth failure, thrown error, or `stopReason: "error"`. An intentional **abort stops immediately** (doesn't burn a fallback); an empty response is terminal. Result `details` gain `fellBackFrom` (the primary) when a fallback served; `advisorModel` names the model that answered.

## Scope / notes

- **No `/advisor` picker UI** in this PR — fallbacks are config-file driven for now, matching how `disabledForModels` works. Happy to add a multi-select picker step in a follow-up if you'd prefer it in the command flow.
- Behavior is unchanged when `fallbackModels` is empty (the 11 existing `execute` tests pass untouched).

## Tests

New cases: `advisor.execute.test.ts` — fallback on refusal/error, all-models-decline returns last failure, fallback on throw, no-fallback-on-abort, no-fallback-on-success, auth-failure chain advancement (primary auth fails → fallback serves; all fail → last auth failure returned). `advisor.restore.test.ts` — resolution order, unknown/unparseable skip, colon-form primary exclusion, mixed-form dedup, clear-on-deactivate. `advisor.command.test.ts` — re-resolve on enable (new primary excluded), clear on disable. `advisor.config.test.ts` — direct `validateFallbackModels` suite. `test/setup.ts` resets the new fallback state.

`npm run check` (biome + tsc) and the full `rpiv-advisor` suite (212 tests) pass.

