### PR TITLE
fix(rpiv-todo): make update-missing-field error recoverable for the model

### DIFF
--- a/packages/rpiv-todo/state/state-reducer.test.ts
+++ b/packages/rpiv-todo/state/state-reducer.test.ts
@@ -51,7 +51,11 @@ describe("applyTaskMutation — update", () => {
 	it("rejects id-only update", () => {
 		const state = stateWith(task({ id: 1, subject: "x" }));
 		const result = applyTaskMutation(state, "update", { id: 1 });
-		expect(result.op).toEqual({ kind: "error", message: "update requires at least one mutable field" });
+		expect(result.op).toEqual({
+			kind: "error",
+			message:
+				"update requires at least one mutable field: subject, description, activeForm, status, owner, metadata, addBlockedBy, or removeBlockedBy",
+		});
 	});
 
 	it("rejects illegal transition completed → in_progress", () => {

--- a/packages/rpiv-todo/state/state-reducer.ts
+++ b/packages/rpiv-todo/state/state-reducer.ts
@@ -121,7 +121,11 @@ export function applyTaskMutation(state: TaskState, action: TaskAction, params: 
 				params.metadata !== undefined ||
 				(params.addBlockedBy && params.addBlockedBy.length > 0) ||
 				(params.removeBlockedBy && params.removeBlockedBy.length > 0);
-			if (!hasMutation) return errorResult(state, "update requires at least one mutable field");
+			if (!hasMutation)
+				return errorResult(
+					state,
+					"update requires at least one mutable field: subject, description, activeForm, status, owner, metadata, addBlockedBy, or removeBlockedBy",
+				);
 
 			let newStatus = current.status;
 			if (params.status !== undefined) {

--- a/packages/rpiv-todo/todo.ts
+++ b/packages/rpiv-todo/todo.ts
@@ -58,6 +58,7 @@ export const DEFAULT_PROMPT_GUIDELINES: string[] = [
 	"When starting any task, mark it in_progress BEFORE beginning work. Mark it completed IMMEDIATELY when done — never batch completions. Exactly one task should be in_progress at a time.",
 	"Never mark a task completed if tests are failing, the implementation is partial, or you hit unresolved errors — keep it in_progress and create a new task for the blocker instead.",
 	"Task status is a 4-state machine: pending → in_progress → completed, plus deleted as a tombstone. Pass activeForm (present-continuous label, e.g. 'researching existing tool') when marking in_progress.",
+	'To change a task\'s status, call update with the task id and the target status, e.g. {"action":"update","id":3,"status":"completed"} or {"action":"update","id":3,"status":"in_progress","activeForm":"writing tests"}. status is the field that changes the task; an update without a mutable field (status or another) is rejected.',
 	"Use blockedBy to express dependencies (A is blocked by B). On create, pass blockedBy as the initial set. On update, use addBlockedBy / removeBlockedBy (additive merge — do not resend the full array). Cycles are rejected.",
 	"list hides tombstoned (deleted) tasks by default; pass includeDeleted:true to see them. Pass status to filter by a single status.",
 	"Subject must be short and imperative (e.g. 'Research existing tool'); description is for long-form detail. activeForm is a present-continuous label shown while in_progress.",

--- a/packages/rpiv-todo/tool/types.ts
+++ b/packages/rpiv-todo/tool/types.ts
@@ -89,7 +89,8 @@ export const TodoParamsSchema = Type.Object({
 	),
 	status: Type.Optional(
 		StringEnum(["pending", "in_progress", "completed", "deleted"] as const, {
-			description: "Target status (update) or list filter (list)",
+			description:
+				"Set this task's status (update): one of pending, in_progress, completed, deleted. When action is list, filters returned tasks by this status.",
 		}),
 	),
 	blockedBy: Type.Optional(


### PR DESCRIPTION
## Problem

When the model needs to mark a task complete (or change any status), it must call the `todo` tool with `action: "update"` and a `status` field. After a conversation compaction or `/reload`, the model can lose the in-context exemplars that taught it the correct call shape, and the tool gives it no in-band way to reconstruct that shape. The result is an un-recoverable failure loop: the model regenerates `update` calls **without** the `status` field, the terse error doesn't name which fields count, and tasks sit `pending` indefinitely after the work is done. Observed live this session: four tasks left outstanding after all work was complete.

The reducer and runtime are correct — calls that *do* send `status` succeed (verified). The defect is in the tool **contract**: three surfaces conspire to make the mutation field hard to reach and impossible to self-correct.

## Root cause (3 compounding factors in installed v2.1.0)

1. **`state/state-reducer.ts` — error message gives no self-correction path.**
   `"update requires at least one mutable field"` doesn't enumerate *which* fields are mutable. On the error, the model can't tell that `status` is the missing piece, so it retries wrong and loops.

2. **`tool/types.ts` — the `status` description buries its mutation role.**
   `"Target status (update) or list filter (list)"` doubles `status` as a list filter, so it reads as a contextual/ambient knob rather than *the* mutation payload. The model reaches for a field by reading its description; this wording steers it away from `status` on `update`.

3. **`todo.ts` `DEFAULT_PROMPT_GUIDELINES` — describes policy, not call shape.**
   "Mark it completed IMMEDIATELY when done" tells the model *when* to mark done, but never the literal `update {id, status: "completed"}` recipe. Guidance text lives in the system prompt and **survives /reload and compaction** (unlike transcript exemplars), so it's the right place to pin a fallback recipe — but currently doesn't.

## Fix (3 surgical, test-safe changes)

1. **`state/state-reducer.ts`** — enumerate the mutable fields in the error message:
   > `update requires at least one mutable field: subject, description, activeForm, status, owner, metadata, addBlockedBy, or removeBlockedBy`

   Lets the model self-correct on the next turn.

2. **`tool/types.ts`** — lead the `status` description with its mutation role:
   > `Set this task's status (update): one of pending, in_progress, completed, deleted. When action is list, filters returned tasks by this status.`

   Keeps the list-filter meaning, no longer buries the mutation role.

3. **`todo.ts` `DEFAULT_PROMPT_GUIDELINES`** — add one exemplar guideline with the literal call shape:
   > `To change a task's status, call update with the task id and the target status, e.g. {"action":"update","id":3,"status":"completed"} or {"action":"update","id":3,"status":"in_progress","activeForm":"writing tests"}. status is the field that changes the task; an update without a mutable field (status or another) is rejected.`

   Survives compaction (system prompt), giving the model a recipe once transcript exemplars are pruned.

## A fourth idea I considered and dropped

Echoing the accepted call shape in the **error tool response** (`tool/response-envelope.ts`). Dropped because fix 1 already carries the enumerated field list in-band on the same `Error:` line that the model receives — duplicating it in a separate response field would be redundant.

## Test impact

- `state/state-reducer.test.ts` updated in lockstep to expect the new message (1 assertion, 1 test).
- `todo.guidance.test.ts` and `todo.register.test.ts` use `DEFAULT_PROMPT_GUIDELINES.length` dynamically, so the added guideline needs no test change.
- Verified locally: the affected files' suites pass (68/68), and the full rpiv-todo suite passes **223/224** — the one failure (`ship-manifest.test.ts`) is **pre-existing on clean `main`** (a Windows path-separator glob issue, `\` vs `/`, unrelated to this change) and reproduced by stashing my edits and re-running on `dba86e7`.
- Pre-commit hooks pass. `package-lock.json` modifications from `npm install` are **not** included (environmental, not part of this fix).

## Scope

Surgical string/guidance changes only — no behavioral or schema-shape changes, no new exports, no persistence/replay surface touched. Safe for a patch release.