### PR TITLE
feat(rpiv-todo): add session completed-task presentations

### DIFF
--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -8,11 +8,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- `completedTaskVisibility: "session"` retains completed tasks in the chronological overlay list across agent turns.
-- Session mode folds an old contiguous completed prefix after `maxVisibleCompleted` rows (default `5`) and exposes it through `completedCollapseKey` (default `ctrl+shift+c`). Pending and in-progress rows remain individually visible.
+- `completedTaskVisibility: "session"` retains the canonical todo state across agent turns.
+- Session presentation supports Claude-like terminal-budgeted `"priority"` projection by default and original-order `"chronological"` projection as an opt-in.
+- Chronological session mode can fold an old contiguous completed prefix after `maxVisibleCompleted` rows (default `5`) and expose it through `completedCollapseKey` (default `ctrl+shift+c`).
 
 ### Changed
-- The default `completedTaskVisibility: "turn"` behavior remains unchanged.
+- The default `completedTaskVisibility: "turn"` behavior and its existing shortcut remain unchanged.
 ## [2.3.1] - 2026-07-31
 
 ## [2.3.0] - 2026-07-31

--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `completedTaskVisibility: "session"` retains completed tasks in the chronological overlay list across agent turns.
+- Session mode folds an old contiguous completed prefix after `maxVisibleCompleted` rows (default `5`) and exposes it through `completedCollapseKey` (default `ctrl+shift+c`). Pending and in-progress rows remain individually visible.
+
+### Changed
+- The default `completedTaskVisibility: "turn"` behavior remains unchanged.
 ## [2.3.1] - 2026-07-31
 
 ## [2.3.0] - 2026-07-31

--- a/packages/rpiv-todo/README.md
+++ b/packages/rpiv-todo/README.md
@@ -52,13 +52,13 @@ by status.
   post-mutation snapshot, and the list is replayed from the session branch. No
   disk writes, nothing to lose.
 - **Finished work stays reviewable.** Completed rows leave at the next agent turn
-  by default. Set `completedTaskVisibility` to `"session"` to keep them in the
-  same chronological list: the newest five stay expanded and older contiguous
-  completed rows fold behind a shortcut until you choose to expand them.
-- **The overlay has a predictable compact mode.** In the default turn mode, the
-  row budget drops completed tasks first and then truncates unfinished work with
-  `+3 more (2 completed, 1 pending)`. Session mode instead keeps every active
-  and pending task visible and only folds an old completed prefix.
+  by default. Set `completedTaskVisibility` to `"session"` to retain them across
+  turns; the default `"priority"` presentation stays within the terminal budget,
+  while `"chronological"` preserves order and folds only old completed rows.
+- **The overlay has a predictable compact mode.** Default `"turn"` mode uses its
+  configured row budget. Session `"priority"` follows Claude-like current-work
+  ordering and a terminal-height summary; session `"chronological"` keeps every
+  active and pending task visible, folding only an old completed prefix.
 - **The agent can sequence work, not just list it.** `blockedBy` dependencies are
   validated before anything is written — dangling ids, deleted dependencies,
   self-blocks, and cycles are all rejected.
@@ -75,21 +75,20 @@ Optional. Create `~/.config/rpiv-todo/config.json` (or
 
 ```json
 {
-  "maxWidgetLines": 8,
   "collapseKey": "alt+t",
   "completedTaskVisibility": "session",
-  "maxVisibleCompleted": 5,
-  "completedCollapseKey": "ctrl+shift+c"
+  "completedTaskPresentation": "priority"
 }
 ```
 
 | Setting | What it does | Default |
 | --- | --- | --- |
-| `maxWidgetLines` | Content rows the overlay may use in the default `"turn"` mode, heading included. Minimum `3`. Applies on the next repaint. | `12` |
+| `maxWidgetLines` | Content-row budget for default `"turn"` mode and priority-mode fallback when terminal height is unavailable. Minimum `3`. | `12` |
 | `collapseKey` | Key that collapses and expands the whole panel, in Pi keybinding form (`alt+o`, `ctrl+shift+t`). Set `"off"` to register no shortcut. Needs `/reload` to rebind. | `"ctrl+shift+t"` |
-| `completedTaskVisibility` | `"turn"` removes displayed completed rows at the next agent turn; `"session"` retains them in the chronological list. Applies on the next agent turn. | `"turn"` |
-| `maxVisibleCompleted` | In session mode, number of newest contiguous completed rows left expanded before older rows fold. | `5` |
-| `completedCollapseKey` | Key that expands or folds the old completed prefix in session mode. Set `"off"` to keep every completed row expanded. Needs `/reload` to rebind. | `"ctrl+shift+c"` |
+| `completedTaskVisibility` | `"turn"` removes displayed completed rows at the next agent turn; `"session"` retains task state across turns. | `"turn"` |
+| `completedTaskPresentation` | Session projection: Claude-like status priority (`"priority"`) or original-order completed-prefix folding (`"chronological"`). | `"priority"` |
+| `maxVisibleCompleted` | In chronological session mode, number of newest contiguous completed rows left expanded before older rows fold. | `5` |
+| `completedCollapseKey` | Key that expands or folds the old completed prefix in chronological session mode. Set `"off"` to keep every completed row expanded. Needs `/reload` to rebind. | `"ctrl+shift+c"` |
 | `guidance` | Replaces the built-in instructions the extension gives the model about when and how to use the todo list. Needs `/reload`. | _(built-ins)_ |
 A missing or malformed file falls back to these defaults. `rpiv-todo` only reads
 this file — it never writes one. Full semantics:

--- a/packages/rpiv-todo/README.md
+++ b/packages/rpiv-todo/README.md
@@ -51,12 +51,14 @@ by status.
 - **Tasks survive `/reload` and compaction.** Each tool call carries the full
   post-mutation snapshot, and the list is replayed from the session branch. No
   disk writes, nothing to lose.
-- **Finished work gets out of the way.** Completed rows stay visible for the rest
-  of the turn, then drop at the start of the next one; the panel disappears
-  entirely when the list empties.
-- **The overlay never eats your terminal.** Past the row budget it drops
-  completed tasks first, truncates unfinished ones last, and tells you what it
-  hid with `+3 more (2 completed, 1 pending)`.
+- **Finished work stays reviewable.** Completed rows leave at the next agent turn
+  by default. Set `completedTaskVisibility` to `"session"` to keep them in the
+  same chronological list: the newest five stay expanded and older contiguous
+  completed rows fold behind a shortcut until you choose to expand them.
+- **The overlay has a predictable compact mode.** In the default turn mode, the
+  row budget drops completed tasks first and then truncates unfinished work with
+  `+3 more (2 completed, 1 pending)`. Session mode instead keeps every active
+  and pending task visible and only folds an old completed prefix.
 - **The agent can sequence work, not just list it.** `blockedBy` dependencies are
   validated before anything is written — dangling ids, deleted dependencies,
   self-blocks, and cycles are all rejected.
@@ -74,16 +76,21 @@ Optional. Create `~/.config/rpiv-todo/config.json` (or
 ```json
 {
   "maxWidgetLines": 8,
-  "collapseKey": "alt+t"
+  "collapseKey": "alt+t",
+  "completedTaskVisibility": "session",
+  "maxVisibleCompleted": 5,
+  "completedCollapseKey": "ctrl+shift+c"
 }
 ```
 
 | Setting | What it does | Default |
 | --- | --- | --- |
-| `maxWidgetLines` | Content rows the overlay may use, heading included. Minimum `3`. Applies on the next repaint. | `12` |
-| `collapseKey` | Key that collapses and expands the panel, in Pi keybinding form (`alt+o`, `ctrl+shift+t`). Set `"off"` to register no shortcut. Needs `/reload` to rebind. | `"ctrl+shift+t"` |
+| `maxWidgetLines` | Content rows the overlay may use in the default `"turn"` mode, heading included. Minimum `3`. Applies on the next repaint. | `12` |
+| `collapseKey` | Key that collapses and expands the whole panel, in Pi keybinding form (`alt+o`, `ctrl+shift+t`). Set `"off"` to register no shortcut. Needs `/reload` to rebind. | `"ctrl+shift+t"` |
+| `completedTaskVisibility` | `"turn"` removes displayed completed rows at the next agent turn; `"session"` retains them in the chronological list. Applies on the next agent turn. | `"turn"` |
+| `maxVisibleCompleted` | In session mode, number of newest contiguous completed rows left expanded before older rows fold. | `5` |
+| `completedCollapseKey` | Key that expands or folds the old completed prefix in session mode. Set `"off"` to keep every completed row expanded. Needs `/reload` to rebind. | `"ctrl+shift+c"` |
 | `guidance` | Replaces the built-in instructions the extension gives the model about when and how to use the todo list. Needs `/reload`. | _(built-ins)_ |
-
 A missing or malformed file falls back to these defaults. `rpiv-todo` only reads
 this file — it never writes one. Full semantics:
 [Configuration](https://github.com/juicesharp/rpiv-mono/blob/main/packages/rpiv-todo/docs/configuration.md).

--- a/packages/rpiv-todo/config.test.ts
+++ b/packages/rpiv-todo/config.test.ts
@@ -5,9 +5,11 @@ import {
 	COLLAPSE_KEY_OFF,
 	DEFAULT_COLLAPSE_KEY,
 	DEFAULT_COMPLETED_COLLAPSE_KEY,
+	DEFAULT_COMPLETED_TASK_PRESENTATION,
 	DEFAULT_COMPLETED_TASK_VISIBILITY,
 	DEFAULT_MAX_VISIBLE_COMPLETED,
 	DEFAULT_MAX_WIDGET_LINES,
+	getCompletedTaskPresentation,
 	getCompletedTaskVisibility,
 	getMaxVisibleCompleted,
 	getMaxWidgetLines,
@@ -84,6 +86,20 @@ describe("getCompletedTaskVisibility", () => {
 	});
 });
 
+describe("getCompletedTaskPresentation", () => {
+	it("returns priority for missing, invalid, and explicit priority values", () => {
+		expect(getCompletedTaskPresentation()).toBe(DEFAULT_COMPLETED_TASK_PRESENTATION);
+		writeConfigFile(JSON.stringify({ completedTaskPresentation: "unknown" }));
+		expect(getCompletedTaskPresentation()).toBe(DEFAULT_COMPLETED_TASK_PRESENTATION);
+		writeConfigFile(JSON.stringify({ completedTaskPresentation: "priority" }));
+		expect(getCompletedTaskPresentation()).toBe("priority");
+	});
+
+	it("returns chronological when explicitly configured", () => {
+		writeConfigFile(JSON.stringify({ completedTaskPresentation: "chronological" }));
+		expect(getCompletedTaskPresentation()).toBe("chronological");
+	});
+});
 describe("getMaxVisibleCompleted", () => {
 	it("returns the default when config is missing, absent, or invalid", () => {
 		expect(getMaxVisibleCompleted()).toBe(DEFAULT_MAX_VISIBLE_COMPLETED);

--- a/packages/rpiv-todo/config.test.ts
+++ b/packages/rpiv-todo/config.test.ts
@@ -4,11 +4,17 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	COLLAPSE_KEY_OFF,
 	DEFAULT_COLLAPSE_KEY,
+	DEFAULT_COMPLETED_COLLAPSE_KEY,
+	DEFAULT_COMPLETED_TASK_VISIBILITY,
+	DEFAULT_MAX_VISIBLE_COMPLETED,
 	DEFAULT_MAX_WIDGET_LINES,
+	getCompletedTaskVisibility,
+	getMaxVisibleCompleted,
 	getMaxWidgetLines,
 	isValidCollapseKeySpec,
 	loadConfig,
 	resolveCollapseKey,
+	resolveCompletedCollapseKey,
 } from "./config.js";
 
 const CONFIG_PATH = join(process.env.HOME!, ".config", "rpiv-todo", "config.json");
@@ -55,7 +61,62 @@ describe("getMaxWidgetLines", () => {
 		expect(getMaxWidgetLines()).toBe(50);
 	});
 });
+describe("getCompletedTaskVisibility", () => {
+	it("returns the turn policy when config is missing, absent, or invalid", () => {
+		expect(getCompletedTaskVisibility()).toBe(DEFAULT_COMPLETED_TASK_VISIBILITY);
+		writeConfigFile(JSON.stringify({}));
+		expect(getCompletedTaskVisibility()).toBe(DEFAULT_COMPLETED_TASK_VISIBILITY);
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "always" }));
+		expect(getCompletedTaskVisibility()).toBe(DEFAULT_COMPLETED_TASK_VISIBILITY);
+	});
 
+	it("returns session when the user opts in", () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		expect(getCompletedTaskVisibility()).toBe("session");
+	});
+
+	it("reads the policy fresh for the next agent turn", () => {
+		expect(getCompletedTaskVisibility()).toBe(DEFAULT_COMPLETED_TASK_VISIBILITY);
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		expect(getCompletedTaskVisibility()).toBe("session");
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "turn" }));
+		expect(getCompletedTaskVisibility()).toBe(DEFAULT_COMPLETED_TASK_VISIBILITY);
+	});
+});
+
+describe("getMaxVisibleCompleted", () => {
+	it("returns the default when config is missing, absent, or invalid", () => {
+		expect(getMaxVisibleCompleted()).toBe(DEFAULT_MAX_VISIBLE_COMPLETED);
+		writeConfigFile(JSON.stringify({}));
+		expect(getMaxVisibleCompleted()).toBe(DEFAULT_MAX_VISIBLE_COMPLETED);
+		writeConfigFile(JSON.stringify({ maxVisibleCompleted: -1 }));
+		expect(getMaxVisibleCompleted()).toBe(DEFAULT_MAX_VISIBLE_COMPLETED);
+		writeConfigFile(JSON.stringify({ maxVisibleCompleted: 1.5 }));
+		expect(getMaxVisibleCompleted()).toBe(DEFAULT_MAX_VISIBLE_COMPLETED);
+	});
+
+	it("accepts zero and non-negative integers", () => {
+		writeConfigFile(JSON.stringify({ maxVisibleCompleted: 0 }));
+		expect(getMaxVisibleCompleted()).toBe(0);
+		writeConfigFile(JSON.stringify({ maxVisibleCompleted: 8 }));
+		expect(getMaxVisibleCompleted()).toBe(8);
+	});
+});
+
+describe("resolveCompletedCollapseKey", () => {
+	it("uses the default when missing or invalid", () => {
+		expect(resolveCompletedCollapseKey()).toBe(DEFAULT_COMPLETED_COLLAPSE_KEY);
+		writeConfigFile(JSON.stringify({ completedCollapseKey: "ctr+c" }));
+		expect(resolveCompletedCollapseKey()).toBe(DEFAULT_COMPLETED_COLLAPSE_KEY);
+	});
+
+	it("accepts off and normalized valid key specs", () => {
+		writeConfigFile(JSON.stringify({ completedCollapseKey: "off" }));
+		expect(resolveCompletedCollapseKey()).toBe(COLLAPSE_KEY_OFF);
+		writeConfigFile(JSON.stringify({ completedCollapseKey: "Alt+C" }));
+		expect(resolveCompletedCollapseKey()).toBe("alt+c");
+	});
+});
 describe("loadConfig — collapseKey", () => {
 	it("surfaces a user-set collapseKey unchanged (validation happens in resolveCollapseKey, not at load)", () => {
 		writeConfigFile(JSON.stringify({ collapseKey: "alt+o" }));

--- a/packages/rpiv-todo/config.ts
+++ b/packages/rpiv-todo/config.ts
@@ -16,11 +16,13 @@ interface TodoConfig {
 	 * available for the session. Validation happens in `getCompletedTaskVisibility`.
 	 */
 	completedTaskVisibility?: string;
+	/** Controls how retained session rows are projected into the overlay. */
+	completedTaskPresentation?: string;
 	/** Maximum number of the newest contiguous completed rows kept expanded in
-	 * session mode. Older rows remain available through the fold control. */
+	 * chronological session mode. Older rows remain available through the fold control. */
 	maxVisibleCompleted?: number;
-	/** Key spec for expanding or collapsing folded completed rows in session mode.
-	 * Pass `"off"` to keep every completed row expanded. */
+	/** Key spec for expanding or collapsing folded completed rows in chronological
+	 * session mode. Pass `"off"` to keep every completed row expanded. */
 	completedCollapseKey?: string;
 }
 
@@ -42,6 +44,12 @@ export type CompletedTaskVisibility = "turn" | "session";
 
 /** Preserve the existing behavior unless the user explicitly opts into session visibility. */
 export const DEFAULT_COMPLETED_TASK_VISIBILITY: CompletedTaskVisibility = "turn";
+
+/** Presentation policy for completed rows retained in session mode. */
+export type CompletedTaskPresentation = "priority" | "chronological";
+
+/** Claude-like priority projection is the default session presentation. */
+export const DEFAULT_COMPLETED_TASK_PRESENTATION: CompletedTaskPresentation = "priority";
 
 /** Number of newest contiguous completed rows shown before older rows fold. */
 export const DEFAULT_MAX_VISIBLE_COMPLETED = 5;
@@ -70,9 +78,16 @@ export function getCompletedTaskVisibility(): CompletedTaskVisibility {
 	return visibility === "session" ? "session" : DEFAULT_COMPLETED_TASK_VISIBILITY;
 }
 
-/** Maximum number of newest contiguous completed rows shown in session mode.
- * Invalid values fall back to the default; zero explicitly folds the whole
- * completed prefix while keeping it available through the expansion shortcut. */
+/** Read the retained-session presentation policy fresh on every render. */
+export function getCompletedTaskPresentation(): CompletedTaskPresentation {
+	const presentation = loadConfig().completedTaskPresentation;
+	return presentation === "chronological" ? "chronological" : DEFAULT_COMPLETED_TASK_PRESENTATION;
+}
+
+/** Maximum number of newest contiguous completed rows shown in chronological
+ * session mode. Invalid values fall back to the default; zero explicitly folds
+ * the whole completed prefix while keeping it available through the expansion
+ * shortcut. */
 export function getMaxVisibleCompleted(): number {
 	const value = loadConfig().maxVisibleCompleted;
 	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0

--- a/packages/rpiv-todo/config.ts
+++ b/packages/rpiv-todo/config.ts
@@ -11,6 +11,17 @@ interface TodoConfig {
 	 * entirely. Validation happens in `resolveCollapseKey`, not at load.
 	 */
 	collapseKey?: string;
+	/**
+	 * Whether completed rows leave the overlay at the next agent turn or remain
+	 * available for the session. Validation happens in `getCompletedTaskVisibility`.
+	 */
+	completedTaskVisibility?: string;
+	/** Maximum number of the newest contiguous completed rows kept expanded in
+	 * session mode. Older rows remain available through the fold control. */
+	maxVisibleCompleted?: number;
+	/** Key spec for expanding or collapsing folded completed rows in session mode.
+	 * Pass `"off"` to keep every completed row expanded. */
+	completedCollapseKey?: string;
 }
 
 /** Default content-row budget when the config is missing/invalid — the prior
@@ -26,14 +37,22 @@ export const DEFAULT_COLLAPSE_KEY: CollapseKeySpec = "ctrl+shift+t";
 /** Sentinel value for `collapseKey` that disables the collapse shortcut entirely. */
 export const COLLAPSE_KEY_OFF: CollapseKeySpec = "off";
 
+/** Visibility policy for completed rows in the overlay. */
+export type CompletedTaskVisibility = "turn" | "session";
+
+/** Preserve the existing behavior unless the user explicitly opts into session visibility. */
+export const DEFAULT_COMPLETED_TASK_VISIBILITY: CompletedTaskVisibility = "turn";
+
+/** Number of newest contiguous completed rows shown before older rows fold. */
+export const DEFAULT_MAX_VISIBLE_COMPLETED = 5;
 export function loadConfig(): TodoConfig {
 	return loadJsonConfigWithLegacyFallback<TodoConfig>("rpiv-todo");
 }
 
 /** Content-row budget for the overlay, read fresh on every call (per-render —
- *  no `/reload`). Mirrors warp's getHeartbeatMs minus its `=== 0` disabled
- *  sentinel: a non-number or a value below the floor of 3 falls back to the
- *  default; no ceiling. */
+ * no `/reload`). Mirrors warp's getHeartbeatMs minus its `=== 0` disabled
+ * sentinel: a non-number or a value below the floor of 3 falls back to the
+ * default; no ceiling. */
 export function getMaxWidgetLines(): number {
 	const config = loadConfig();
 	const lines = config.maxWidgetLines;
@@ -41,6 +60,25 @@ export function getMaxWidgetLines(): number {
 	return lines;
 }
 
+/**
+ * Read the completed-row policy fresh for every agent turn. Invalid values keep
+ * the existing compact-overlay behavior, so config typos cannot make completion
+ * history unexpectedly consume editor space.
+ */
+export function getCompletedTaskVisibility(): CompletedTaskVisibility {
+	const visibility = loadConfig().completedTaskVisibility;
+	return visibility === "session" ? "session" : DEFAULT_COMPLETED_TASK_VISIBILITY;
+}
+
+/** Maximum number of newest contiguous completed rows shown in session mode.
+ * Invalid values fall back to the default; zero explicitly folds the whole
+ * completed prefix while keeping it available through the expansion shortcut. */
+export function getMaxVisibleCompleted(): number {
+	const value = loadConfig().maxVisibleCompleted;
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+		? value
+		: DEFAULT_MAX_VISIBLE_COMPLETED;
+}
 // Named keys accepted by pi-tui's `matchesKey` (keys.js switch on the parsed base key).
 // parseKeyId lowercases the id before matching, so lowercase spellings are canonical.
 const SPECIAL_KEYS = new Set([
@@ -85,17 +123,29 @@ export function isValidCollapseKeySpec(spec: string): boolean {
 	return base.length === 1 ? /[a-z0-9_\-!@#$%^&*()|~`'":;,./<>?[\]{}=\\]/.test(base) : SPECIAL_KEYS.has(base);
 }
 
-/** Resolve the collapse/expand key from config, read fresh on every call
- *  (per-render / per-registration — no `/reload`); mirrors getMaxWidgetLines().
- *  Returns DEFAULT_COLLAPSE_KEY when the field is missing/non-string/empty/blank/
- *  invalid, COLLAPSE_KEY_OFF when set to the sentinel, or the lowercased validated
- *  spec. */
-export function resolveCollapseKey(): CollapseKeySpec {
-	const config = loadConfig();
-	const raw = typeof config.collapseKey === "string" ? config.collapseKey.trim().toLowerCase() : undefined;
-	if (raw === undefined || raw === "") return DEFAULT_COLLAPSE_KEY;
+/** Resolve a configured collapse key. The caller chooses the fallback, allowing
+ * both overlay controls to share the same strict grammar and `"off"` sentinel. */
+function resolveConfiguredCollapseKey(rawValue: unknown, fallback: CollapseKeySpec): CollapseKeySpec {
+	const raw = typeof rawValue === "string" ? rawValue.trim().toLowerCase() : undefined;
+	if (raw === undefined || raw === "") return fallback;
 	if (raw === COLLAPSE_KEY_OFF) return COLLAPSE_KEY_OFF;
-	return isValidCollapseKeySpec(raw) ? raw : DEFAULT_COLLAPSE_KEY;
+	return isValidCollapseKeySpec(raw) ? raw : fallback;
+}
+
+/** Resolve the whole-overlay collapse key. Read fresh per render/registration; a
+ * `/reload` remains necessary to rebind the registered shortcut. */
+export function resolveCollapseKey(): CollapseKeySpec {
+	return resolveConfiguredCollapseKey(loadConfig().collapseKey, DEFAULT_COLLAPSE_KEY);
+}
+
+/** Default shortcut for expanding and collapsing folded completed rows. */
+export const DEFAULT_COMPLETED_COLLAPSE_KEY: CollapseKeySpec = "ctrl+shift+c";
+
+/** Resolve the completed-row fold shortcut. `"off"` keeps all completed rows
+ * expanded, and a collision with `collapseKey` is resolved by the extension at
+ * registration time so one key never controls two widget states. */
+export function resolveCompletedCollapseKey(): CollapseKeySpec {
+	return resolveConfiguredCollapseKey(loadConfig().completedCollapseKey, DEFAULT_COMPLETED_COLLAPSE_KEY);
 }
 
 export { validateGuidanceFields };

--- a/packages/rpiv-todo/docs/configuration.md
+++ b/packages/rpiv-todo/docs/configuration.md
@@ -56,8 +56,9 @@ terminal rows.
 - No ceiling.
 - Read fresh on every render, so a change takes effect on the next repaint —
   no `/reload`.
-- Session `"priority"` normally derives its three-to-five task budget from the
-  active terminal height. This option is its fallback only when that height is
+- Session `"priority"` derives its three-to-five task budget from an active
+  terminal taller than 10 rows. At 10 rows or fewer it shows only the heading
+  and the overflow summary. This option is the fallback when terminal height is
   unavailable. Chronological session mode does not apply the row budget.
 ## `completedTaskVisibility`
 
@@ -82,11 +83,12 @@ next agent turn starts.
 visibility is `"session"`. A missing, non-string, or unrecognized value falls
 back to `"priority"`. The choice is read at every render.
 
-- `"priority"` follows Claude-like terminal behavior: temporarily recent
-  completion, then in-progress work, unblocked pending work, blocked pending
-  work, and older completion. Items beyond the terminal budget become one
-  `… +N` status-counted summary row. It does not register a completed-row
-  shortcut.
+- `"priority"` follows Claude-like terminal behavior. When the full list fits its
+  terminal budget, it keeps original task order. On overflow it shows temporarily
+  recent completion, then in-progress work, unblocked pending work, blocked
+  pending work, and older completion. Remaining items become one `… +N`
+  status-counted summary row. On terminals with 10 rows or fewer, only that
+  summary is shown. It does not register a completed-row shortcut.
 - `"chronological"` keeps original task order. It shows every pending and
   in-progress row, then folds only an old contiguous completed prefix at the
   top of the list.

--- a/packages/rpiv-todo/docs/configuration.md
+++ b/packages/rpiv-todo/docs/configuration.md
@@ -33,6 +33,9 @@ extension only reads it.
 {
   "maxWidgetLines": 8,
   "collapseKey": "alt+t",
+  "completedTaskVisibility": "session",
+  "maxVisibleCompleted": 5,
+  "completedCollapseKey": "ctrl+shift+c",
   "guidance": {
     "promptSnippet": "Use the `todo` tool to track multi-step work before starting it.",
     "promptGuidelines": [
@@ -45,18 +48,65 @@ extension only reads it.
 
 ## `maxWidgetLines`
 
-**Default `12`.** The content-row budget for the overlay — the heading row and,
-on overflow, the `+N more` summary row both count against it. Only the trailing
-blank spacer sits outside the budget, so `12` renders up to 13 terminal rows.
+**Default `12`.** The content-row budget for the default `"turn"` overlay. The
+heading and, on overflow, the `+N more` summary row both count against it. Only
+the trailing blank spacer sits outside the budget, so `12` renders up to 13
+terminal rows.
 
 - Floor of `3`. A number below `3` falls back to the default.
 - A non-number falls back to the default.
 - No ceiling.
 - Read fresh on every render, so a change takes effect on the next repaint —
   no `/reload`.
+- In `"session"` completed-task visibility, this budget does not hide or truncate
+  completed, pending, or in-progress rows. Session mode prioritizes keeping the
+  active plan visible and folds only an eligible completed prefix.
+## `completedTaskVisibility`
+
+**Default `"turn"`.** Controls whether completed rows remain available after the
+next agent turn starts.
+
+- `"turn"` keeps the compact-overlay default: a completed row stays visible for
+  the remainder of the current turn, then drops from later overlay renders.
+- `"session"` retains completed tasks for the session, the todo list is cleared,
+  or a task is deleted. It preserves the original chronological list and can
+  fold only the oldest rows of its contiguous completed prefix.
+- If a user changes from `"session"` to `"turn"`, the next agent turn hides the
+  retained completed rows. The reverse change restores rows that the turn policy
+  previously hid.
+- A missing, non-string, or unrecognized value falls back to `"turn"`.
+- The policy is read at every agent turn, so a change takes effect on the next
+  turn without `/reload`.
+
+## `maxVisibleCompleted`
+
+**Default `5`.** In `"session"` mode, the number of newest rows kept expanded
+within the contiguous completed prefix at the top of the todo list. When that
+prefix is longer, the older rows become one expandable `▶ N completed` row in
+the same list position. A completed task after an unfinished task never moves or
+joins that folded prefix.
+
+- `0` folds the whole completed prefix.
+- A negative number, fractional number, non-number, or unsafe integer falls back
+  to the default.
+- The value is read on every render, so a change takes effect on the next repaint
+  without `/reload`.
+- This setting applies only when `completedTaskVisibility` is `"session"`.
+
+## `completedCollapseKey`
+
+**Default `"ctrl+shift+c"`.** The shortcut that expands and folds the older
+completed prefix in `"session"` mode. The collapsed row shows the currently
+configured key as its expansion hint.
+
+- The value uses the same strict Pi keybinding grammar as `collapseKey`. Missing,
+  blank, non-string, and invalid values fall back to the default.
+- `"off"` disables completed-row folding and leaves every completed row expanded.
+- It must not equal `collapseKey`. A collision registers only the whole-panel
+  shortcut, writes a warning, and leaves every completed row expanded.
+- The binding is resolved once at extension load. Run `/reload` after editing it.
 
 ## `collapseKey`
-
 **Default `"ctrl+shift+t"`.** The shortcut that collapses and expands the
 overlay.
 

--- a/packages/rpiv-todo/docs/configuration.md
+++ b/packages/rpiv-todo/docs/configuration.md
@@ -31,11 +31,9 @@ extension only reads it.
 
 ```json
 {
-  "maxWidgetLines": 8,
   "collapseKey": "alt+t",
   "completedTaskVisibility": "session",
-  "maxVisibleCompleted": 5,
-  "completedCollapseKey": "ctrl+shift+c",
+  "completedTaskPresentation": "priority",
   "guidance": {
     "promptSnippet": "Use the `todo` tool to track multi-step work before starting it.",
     "promptGuidelines": [
@@ -58,9 +56,9 @@ terminal rows.
 - No ceiling.
 - Read fresh on every render, so a change takes effect on the next repaint —
   no `/reload`.
-- In `"session"` completed-task visibility, this budget does not hide or truncate
-  completed, pending, or in-progress rows. Session mode prioritizes keeping the
-  active plan visible and folds only an eligible completed prefix.
+- Session `"priority"` normally derives its three-to-five task budget from the
+  active terminal height. This option is its fallback only when that height is
+  unavailable. Chronological session mode does not apply the row budget.
 ## `completedTaskVisibility`
 
 **Default `"turn"`.** Controls whether completed rows remain available after the
@@ -68,9 +66,9 @@ next agent turn starts.
 
 - `"turn"` keeps the compact-overlay default: a completed row stays visible for
   the remainder of the current turn, then drops from later overlay renders.
-- `"session"` retains completed tasks for the session, the todo list is cleared,
-  or a task is deleted. It preserves the original chronological list and can
-  fold only the oldest rows of its contiguous completed prefix.
+- `"session"` retains every task in canonical session state until the session
+  ends, the todo list is cleared, or the task is deleted. Presentation controls
+  only what the overlay projects, never the underlying task state.
 - If a user changes from `"session"` to `"turn"`, the next agent turn hides the
   retained completed rows. The reverse change restores rows that the turn policy
   previously hid.
@@ -78,33 +76,51 @@ next agent turn starts.
 - The policy is read at every agent turn, so a change takes effect on the next
   turn without `/reload`.
 
+## `completedTaskPresentation`
+
+**Default `"priority"`.** Controls the overlay projection while completed-task
+visibility is `"session"`. A missing, non-string, or unrecognized value falls
+back to `"priority"`. The choice is read at every render.
+
+- `"priority"` follows Claude-like terminal behavior: temporarily recent
+  completion, then in-progress work, unblocked pending work, blocked pending
+  work, and older completion. Items beyond the terminal budget become one
+  `… +N` status-counted summary row. It does not register a completed-row
+  shortcut.
+- `"chronological"` keeps original task order. It shows every pending and
+  in-progress row, then folds only an old contiguous completed prefix at the
+  top of the list.
+
 ## `maxVisibleCompleted`
 
-**Default `5`.** In `"session"` mode, the number of newest rows kept expanded
-within the contiguous completed prefix at the top of the todo list. When that
-prefix is longer, the older rows become one expandable `▶ N completed` row in
-the same list position. A completed task after an unfinished task never moves or
-joins that folded prefix.
+**Default `5`.** In `"chronological"` session mode, the number of newest rows
+kept expanded within the contiguous completed prefix at the top of the todo
+list. When that prefix is longer, the older rows become one expandable
+`▶ N completed` row in the same list position. A completed task after an
+unfinished task never moves or joins that folded prefix.
 
 - `0` folds the whole completed prefix.
 - A negative number, fractional number, non-number, or unsafe integer falls back
   to the default.
 - The value is read on every render, so a change takes effect on the next repaint
   without `/reload`.
-- This setting applies only when `completedTaskVisibility` is `"session"`.
+- This setting applies only when visibility is `"session"` and presentation is
+  `"chronological"`.
 
 ## `completedCollapseKey`
 
 **Default `"ctrl+shift+c"`.** The shortcut that expands and folds the older
-completed prefix in `"session"` mode. The collapsed row shows the currently
-configured key as its expansion hint.
+completed prefix in `"chronological"` session mode. The collapsed row shows the
+currently configured key as its expansion hint.
 
 - The value uses the same strict Pi keybinding grammar as `collapseKey`. Missing,
   blank, non-string, and invalid values fall back to the default.
 - `"off"` disables completed-row folding and leaves every completed row expanded.
 - It must not equal `collapseKey`. A collision registers only the whole-panel
   shortcut, writes a warning, and leaves every completed row expanded.
-- The binding is resolved once at extension load. Run `/reload` after editing it.
+- The binding is resolved once at extension load. Run `/reload` after editing it
+  or after switching presentation to `"chronological"`; priority mode never
+  registers this shortcut.
 
 ## `collapseKey`
 **Default `"ctrl+shift+t"`.** The shortcut that collapses and expands the

--- a/packages/rpiv-todo/docs/overlay.md
+++ b/packages/rpiv-todo/docs/overlay.md
@@ -53,24 +53,22 @@ Rows longer than the terminal width are truncated with `…`.
 
 In the default `"turn"` policy, the content-row budget is `maxWidgetLines`
 (default `12`), and the heading counts against it. When there are more tasks
-than fit:
+than fit, completed tasks are dropped first; if unfinished tasks still overflow,
+the tail is truncated and the last row becomes `+N more (X completed, Y pending)`.
 
-1. one row is reserved for the summary line;
-2. completed tasks are dropped first, newest first — the oldest completed rows
-   are the last completed rows to go;
-3. if the unfinished tasks alone still overflow, the tail of that list is
-   truncated;
-4. the last row becomes `+N more (X completed, Y pending)`.
+Session mode retains the complete task state but offers two projections:
 
-In `"session"` completed-task visibility, the panel does not apply that height
-budget: pending and in-progress tasks always stay as individual rows. When the
-contiguous completed prefix at the top exceeds `maxVisibleCompleted` (default
-`5`), only its older rows fold into a single expandable row. The expanded view
-may grow the widget to show every folded row.
+- `"priority"` is the default Claude-like projection. It derives a three-to-five
+  task budget from terminal height, then shows recently completed tasks,
+  in-progress tasks, unblocked pending tasks, blocked pending tasks, and older
+  completed tasks in that order. Hidden rows become one `… +N` row with status
+  counts.
+- `"chronological"` preserves original task order, shows every pending and
+  in-progress task, and folds only an old contiguous completed prefix after
+  `maxVisibleCompleted` rows. Its expanded completed group can grow the widget.
 
-See [configuration.md](./configuration.md#maxwidgetlines) for the turn-mode
-budget and [completed-task visibility](./configuration.md#completedtaskvisibility)
-for the session-mode rules.
+See [configuration.md](./configuration.md#completedtaskpresentation) for the
+two session-mode policies.
 
 ## Completed tasks
 
@@ -80,10 +78,10 @@ next agent turn, every completed row that has been displayed is hidden from
 later renders. Reloading or compacting resets that tracking, so a fresh session
 shows the full list again.
 
-With `completedTaskVisibility: "session"`, completed rows stay in the same
-chronological list until the session ends, the list is cleared, or the task is
-deleted. If the list begins with more completed rows than `maxVisibleCompleted`,
-the oldest ones fold in place:
+With `completedTaskVisibility: "session"`, tasks remain in canonical session
+state across turns. The default `"priority"` view keeps the terminal focused on
+current work and represents hidden rows with `… +N`. Select `"chronological"`
+when the original execution order matters:
 
 ```text
 ● Todos (6/7)
@@ -93,20 +91,21 @@ the oldest ones fold in place:
 └─ ○ Next task
 ```
 
-Press `completedCollapseKey` (default `ctrl+shift+c`) to expand every folded row
-in place, then press it again to fold them. A completed task behind any pending
-or in-progress task retains its original position and is never moved into that
-fold.
+In chronological mode, `completedCollapseKey` expands the folded rows in place,
+then folds them again. A completed task behind any pending or in-progress task
+retains its original position and is never moved into that fold. Priority mode
+does not register a completed-row shortcut; use `/todos` for the unbounded list.
+expanded until `/reload` binds that shortcut.
 ## Collapsing
 
 Press `ctrl+shift+t` to collapse the whole panel to two lines — the heading plus
 a dim `└─ ctrl+shift+t to expand` hint — and again to expand it. The hint always
-shows the currently configured `collapseKey`.
+shows the currently configured `collapseKey`. This works independently of both
+session presentations.
 
-The separate `completedCollapseKey` only expands or folds the older completed
-prefix in session mode; it does not collapse the whole panel. Rebind or disable
-either key through configuration. If both keys resolve to the same value, the
-whole-panel key wins and completed rows stay expanded.
+The separate `completedCollapseKey` applies only to chronological session mode.
+If both keys resolve to the same value, the whole-panel key wins and completed
+rows stay expanded.
 ## `/todos`
 
 `/todos` prints the whole list grouped by status, independent of the overlay's

--- a/packages/rpiv-todo/docs/overlay.md
+++ b/packages/rpiv-todo/docs/overlay.md
@@ -58,11 +58,12 @@ the tail is truncated and the last row becomes `+N more (X completed, Y pending)
 
 Session mode retains the complete task state but offers two projections:
 
-- `"priority"` is the default Claude-like projection. It derives a three-to-five
-  task budget from terminal height, then shows recently completed tasks,
-  in-progress tasks, unblocked pending tasks, blocked pending tasks, and older
-  completed tasks in that order. Hidden rows become one `… +N` row with status
-  counts.
+- `"priority"` is the default Claude-like projection. On a terminal taller than
+  10 rows it derives a three-to-five task budget. When all tasks fit, it keeps
+  original order; on overflow it shows recently completed tasks, in-progress
+  tasks, unblocked pending tasks, blocked pending tasks, and older completed
+  tasks in that order. Hidden rows become one `… +N` row with status counts. At
+  10 rows or fewer it renders only the heading and that summary.
 - `"chronological"` preserves original task order, shows every pending and
   in-progress task, and folds only an old contiguous completed prefix after
   `maxVisibleCompleted` rows. Its expanded completed group can grow the widget.
@@ -79,9 +80,10 @@ later renders. Reloading or compacting resets that tracking, so a fresh session
 shows the full list again.
 
 With `completedTaskVisibility: "session"`, tasks remain in canonical session
-state across turns. The default `"priority"` view keeps the terminal focused on
-current work and represents hidden rows with `… +N`. Select `"chronological"`
-when the original execution order matters:
+state across turns. The default `"priority"` view preserves original order while
+everything fits, then keeps the terminal focused on current work with `… +N`
+when it does not. Select `"chronological"` when the original execution order
+must stay visible even for long lists:
 
 ```text
 ● Todos (6/7)
@@ -95,7 +97,6 @@ In chronological mode, `completedCollapseKey` expands the folded rows in place,
 then folds them again. A completed task behind any pending or in-progress task
 retains its original position and is never moved into that fold. Priority mode
 does not register a completed-row shortcut; use `/todos` for the unbounded list.
-expanded until `/reload` binds that shortcut.
 ## Collapsing
 
 Press `ctrl+shift+t` to collapse the whole panel to two lines — the heading plus

--- a/packages/rpiv-todo/docs/overlay.md
+++ b/packages/rpiv-todo/docs/overlay.md
@@ -51,8 +51,9 @@ Rows longer than the terminal width are truncated with `…`.
 
 ## Overflow
 
-The content-row budget is `maxWidgetLines` (default `12`), and the heading counts
-against it. When there are more tasks than fit:
+In the default `"turn"` policy, the content-row budget is `maxWidgetLines`
+(default `12`), and the heading counts against it. When there are more tasks
+than fit:
 
 1. one row is reserved for the summary line;
 2. completed tasks are dropped first, newest first — the oldest completed rows
@@ -61,28 +62,51 @@ against it. When there are more tasks than fit:
    truncated;
 4. the last row becomes `+N more (X completed, Y pending)`.
 
-Unfinished work is therefore the last thing to disappear. See
-[configuration.md](./configuration.md#maxwidgetlines) for the budget's floor and
-reload semantics.
+In `"session"` completed-task visibility, the panel does not apply that height
+budget: pending and in-progress tasks always stay as individual rows. When the
+contiguous completed prefix at the top exceeds `maxVisibleCompleted` (default
+`5`), only its older rows fold into a single expandable row. The expanded view
+may grow the widget to show every folded row.
 
-## Completed tasks fading out
+See [configuration.md](./configuration.md#maxwidgetlines) for the turn-mode
+budget and [completed-task visibility](./configuration.md#completedtaskvisibility)
+for the session-mode rules.
 
-A completed task stays on screen for the remainder of the turn in which it was
-completed. At the start of the next agent turn, every completed row that has
-already been displayed is hidden from later renders. Reloading or compacting the
-session resets that tracking, so a fresh session shows the full list again.
+## Completed tasks
 
+With the default `completedTaskVisibility: "turn"`, a completed task stays on
+screen for the remainder of the turn in which it completed. At the start of the
+next agent turn, every completed row that has been displayed is hidden from
+later renders. Reloading or compacting resets that tracking, so a fresh session
+shows the full list again.
+
+With `completedTaskVisibility: "session"`, completed rows stay in the same
+chronological list until the session ends, the list is cleared, or the task is
+deleted. If the list begins with more completed rows than `maxVisibleCompleted`,
+the oldest ones fold in place:
+
+```text
+● Todos (6/7)
+├─ ▶ 1 completed · ctrl+shift+c to expand
+├─ ✓ Most recent completed task
+├─ ◐ Current task
+└─ ○ Next task
+```
+
+Press `completedCollapseKey` (default `ctrl+shift+c`) to expand every folded row
+in place, then press it again to fold them. A completed task behind any pending
+or in-progress task retains its original position and is never moved into that
+fold.
 ## Collapsing
 
-Press `ctrl+shift+t` to collapse the panel to two lines — the heading plus a dim
-`└─ ctrl+shift+t to expand` hint — and again to expand it. The hint always shows
-the currently configured key.
+Press `ctrl+shift+t` to collapse the whole panel to two lines — the heading plus
+a dim `└─ ctrl+shift+t to expand` hint — and again to expand it. The hint always
+shows the currently configured `collapseKey`.
 
-Rebind or disable the shortcut with the `collapseKey` option; see
-[configuration.md](./configuration.md#collapsekey). If the shortcut is set to
-`"off"` while the panel is collapsed, the hint becomes a static `collapsed`
-label rather than advertising an unbindable key.
-
+The separate `completedCollapseKey` only expands or folds the older completed
+prefix in session mode; it does not collapse the whole panel. Rebind or disable
+either key through configuration. If both keys resolve to the same value, the
+whole-panel key wins and completed rows stay expanded.
 ## `/todos`
 
 `/todos` prints the whole list grouped by status, independent of the overlay's

--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -21,7 +21,13 @@
 
 import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
-import { COLLAPSE_KEY_OFF, resolveCollapseKey, resolveCompletedCollapseKey } from "./config.js";
+import {
+	COLLAPSE_KEY_OFF,
+	getCompletedTaskPresentation,
+	getCompletedTaskVisibility,
+	resolveCollapseKey,
+	resolveCompletedCollapseKey,
+} from "./config.js";
 import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
 import { replayFromBranch } from "./state/replay.js";
 import {
@@ -142,6 +148,7 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 		if (generation !== lifecycleGeneration || !uiCtx) return;
 
 		todoOverlay ??= new TodoOverlay();
+		todoOverlay.setCompletedRowsShortcutEnabled?.(completedRowsShortcutEnabled);
 		todoOverlay.setUICtx(uiCtx);
 		if (resetCompletedDisplayState) todoOverlay.resetCompletedDisplayState();
 		todoOverlay.update();
@@ -165,7 +172,14 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 	}
 
 	const completedCollapseKey = resolveCompletedCollapseKey();
-	if (completedCollapseKey !== COLLAPSE_KEY_OFF && completedCollapseKey !== collapseKey) {
+	const sessionVisibilityEnabled = getCompletedTaskVisibility() === "session";
+	const chronologicalPresentationEnabled = getCompletedTaskPresentation() === "chronological";
+	const completedRowsShortcutEnabled =
+		sessionVisibilityEnabled &&
+		chronologicalPresentationEnabled &&
+		completedCollapseKey !== COLLAPSE_KEY_OFF &&
+		completedCollapseKey !== collapseKey;
+	if (completedRowsShortcutEnabled) {
 		pi.registerShortcut(completedCollapseKey as KeyId, {
 			description: "Expand or collapse older completed todos",
 			handler: (ctx) => {
@@ -173,7 +187,12 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 				todoOverlay.toggleCompletedRows();
 			},
 		});
-	} else if (completedCollapseKey !== COLLAPSE_KEY_OFF && completedCollapseKey === collapseKey) {
+	} else if (
+		sessionVisibilityEnabled &&
+		chronologicalPresentationEnabled &&
+		completedCollapseKey !== COLLAPSE_KEY_OFF &&
+		completedCollapseKey === collapseKey
+	) {
 		console.warn("[rpiv-todo] completedCollapseKey matches collapseKey; older completed todos will remain expanded");
 	}
 	// Re-key a session's slot from its branch, then refresh the overlay only when

--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -21,7 +21,7 @@
 
 import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
-import { COLLAPSE_KEY_OFF, resolveCollapseKey } from "./config.js";
+import { COLLAPSE_KEY_OFF, resolveCollapseKey, resolveCompletedCollapseKey } from "./config.js";
 import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
 import { replayFromBranch } from "./state/replay.js";
 import {
@@ -150,14 +150,9 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 	registerTodoTool(pi);
 	registerTodosCommand(pi);
 
-	// Collapse/expand hotkey for the todo overlay. The key is resolved once at
-	// factory scope from config (register-once contract: a config change needs
-	// `/reload` to re-bind, same as lane-switcher's env hotkey) and the binding is
-	// skipped entirely when collapseKey is "off". The handler closes over the
-	// closure-local `todoOverlay` by reference and re-reads it at fire time, so an
-	// overlay loaded after shortcut registration is picked up. No-op in headless
-	// mode, before the overlay has loaded, or when the widget isn't currently
-	// registered (auto-hidden on an empty list).
+	// Collapse/expand hotkeys resolve once at factory scope: `/reload` is required
+	// after a config edit to rebind either key. The completed-row control is kept
+	// separate so it never changes the existing whole-overlay collapse behavior.
 	const collapseKey = resolveCollapseKey();
 	if (collapseKey !== COLLAPSE_KEY_OFF) {
 		pi.registerShortcut(collapseKey as KeyId, {
@@ -169,6 +164,18 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 		});
 	}
 
+	const completedCollapseKey = resolveCompletedCollapseKey();
+	if (completedCollapseKey !== COLLAPSE_KEY_OFF && completedCollapseKey !== collapseKey) {
+		pi.registerShortcut(completedCollapseKey as KeyId, {
+			description: "Expand or collapse older completed todos",
+			handler: (ctx) => {
+				if (!ctx.hasUI || !todoOverlay?.isRegistered()) return;
+				todoOverlay.toggleCompletedRows();
+			},
+		});
+	} else if (completedCollapseKey !== COLLAPSE_KEY_OFF && completedCollapseKey === collapseKey) {
+		console.warn("[rpiv-todo] completedCollapseKey matches collapseKey; older completed todos will remain expanded");
+	}
 	// Re-key a session's slot from its branch, then refresh the overlay only when
 	// the refreshed session IS the foreground. Shared by session_compact and
 	// session_tree (verbatim-identical pre-extraction). A stale ctx (auto-compaction

--- a/packages/rpiv-todo/state/selectors.ts
+++ b/packages/rpiv-todo/state/selectors.ts
@@ -96,6 +96,52 @@ export function selectOverlayLayout(state: TaskState, budget: number): OverlayLa
 	return { visible, hiddenCompleted: totalCompleted, truncatedTail };
 }
 
+export interface PriorityOverlayLayout {
+	visible: readonly Task[];
+	hiddenInProgress: number;
+	hiddenPending: number;
+	hiddenCompleted: number;
+	get hiddenTotal(): number;
+}
+
+/**
+ * Project the full task state into Claude-like terminal priority order. Freshly
+ * completed tasks are temporarily surfaced, then active work, unblocked pending
+ * work, blocked pending work, and finally older completed tasks. The canonical
+ * state itself remains untouched and in chronological order.
+ */
+export function selectPriorityOverlayLayout(
+	state: TaskState,
+	budget: number,
+	recentlyCompletedTaskIds: ReadonlySet<number>,
+): PriorityOverlayLayout {
+	const tasks = selectVisibleTasks(state);
+	const activeTaskIds = new Set(tasks.filter((task) => task.status !== "completed").map((task) => task.id));
+	const recentlyCompleted = tasks.filter(
+		(task) => task.status === "completed" && recentlyCompletedTaskIds.has(task.id),
+	);
+	const olderCompleted = tasks.filter((task) => task.status === "completed" && !recentlyCompletedTaskIds.has(task.id));
+	const inProgress = tasks.filter((task) => task.status === "in_progress");
+	const pending = tasks.filter((task) => task.status === "pending");
+	const readyPending = pending.filter((task) => !task.blockedBy?.some((id) => activeTaskIds.has(id)));
+	const blockedPending = pending.filter((task) => task.blockedBy?.some((id) => activeTaskIds.has(id)));
+	const ordered = [...recentlyCompleted, ...inProgress, ...readyPending, ...blockedPending, ...olderCompleted];
+	const visible = ordered.slice(0, Math.max(0, budget));
+	const hidden = ordered.slice(visible.length);
+	const hiddenInProgress = hidden.filter((task) => task.status === "in_progress").length;
+	const hiddenPending = hidden.filter((task) => task.status === "pending").length;
+	const hiddenCompleted = hidden.filter((task) => task.status === "completed").length;
+	return {
+		visible,
+		hiddenInProgress,
+		hiddenPending,
+		hiddenCompleted,
+		get hiddenTotal() {
+			return hiddenInProgress + hiddenPending + hiddenCompleted;
+		},
+	};
+}
+
 /**
  * Helper: whether any visible task is `pending` or `in_progress`. The overlay
  * uses this to pick the heading icon (`accent`+`●` vs `dim`+`○`).

--- a/packages/rpiv-todo/state/selectors.ts
+++ b/packages/rpiv-todo/state/selectors.ts
@@ -105,7 +105,8 @@ export interface PriorityOverlayLayout {
 }
 
 /**
- * Project the full task state into Claude-like terminal priority order. Freshly
+ * Project the full task state into a Claude-like terminal projection. When every
+ * task fits, retain the canonical chronological order. On overflow, freshly
  * completed tasks are temporarily surfaced, then active work, unblocked pending
  * work, blocked pending work, and finally older completed tasks. The canonical
  * state itself remains untouched and in chronological order.
@@ -116,6 +117,18 @@ export function selectPriorityOverlayLayout(
 	recentlyCompletedTaskIds: ReadonlySet<number>,
 ): PriorityOverlayLayout {
 	const tasks = selectVisibleTasks(state);
+	const safeBudget = Math.max(0, budget);
+	if (tasks.length <= safeBudget) {
+		return {
+			visible: tasks,
+			hiddenInProgress: 0,
+			hiddenPending: 0,
+			hiddenCompleted: 0,
+			get hiddenTotal() {
+				return 0;
+			},
+		};
+	}
 	const activeTaskIds = new Set(tasks.filter((task) => task.status !== "completed").map((task) => task.id));
 	const recentlyCompleted = tasks.filter(
 		(task) => task.status === "completed" && recentlyCompletedTaskIds.has(task.id),
@@ -126,7 +139,7 @@ export function selectPriorityOverlayLayout(
 	const readyPending = pending.filter((task) => !task.blockedBy?.some((id) => activeTaskIds.has(id)));
 	const blockedPending = pending.filter((task) => task.blockedBy?.some((id) => activeTaskIds.has(id)));
 	const ordered = [...recentlyCompleted, ...inProgress, ...readyPending, ...blockedPending, ...olderCompleted];
-	const visible = ordered.slice(0, Math.max(0, budget));
+	const visible = ordered.slice(0, safeBudget);
 	const hidden = ordered.slice(visible.length);
 	const hiddenInProgress = hidden.filter((task) => task.status === "in_progress").length;
 	const hiddenPending = hidden.filter((task) => task.status === "pending").length;

--- a/packages/rpiv-todo/todo-overlay.render.test.ts
+++ b/packages/rpiv-todo/todo-overlay.render.test.ts
@@ -138,6 +138,114 @@ describe("TodoOverlay — per-task formatting", () => {
 		overlay.hideCompletedTasksFromPreviousTurn();
 		expect(widget.render(200)).toEqual([]);
 	});
+
+	it("keeps completed rows and counts visible across agent turns in session mode", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		const { widget, overlay } = await setup([
+			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "completed" },
+			{ action: "create", subject: "next" },
+		]);
+		expect(widget.render(200).join("\n")).toContain("Todos (1/2)");
+		overlay.hideCompletedTasksFromPreviousTurn();
+		const nextTurn = widget.render(200).join("\n");
+		expect(nextTurn).toContain("Todos (1/2)");
+		expect(nextTurn).toContain("done");
+		expect(nextTurn).toContain("next");
+	});
+
+	it("applies a session-to-turn policy change at the next agent turn", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		const { widget, overlay } = await setup([
+			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "completed" },
+			{ action: "create", subject: "next" },
+		]);
+		// Rendering in session mode marks the retained rows. The following agent turn
+		// must apply a switch back to turn mode immediately, not one turn later.
+		expect(widget.render(200).join("\n")).toContain("Todos (1/2)");
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "turn" }));
+		overlay.hideCompletedTasksFromPreviousTurn();
+		const nextTurn = widget.render(200).join("\n");
+		expect(nextTurn).toContain("Todos (0/1)");
+		expect(nextTurn).not.toContain("done");
+		expect(nextTurn).toContain("next");
+	});
+});
+
+describe("TodoOverlay — session completed-row folding", () => {
+	it("folds only the oldest completed prefix, retains the newest five rows, and expands in place", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 5 }));
+		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
+		for (let i = 1; i <= 7; i++) actions.push({ action: "create", subject: `task-${i}` });
+		for (let i = 1; i <= 6; i++) actions.push({ action: "update", id: i, status: "completed" });
+		const { widget, overlay } = await setup(actions);
+		const folded = widget.render(200).join("\n");
+		expect(folded).toContain("Todos (6/7)");
+		expect(folded).toContain("▶ 1 completed");
+		expect(folded).toContain("ctrl+shift+c to expand");
+		expect(folded).not.toContain("task-1");
+		for (let i = 2; i <= 7; i++) expect(folded).toContain(`task-${i}`);
+		expect(folded.indexOf("▶ 1 completed")).toBeLessThan(folded.indexOf("task-2"));
+		overlay.toggleCompletedRows();
+		const expanded = widget.render(200).join("\n");
+		expect(expanded).toContain("▼ 1 completed");
+		expect(expanded).toContain("task-1");
+		expect(expanded.indexOf("task-1")).toBeLessThan(expanded.indexOf("task-2"));
+		overlay.toggleCompletedRows();
+		expect(widget.render(200).join("\n")).not.toContain("task-1");
+	});
+
+	it("keeps all active and pending rows visible beyond maxWidgetLines", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxWidgetLines: 3 }));
+		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
+		for (let i = 1; i <= 8; i++) actions.push({ action: "create", subject: `open-${i}` });
+		const { widget } = await setup(actions);
+		const lines = widget.render(200);
+		for (let i = 1; i <= 8; i++) expect(lines.join("\n")).toContain(`open-${i}`);
+		expect(lines).toHaveLength(10); // heading + 8 tasks + trailing spacer
+		expect(lines.join("\n")).not.toContain("+5 more");
+	});
+
+	it("does not reorder or fold completed rows behind an unfinished task", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 5 }));
+		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
+		for (let i = 1; i <= 8; i++) actions.push({ action: "create", subject: `task-${i}` });
+		actions.push({ action: "update", id: 1, status: "completed" });
+		for (let i = 3; i <= 8; i++) actions.push({ action: "update", id: i, status: "completed" });
+		const { widget } = await setup(actions);
+		const output = widget.render(200).join("\n");
+		expect(output).not.toContain("▶");
+		for (const i of [1, 3, 4, 5, 6, 7, 8]) expect(output).toContain(`task-${i}`);
+		expect(output.indexOf("task-1")).toBeLessThan(output.indexOf("task-2"));
+		expect(output.indexOf("task-2")).toBeLessThan(output.indexOf("task-3"));
+	});
+
+	it("keeps all completed rows expanded when the completed-row shortcut is off", async () => {
+		writeConfigFile(
+			JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 0, completedCollapseKey: "off" }),
+		);
+		const { widget } = await setup([
+			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "completed" },
+		]);
+		const output = widget.render(200).join("\n");
+		expect(output).toContain("done");
+		expect(output).not.toContain("▶");
+	});
+
+	it("keeps completed rows expanded when the completed-row key collides with the whole-panel key", async () => {
+		writeConfigFile(
+			JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 0, collapseKey: "ctrl+shift+c" }),
+		);
+		const { widget } = await setup([
+			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "completed" },
+		]);
+		const output = widget.render(200).join("\n");
+		expect(output).toContain("done");
+		expect(output).not.toContain("▶");
+	});
 });
 
 describe("TodoOverlay — showIds gate", () => {

--- a/packages/rpiv-todo/todo-overlay.render.test.ts
+++ b/packages/rpiv-todo/todo-overlay.render.test.ts
@@ -23,7 +23,7 @@ const identityTheme = {
 	strikethrough: (s: string) => s,
 };
 
-async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }>) {
+async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }>, terminalRows = 24) {
 	__resetState();
 	setActiveRenderSession("test-session");
 	const { pi, captured } = createMockPi();
@@ -42,8 +42,9 @@ async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }
 		tui: { requestRender: () => void },
 		theme: typeof identityTheme,
 	) => { render: (w: number) => string[]; invalidate: () => void };
-	const widget = factory({ requestRender: vi.fn() }, identityTheme);
-	return { widget, tool, ui, overlay };
+	const tui = { requestRender: vi.fn(), terminal: { rows: terminalRows } };
+	const widget = factory(tui, identityTheme);
+	return { widget, tool, ui, overlay, tui };
 }
 
 beforeEach(() => {
@@ -175,7 +176,13 @@ describe("TodoOverlay — per-task formatting", () => {
 
 describe("TodoOverlay — session completed-row folding", () => {
 	it("folds only the oldest completed prefix, retains the newest five rows, and expands in place", async () => {
-		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 5 }));
+		writeConfigFile(
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				maxVisibleCompleted: 5,
+			}),
+		);
 		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
 		for (let i = 1; i <= 7; i++) actions.push({ action: "create", subject: `task-${i}` });
 		for (let i = 1; i <= 6; i++) actions.push({ action: "update", id: i, status: "completed" });
@@ -197,7 +204,13 @@ describe("TodoOverlay — session completed-row folding", () => {
 	});
 
 	it("keeps all active and pending rows visible beyond maxWidgetLines", async () => {
-		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxWidgetLines: 3 }));
+		writeConfigFile(
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				maxWidgetLines: 3,
+			}),
+		);
 		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
 		for (let i = 1; i <= 8; i++) actions.push({ action: "create", subject: `open-${i}` });
 		const { widget } = await setup(actions);
@@ -208,7 +221,13 @@ describe("TodoOverlay — session completed-row folding", () => {
 	});
 
 	it("does not reorder or fold completed rows behind an unfinished task", async () => {
-		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 5 }));
+		writeConfigFile(
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				maxVisibleCompleted: 5,
+			}),
+		);
 		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
 		for (let i = 1; i <= 8; i++) actions.push({ action: "create", subject: `task-${i}` });
 		actions.push({ action: "update", id: 1, status: "completed" });
@@ -223,7 +242,12 @@ describe("TodoOverlay — session completed-row folding", () => {
 
 	it("keeps all completed rows expanded when the completed-row shortcut is off", async () => {
 		writeConfigFile(
-			JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 0, completedCollapseKey: "off" }),
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				maxVisibleCompleted: 0,
+				completedCollapseKey: "off",
+			}),
 		);
 		const { widget } = await setup([
 			{ action: "create", subject: "done" },
@@ -234,9 +258,32 @@ describe("TodoOverlay — session completed-row folding", () => {
 		expect(output).not.toContain("▶");
 	});
 
+	it("keeps completed rows expanded until the session shortcut has been bound", async () => {
+		writeConfigFile(
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				maxVisibleCompleted: 0,
+			}),
+		);
+		const { widget, overlay } = await setup([
+			{ action: "create", subject: "done" },
+			{ action: "update", id: 1, status: "completed" },
+		]);
+		overlay.setCompletedRowsShortcutEnabled(false);
+		const output = widget.render(200).join("\n");
+		expect(output).toContain("done");
+		expect(output).not.toContain("▶");
+	});
+
 	it("keeps completed rows expanded when the completed-row key collides with the whole-panel key", async () => {
 		writeConfigFile(
-			JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 0, collapseKey: "ctrl+shift+c" }),
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				maxVisibleCompleted: 0,
+				collapseKey: "ctrl+shift+c",
+			}),
 		);
 		const { widget } = await setup([
 			{ action: "create", subject: "done" },
@@ -245,6 +292,59 @@ describe("TodoOverlay — session completed-row folding", () => {
 		const output = widget.render(200).join("\n");
 		expect(output).toContain("done");
 		expect(output).not.toContain("▶");
+	});
+});
+
+describe("TodoOverlay — session priority presentation", () => {
+	it("uses Claude-like priority order and a status-counted overflow summary by default", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		const { widget } = await setup(
+			[
+				{ action: "create", subject: "old-completed" },
+				{ action: "update", id: 1, status: "completed" },
+				{ action: "create", subject: "in-progress" },
+				{ action: "update", id: 2, status: "in_progress" },
+				{ action: "create", subject: "ready" },
+				{ action: "create", subject: "blocked", blockedBy: [3] },
+				{ action: "create", subject: "other-completed" },
+				{ action: "update", id: 5, status: "completed" },
+			],
+			16,
+		);
+		const output = widget.render(200).join("\n");
+		expect(output).toContain("Todos (2/5)");
+		expect(output.indexOf("in-progress")).toBeLessThan(output.indexOf("ready"));
+		expect(output.indexOf("ready")).toBeLessThan(output.indexOf("blocked"));
+		expect(output).not.toContain("old-completed");
+		expect(output).not.toContain("other-completed");
+		expect(output).toContain("… +2 completed");
+	});
+
+	it("temporarily surfaces a task completed during the current session", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		const { widget, tool } = await setup(
+			[
+				{ action: "create", subject: "old-completed" },
+				{ action: "update", id: 1, status: "completed" },
+				{ action: "create", subject: "in-progress" },
+				{ action: "update", id: 2, status: "in_progress" },
+				{ action: "create", subject: "newly-completed" },
+				{ action: "create", subject: "ready" },
+			],
+			16,
+		);
+		widget.render(200); // establish the pre-completion snapshot
+		await tool.execute?.(
+			"tc",
+			{ action: "update", id: 3, status: "completed" } as never,
+			undefined as never,
+			undefined as never,
+			createMockCtx() as never,
+		);
+		const output = widget.render(200).join("\n");
+		expect(output.indexOf("newly-completed")).toBeLessThan(output.indexOf("in-progress"));
+		expect(output.indexOf("in-progress")).toBeLessThan(output.indexOf("ready"));
+		expect(output).not.toContain("old-completed");
 	});
 });
 

--- a/packages/rpiv-todo/todo-overlay.render.test.ts
+++ b/packages/rpiv-todo/todo-overlay.render.test.ts
@@ -320,6 +320,60 @@ describe("TodoOverlay — session priority presentation", () => {
 		expect(output).toContain("… +2 completed");
 	});
 
+	it("returns an expired recent completion to the older-completed overflow group", async () => {
+		vi.useFakeTimers();
+		try {
+			writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+			const { widget, tool, tui } = await setup(
+				[
+					{ action: "create", subject: "old-completed" },
+					{ action: "update", id: 1, status: "completed" },
+					{ action: "create", subject: "in-progress" },
+					{ action: "update", id: 2, status: "in_progress" },
+					{ action: "create", subject: "newly-completed" },
+					{ action: "create", subject: "ready" },
+				],
+				16,
+			);
+			widget.render(200); // establish the pre-completion snapshot
+			await tool.execute?.(
+				"tc",
+				{ action: "update", id: 3, status: "completed" } as never,
+				undefined as never,
+				undefined as never,
+				createMockCtx() as never,
+			);
+			let output = widget.render(200).join("\n");
+			expect(output.indexOf("newly-completed")).toBeLessThan(output.indexOf("in-progress"));
+			await vi.advanceTimersByTimeAsync(5_000);
+			expect(tui.requestRender).toHaveBeenCalledWith(true);
+			output = widget.render(200).join("\n");
+			expect(output.indexOf("in-progress")).toBeLessThan(output.indexOf("ready"));
+			expect(output).not.toContain("newly-completed");
+			expect(output).toContain("… +1 completed");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps original task order when the complete priority list fits the terminal budget", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		const { widget } = await setup(
+			[
+				{ action: "create", subject: "completed-first" },
+				{ action: "update", id: 1, status: "completed" },
+				{ action: "create", subject: "in-progress-second" },
+				{ action: "update", id: 2, status: "in_progress" },
+				{ action: "create", subject: "pending-third" },
+			],
+			24,
+		);
+		const output = widget.render(200).join("\n");
+		expect(output.indexOf("completed-first")).toBeLessThan(output.indexOf("in-progress-second"));
+		expect(output.indexOf("in-progress-second")).toBeLessThan(output.indexOf("pending-third"));
+		expect(output).not.toContain("… +");
+	});
+
 	it("temporarily surfaces a task completed during the current session", async () => {
 		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
 		const { widget, tool } = await setup(

--- a/packages/rpiv-todo/todo-overlay.shortcut.test.ts
+++ b/packages/rpiv-todo/todo-overlay.shortcut.test.ts
@@ -54,6 +54,13 @@ describe("rpiv-todo — collapse/expand shortcut registration", () => {
 		expect(shortcut?.description).toContain("Collapse");
 	});
 
+	it("registers the default completed-row shortcut separately", () => {
+		const { captured } = setup();
+		const shortcut = captured.shortcuts.get("ctrl+shift+c");
+		expect(shortcut).toBeDefined();
+		expect(shortcut?.description).toContain("completed");
+	});
+
 	it("handler is a no-op in headless mode (!ctx.hasUI)", async () => {
 		const { captured, sessionStart, toolEnd, tool } = setup();
 		const ctx = createMockCtx({ sessionId: "s1", hasUI: true });
@@ -133,6 +140,45 @@ describe("rpiv-todo — collapse/expand shortcut registration", () => {
 		await captured.shortcuts.get("ctrl+shift+t")?.handler?.(ctx as never);
 		expect(widget.render(200).some((l) => l.includes("ctrl+shift+t to expand"))).toBe(false);
 	});
+
+	it("completed-row handler expands a folded prefix without collapsing the whole overlay", async () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 0 }));
+		const { captured, sessionStart, toolEnd, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "s1", hasUI: true });
+		await sessionStart?.({} as never, ctx as never);
+		await tool.execute?.(
+			"tc",
+			{ action: "create", subject: "done" } as never,
+			undefined as never,
+			undefined as never,
+			ctx as never,
+		);
+		await toolEnd?.({ toolName: "todo", isError: false });
+		await tool.execute?.(
+			"tc",
+			{ action: "update", id: 1, status: "completed" } as never,
+			undefined as never,
+			undefined as never,
+			ctx as never,
+		);
+		await toolEnd?.({ toolName: "todo", isError: false });
+		const setWidget = ctx.ui.setWidget as ReturnType<typeof vi.fn>;
+		const factory = setWidget.mock.calls[0][1] as (
+			tui: { requestRender: (...args: unknown[]) => void },
+			theme: { fg: (c: string, s: string) => string },
+		) => { render: (w: number) => string[]; invalidate: () => void };
+		const requestRender = vi.fn();
+		const widget = factory({ requestRender }, {
+			fg: (_c: string, s: string) => s,
+			strikethrough: (s: string) => s,
+		} as { fg: (c: string, s: string) => string; strikethrough: (s: string) => string });
+		expect(widget.render(200).join("\n")).toContain("▶ 1 completed");
+		await captured.shortcuts.get("ctrl+shift+c")?.handler?.(ctx as never);
+		expect(requestRender).toHaveBeenCalledWith(true);
+		const expanded = widget.render(200).join("\n");
+		expect(expanded).toContain("▼ 1 completed");
+		expect(expanded).toContain("done");
+	});
 });
 
 describe("rpiv-todo — collapse/expand shortcut config resolution", () => {
@@ -146,10 +192,18 @@ describe("rpiv-todo — collapse/expand shortcut config resolution", () => {
 		expect(captured.shortcuts.has("ctrl+shift+t")).toBe(false);
 	});
 
-	it("skips registerShortcut entirely when collapseKey is 'off'", () => {
+	it("keeps the completed-row shortcut when the whole-overlay shortcut is off", () => {
 		writeConfigFile(JSON.stringify({ collapseKey: "off" }));
 		const { captured } = setup();
-		expect(captured.shortcuts.size).toBe(0);
+		expect(captured.shortcuts.has("ctrl+shift+t")).toBe(false);
+		expect(captured.shortcuts.has("ctrl+shift+c")).toBe(true);
+	});
+
+	it("skips only the completed-row shortcut when it is off", () => {
+		writeConfigFile(JSON.stringify({ completedCollapseKey: "off" }));
+		const { captured } = setup();
+		expect(captured.shortcuts.has("ctrl+shift+t")).toBe(true);
+		expect(captured.shortcuts.has("ctrl+shift+c")).toBe(false);
 	});
 
 	it("falls back to the default key when collapseKey is invalid", () => {
@@ -161,5 +215,14 @@ describe("rpiv-todo — collapse/expand shortcut config resolution", () => {
 	it("default config registers the default key (ctrl+shift+t)", () => {
 		const { captured } = setup();
 		expect(captured.shortcuts.has("ctrl+shift+t")).toBe(true);
+	});
+
+	it("warns and leaves completed rows expanded when both controls use the same key", () => {
+		writeConfigFile(JSON.stringify({ collapseKey: "ctrl+shift+c" }));
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const { captured } = setup();
+		expect(captured.shortcuts.size).toBe(1);
+		expect(captured.shortcuts.has("ctrl+shift+c")).toBe(true);
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("completedCollapseKey matches collapseKey"));
 	});
 });

--- a/packages/rpiv-todo/todo-overlay.shortcut.test.ts
+++ b/packages/rpiv-todo/todo-overlay.shortcut.test.ts
@@ -54,11 +54,25 @@ describe("rpiv-todo — collapse/expand shortcut registration", () => {
 		expect(shortcut?.description).toContain("Collapse");
 	});
 
-	it("registers the default completed-row shortcut separately", () => {
+	it("does not register the completed-row shortcut under the default turn policy", () => {
+		const { captured } = setup();
+		expect(captured.shortcuts.has("ctrl+shift+c")).toBe(false);
+	});
+
+	it("registers the completed-row shortcut only for chronological session presentation", () => {
+		writeConfigFile(
+			JSON.stringify({ completedTaskVisibility: "session", completedTaskPresentation: "chronological" }),
+		);
 		const { captured } = setup();
 		const shortcut = captured.shortcuts.get("ctrl+shift+c");
 		expect(shortcut).toBeDefined();
 		expect(shortcut?.description).toContain("completed");
+	});
+
+	it("does not register the completed-row shortcut for default priority session presentation", () => {
+		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session" }));
+		const { captured } = setup();
+		expect(captured.shortcuts.has("ctrl+shift+c")).toBe(false);
 	});
 
 	it("handler is a no-op in headless mode (!ctx.hasUI)", async () => {
@@ -142,7 +156,13 @@ describe("rpiv-todo — collapse/expand shortcut registration", () => {
 	});
 
 	it("completed-row handler expands a folded prefix without collapsing the whole overlay", async () => {
-		writeConfigFile(JSON.stringify({ completedTaskVisibility: "session", maxVisibleCompleted: 0 }));
+		writeConfigFile(
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				maxVisibleCompleted: 0,
+			}),
+		);
 		const { captured, sessionStart, toolEnd, tool } = setup();
 		const ctx = createMockCtx({ sessionId: "s1", hasUI: true });
 		await sessionStart?.({} as never, ctx as never);
@@ -193,14 +213,26 @@ describe("rpiv-todo — collapse/expand shortcut config resolution", () => {
 	});
 
 	it("keeps the completed-row shortcut when the whole-overlay shortcut is off", () => {
-		writeConfigFile(JSON.stringify({ collapseKey: "off" }));
+		writeConfigFile(
+			JSON.stringify({
+				collapseKey: "off",
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+			}),
+		);
 		const { captured } = setup();
 		expect(captured.shortcuts.has("ctrl+shift+t")).toBe(false);
 		expect(captured.shortcuts.has("ctrl+shift+c")).toBe(true);
 	});
 
 	it("skips only the completed-row shortcut when it is off", () => {
-		writeConfigFile(JSON.stringify({ completedCollapseKey: "off" }));
+		writeConfigFile(
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				completedCollapseKey: "off",
+			}),
+		);
 		const { captured } = setup();
 		expect(captured.shortcuts.has("ctrl+shift+t")).toBe(true);
 		expect(captured.shortcuts.has("ctrl+shift+c")).toBe(false);
@@ -218,7 +250,13 @@ describe("rpiv-todo — collapse/expand shortcut config resolution", () => {
 	});
 
 	it("warns and leaves completed rows expanded when both controls use the same key", () => {
-		writeConfigFile(JSON.stringify({ collapseKey: "ctrl+shift+c" }));
+		writeConfigFile(
+			JSON.stringify({
+				completedTaskVisibility: "session",
+				completedTaskPresentation: "chronological",
+				collapseKey: "ctrl+shift+c",
+			}),
+		);
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 		const { captured } = setup();
 		expect(captured.shortcuts.size).toBe(1);

--- a/packages/rpiv-todo/todo-overlay.ts
+++ b/packages/rpiv-todo/todo-overlay.ts
@@ -14,7 +14,14 @@
 
 import type { ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { type TUI, truncateToWidth } from "@earendil-works/pi-tui";
-import { COLLAPSE_KEY_OFF, getMaxWidgetLines, resolveCollapseKey } from "./config.js";
+import {
+	COLLAPSE_KEY_OFF,
+	getCompletedTaskVisibility,
+	getMaxVisibleCompleted,
+	getMaxWidgetLines,
+	resolveCollapseKey,
+	resolveCompletedCollapseKey,
+} from "./config.js";
 import { formatStatusLabel, t } from "./state/i18n-bridge.js";
 import { selectHasActive, selectOverlayLayout, selectShowTaskIds, selectTodoCounts } from "./state/selectors.js";
 import { getRenderState } from "./state/store.js";
@@ -34,6 +41,8 @@ export class TodoOverlay {
 	private tui: TUI | undefined;
 	private completedTaskIdsPendingHide = new Set<number>();
 	private hiddenCompletedTaskIds = new Set<number>();
+	private completedRowsExpanded = false;
+	private completedSessionWasActive = false;
 	private lastNextId: number | undefined;
 	private collapsed = false;
 
@@ -85,10 +94,32 @@ export class TodoOverlay {
 	resetCompletedDisplayState(): void {
 		this.completedTaskIdsPendingHide.clear();
 		this.hiddenCompletedTaskIds.clear();
+		this.completedRowsExpanded = false;
+		this.completedSessionWasActive = false;
 		this.lastNextId = undefined;
 	}
 
 	hideCompletedTasksFromPreviousTurn(): void {
+		if (getCompletedTaskVisibility() === "session") {
+			// Session mode keeps completed rows available. Clear only stale state from a
+			// preceding turn-mode render without collapsing a user-expanded fold.
+			this.completedTaskIdsPendingHide.clear();
+			this.hiddenCompletedTaskIds.clear();
+			this.completedSessionWasActive = true;
+			this.tui?.requestRender();
+			return;
+		}
+		if (this.completedSessionWasActive) {
+			// A policy change is applied on this turn boundary: rows retained under
+			// session mode now become subject to the compact turn-mode behavior.
+			for (const task of this.getSnapshot().tasks) {
+				if (task.status === "completed") this.hiddenCompletedTaskIds.add(task.id);
+			}
+			this.completedRowsExpanded = false;
+			this.completedSessionWasActive = false;
+			this.tui?.requestRender();
+			return;
+		}
 		if (this.completedTaskIdsPendingHide.size === 0) return;
 		for (const taskId of this.completedTaskIdsPendingHide) {
 			this.hiddenCompletedTaskIds.add(taskId);
@@ -96,7 +127,6 @@ export class TodoOverlay {
 		this.completedTaskIdsPendingHide.clear();
 		this.tui?.requestRender();
 	}
-
 	toggleCollapse(): void {
 		this.collapsed = !this.collapsed;
 		// Forced full redraw on the collapsed↔expanded height step, mirroring the
@@ -105,6 +135,12 @@ export class TodoOverlay {
 		this.tui?.requestRender(true);
 	}
 
+	toggleCompletedRows(): void {
+		const snapshot = this.getSnapshot();
+		if (this.getFoldedCompletedPrefixCount(this.selectOverlayTasks(snapshot)) === 0) return;
+		this.completedRowsExpanded = !this.completedRowsExpanded;
+		this.tui?.requestRender(true);
+	}
 	isRegistered(): boolean {
 		return this.widgetRegistered;
 	}
@@ -128,13 +164,29 @@ export class TodoOverlay {
 	}
 
 	private selectOverlayTasks(snapshot: ReturnType<TodoOverlay["getSnapshot"]>) {
-		return snapshot.tasks.filter((task) => task.status !== "deleted" && !this.shouldHideCompletedTask(task));
+		const visibility = getCompletedTaskVisibility();
+		return snapshot.tasks.filter(
+			(task) => task.status !== "deleted" && (visibility === "session" || !this.shouldHideCompletedTask(task)),
+		);
+	}
+
+	private getFoldedCompletedPrefixCount(
+		tasks: readonly ReturnType<TodoOverlay["getSnapshot"]>["tasks"][number][],
+	): number {
+		if (getCompletedTaskVisibility() !== "session") return 0;
+		const completedKey = resolveCompletedCollapseKey();
+		if (completedKey === COLLAPSE_KEY_OFF || completedKey === resolveCollapseKey()) return 0;
+		let completedPrefixCount = 0;
+		for (const task of tasks) {
+			if (task.status !== "completed") break;
+			completedPrefixCount++;
+		}
+		return Math.max(0, completedPrefixCount - getMaxVisibleCompleted());
 	}
 
 	private shouldHideCompletedTask(task: ReturnType<TodoOverlay["getSnapshot"]>["tasks"][number]): boolean {
 		return task.status === "completed" && this.hiddenCompletedTaskIds.has(task.id);
 	}
-
 	private renderWidget(theme: Theme, width: number): string[] {
 		const snapshot = this.getSnapshot();
 		const overlayTasks = this.selectOverlayTasks(snapshot);
@@ -170,8 +222,33 @@ export class TodoOverlay {
 		}
 
 		const lines: string[] = [heading];
-		// Budget for content rows (heading + tasks/summary). The rendered widget is
-		// one line taller — withTrailingSpacer() appends a blank row below the panel.
+		const completedVisibility = getCompletedTaskVisibility();
+		if (completedVisibility === "session") this.completedSessionWasActive = true;
+		if (completedVisibility === "session") {
+			// Session mode preserves the chronological list. Only an old completed prefix
+			// folds, leaving all active and pending rows individually visible even beyond
+			// the normal terminal-row budget.
+			const foldedCompletedCount = this.getFoldedCompletedPrefixCount(overlayTasks);
+			const visibleTasks = this.completedRowsExpanded ? overlayTasks : overlayTasks.slice(foldedCompletedCount);
+			if (foldedCompletedCount > 0) {
+				const icon = this.completedRowsExpanded ? "▼" : "▶";
+				const label = `${foldedCompletedCount} ${formatStatusLabel("completed")}`;
+				const key = resolveCompletedCollapseKey();
+				const detail = this.completedRowsExpanded
+					? label
+					: `${label} · ${t("overlay.expandHint", OVERLAY_EXPAND_HINT).replace("{key}", key)}`;
+				lines.push(truncate(`${theme.fg("dim", "├─")} ${theme.fg("dim", `${icon} ${detail}`)}`));
+			}
+			for (const task of visibleTasks) {
+				lines.push(truncate(`${theme.fg("dim", "├─")} ${formatOverlayTaskLine(task, theme, showIds)}`));
+			}
+			const last = lines.length - 1;
+			lines[last] = lines[last].replace("├─", "└─");
+			return this.withTrailingSpacer(lines);
+		}
+
+		// Turn mode retains the upstream compact-overlay behavior, including the
+		// terminal-height budget and next-agent-turn removal of completed rows.
 		const layout = selectOverlayLayout(overlayState, getMaxWidgetLines() - 1);
 		for (const task of layout.visible) {
 			lines.push(truncate(`${theme.fg("dim", "├─")} ${formatOverlayTaskLine(task, theme, showIds)}`));

--- a/packages/rpiv-todo/todo-overlay.ts
+++ b/packages/rpiv-todo/todo-overlay.ts
@@ -323,9 +323,9 @@ export class TodoOverlay {
 				return this.withTrailingSpacer(lines);
 			}
 
-			// Claude-like projection keeps the session state intact while fitting current
-			// work into the terminal: recent completion, in-progress, ready pending,
-			// blocked pending, then older completion.
+			// Claude-like projection keeps the session state intact. It preserves order
+			// when everything fits; on overflow it prioritizes recent completion,
+			// in-progress work, ready pending, blocked pending, then older completion.
 			const priorityLayout = selectPriorityOverlayLayout(
 				overlayState,
 				this.getPriorityTaskBudget(),

--- a/packages/rpiv-todo/todo-overlay.ts
+++ b/packages/rpiv-todo/todo-overlay.ts
@@ -16,6 +16,7 @@ import type { ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent"
 import { type TUI, truncateToWidth } from "@earendil-works/pi-tui";
 import {
 	COLLAPSE_KEY_OFF,
+	getCompletedTaskPresentation,
 	getCompletedTaskVisibility,
 	getMaxVisibleCompleted,
 	getMaxWidgetLines,
@@ -23,7 +24,13 @@ import {
 	resolveCompletedCollapseKey,
 } from "./config.js";
 import { formatStatusLabel, t } from "./state/i18n-bridge.js";
-import { selectHasActive, selectOverlayLayout, selectShowTaskIds, selectTodoCounts } from "./state/selectors.js";
+import {
+	selectHasActive,
+	selectOverlayLayout,
+	selectPriorityOverlayLayout,
+	selectShowTaskIds,
+	selectTodoCounts,
+} from "./state/selectors.js";
 import { getRenderState } from "./state/store.js";
 import { formatOverlayTaskLine } from "./view/format.js";
 
@@ -34,6 +41,7 @@ const OVERLAY_HEADING = "Todos";
 const OVERLAY_MORE = "more";
 const OVERLAY_EXPAND_HINT = "{key} to expand";
 const OVERLAY_COLLAPSED = "collapsed";
+const RECENT_COMPLETION_WINDOW_MS = 5_000;
 
 export class TodoOverlay {
 	private uiCtx: ExtensionUIContext | undefined;
@@ -42,9 +50,20 @@ export class TodoOverlay {
 	private completedTaskIdsPendingHide = new Set<number>();
 	private hiddenCompletedTaskIds = new Set<number>();
 	private completedRowsExpanded = false;
+	// Standalone overlay tests do not exercise extension shortcut registration; the
+	// extension explicitly disables this when session folding is not bound.
+	private completedRowsShortcutEnabled = true;
 	private completedSessionWasActive = false;
+	private observedTaskStatuses = new Map<number, string>();
+	private recentCompletedAt = new Map<number, number>();
+	private recentCompletionTimer: ReturnType<typeof setTimeout> | undefined;
 	private lastNextId: number | undefined;
 	private collapsed = false;
+
+	setCompletedRowsShortcutEnabled(enabled: boolean): void {
+		this.completedRowsShortcutEnabled = enabled;
+		if (!enabled) this.completedRowsExpanded = false;
+	}
 
 	setUICtx(ctx: ExtensionUIContext): void {
 		// Identity-compare so repeat session_start handlers are idempotent;
@@ -96,6 +115,10 @@ export class TodoOverlay {
 		this.hiddenCompletedTaskIds.clear();
 		this.completedRowsExpanded = false;
 		this.completedSessionWasActive = false;
+		this.observedTaskStatuses.clear();
+		this.recentCompletedAt.clear();
+		if (this.recentCompletionTimer) clearTimeout(this.recentCompletionTimer);
+		this.recentCompletionTimer = undefined;
 		this.lastNextId = undefined;
 	}
 
@@ -141,6 +164,7 @@ export class TodoOverlay {
 		this.completedRowsExpanded = !this.completedRowsExpanded;
 		this.tui?.requestRender(true);
 	}
+
 	isRegistered(): boolean {
 		return this.widgetRegistered;
 	}
@@ -151,6 +175,7 @@ export class TodoOverlay {
 			this.resetCompletedDisplayState();
 		}
 		this.lastNextId = state.nextId;
+		this.observeTaskStatusTransitions(state.tasks);
 		const completedTaskIds = new Set(
 			state.tasks.filter((task) => task.status === "completed").map((task) => task.id),
 		);
@@ -161,6 +186,57 @@ export class TodoOverlay {
 			if (!completedTaskIds.has(taskId)) this.hiddenCompletedTaskIds.delete(taskId);
 		}
 		return { tasks: [...state.tasks], nextId: state.nextId };
+	}
+
+	private observeTaskStatusTransitions(
+		tasks: readonly ReturnType<TodoOverlay["getSnapshot"]>["tasks"][number][],
+	): void {
+		const now = Date.now();
+		const currentStatuses = new Map<number, string>();
+		for (const task of tasks) {
+			currentStatuses.set(task.id, task.status);
+			const previousStatus = this.observedTaskStatuses.get(task.id);
+			if (previousStatus !== undefined && previousStatus !== "completed" && task.status === "completed") {
+				this.recentCompletedAt.set(task.id, now);
+			} else if (task.status !== "completed") {
+				this.recentCompletedAt.delete(task.id);
+			}
+		}
+		for (const taskId of this.recentCompletedAt.keys()) {
+			if (!currentStatuses.has(taskId)) this.recentCompletedAt.delete(taskId);
+		}
+		this.observedTaskStatuses = currentStatuses;
+		for (const [taskId, completedAt] of this.recentCompletedAt) {
+			if (now - completedAt >= RECENT_COMPLETION_WINDOW_MS) this.recentCompletedAt.delete(taskId);
+		}
+		this.scheduleRecentCompletionRender();
+	}
+
+	private scheduleRecentCompletionRender(): void {
+		if (this.recentCompletionTimer) clearTimeout(this.recentCompletionTimer);
+		this.recentCompletionTimer = undefined;
+		if (getCompletedTaskVisibility() !== "session" || getCompletedTaskPresentation() !== "priority") return;
+		const now = Date.now();
+		let nextExpiry = Number.POSITIVE_INFINITY;
+		for (const completedAt of this.recentCompletedAt.values()) {
+			nextExpiry = Math.min(nextExpiry, completedAt + RECENT_COMPLETION_WINDOW_MS);
+		}
+		if (!Number.isFinite(nextExpiry)) return;
+		const timer = setTimeout(() => this.tui?.requestRender(true), Math.max(1, nextExpiry - now));
+		timer.unref?.();
+		this.recentCompletionTimer = timer;
+	}
+
+	private getRecentCompletedTaskIds(): ReadonlySet<number> {
+		return new Set(this.recentCompletedAt.keys());
+	}
+
+	private getPriorityTaskBudget(): number {
+		const terminalRows = this.tui?.terminal?.rows;
+		if (typeof terminalRows === "number") {
+			return terminalRows <= 10 ? 0 : Math.min(5, Math.max(3, terminalRows - 14));
+		}
+		return Math.min(5, Math.max(3, getMaxWidgetLines() - 1));
 	}
 
 	private selectOverlayTasks(snapshot: ReturnType<TodoOverlay["getSnapshot"]>) {
@@ -174,6 +250,7 @@ export class TodoOverlay {
 		tasks: readonly ReturnType<TodoOverlay["getSnapshot"]>["tasks"][number][],
 	): number {
 		if (getCompletedTaskVisibility() !== "session") return 0;
+		if (getCompletedTaskPresentation() !== "chronological" || !this.completedRowsShortcutEnabled) return 0;
 		const completedKey = resolveCompletedCollapseKey();
 		if (completedKey === COLLAPSE_KEY_OFF || completedKey === resolveCollapseKey()) return 0;
 		let completedPrefixCount = 0;
@@ -225,22 +302,50 @@ export class TodoOverlay {
 		const completedVisibility = getCompletedTaskVisibility();
 		if (completedVisibility === "session") this.completedSessionWasActive = true;
 		if (completedVisibility === "session") {
-			// Session mode preserves the chronological list. Only an old completed prefix
-			// folds, leaving all active and pending rows individually visible even beyond
-			// the normal terminal-row budget.
-			const foldedCompletedCount = this.getFoldedCompletedPrefixCount(overlayTasks);
-			const visibleTasks = this.completedRowsExpanded ? overlayTasks : overlayTasks.slice(foldedCompletedCount);
-			if (foldedCompletedCount > 0) {
-				const icon = this.completedRowsExpanded ? "▼" : "▶";
-				const label = `${foldedCompletedCount} ${formatStatusLabel("completed")}`;
-				const key = resolveCompletedCollapseKey();
-				const detail = this.completedRowsExpanded
-					? label
-					: `${label} · ${t("overlay.expandHint", OVERLAY_EXPAND_HINT).replace("{key}", key)}`;
-				lines.push(truncate(`${theme.fg("dim", "├─")} ${theme.fg("dim", `${icon} ${detail}`)}`));
+			if (getCompletedTaskPresentation() === "chronological") {
+				// Preserve chronological order and fold only an old completed prefix.
+				const foldedCompletedCount = this.getFoldedCompletedPrefixCount(overlayTasks);
+				const visibleTasks = this.completedRowsExpanded ? overlayTasks : overlayTasks.slice(foldedCompletedCount);
+				if (foldedCompletedCount > 0) {
+					const icon = this.completedRowsExpanded ? "▼" : "▶";
+					const label = `${foldedCompletedCount} ${formatStatusLabel("completed")}`;
+					const key = resolveCompletedCollapseKey();
+					const detail = this.completedRowsExpanded
+						? label
+						: `${label} · ${t("overlay.expandHint", OVERLAY_EXPAND_HINT).replace("{key}", key)}`;
+					lines.push(truncate(`${theme.fg("dim", "├─")} ${theme.fg("dim", `${icon} ${detail}`)}`));
+				}
+				for (const task of visibleTasks) {
+					lines.push(truncate(`${theme.fg("dim", "├─")} ${formatOverlayTaskLine(task, theme, showIds)}`));
+				}
+				const last = lines.length - 1;
+				lines[last] = lines[last].replace("├─", "└─");
+				return this.withTrailingSpacer(lines);
 			}
-			for (const task of visibleTasks) {
+
+			// Claude-like projection keeps the session state intact while fitting current
+			// work into the terminal: recent completion, in-progress, ready pending,
+			// blocked pending, then older completion.
+			const priorityLayout = selectPriorityOverlayLayout(
+				overlayState,
+				this.getPriorityTaskBudget(),
+				this.getRecentCompletedTaskIds(),
+			);
+			for (const task of priorityLayout.visible) {
 				lines.push(truncate(`${theme.fg("dim", "├─")} ${formatOverlayTaskLine(task, theme, showIds)}`));
+			}
+			if (priorityLayout.hiddenTotal > 0) {
+				const hiddenParts: string[] = [];
+				if (priorityLayout.hiddenInProgress > 0) {
+					hiddenParts.push(`${priorityLayout.hiddenInProgress} ${formatStatusLabel("in_progress")}`);
+				}
+				if (priorityLayout.hiddenPending > 0) {
+					hiddenParts.push(`${priorityLayout.hiddenPending} ${formatStatusLabel("pending")}`);
+				}
+				if (priorityLayout.hiddenCompleted > 0) {
+					hiddenParts.push(`${priorityLayout.hiddenCompleted} ${formatStatusLabel("completed")}`);
+				}
+				lines.push(truncate(`${theme.fg("dim", "├─")} ${theme.fg("dim", `… +${hiddenParts.join(", ")}`)}`));
 			}
 			const last = lines.length - 1;
 			lines[last] = lines[last].replace("├─", "└─");


### PR DESCRIPTION
## Summary

- Add opt-in `completedTaskVisibility: "session"` retention for completed todo state across agent turns.
- Keep the existing `"turn"` behavior as the default for backward compatibility.
- Add `completedTaskPresentation` for retained session views:
  - `"priority"` is the default Claude-like terminal-budgeted projection.
  - `"chronological"` preserves task order and retains completed-prefix folding.
- Register `completedCollapseKey` only for chronological session mode.
- Preserve original task order in priority mode when every task fits; apply status-based ordering only on overflow.
- Temporarily promote newly completed tasks in priority mode, then return them to the older-completed group after the five-second window.

## Configuration

```json
{
  "completedTaskVisibility": "session",
  "completedTaskPresentation": "priority"
}
```

Use chronological folding instead:

```json
{
  "completedTaskVisibility": "session",
  "completedTaskPresentation": "chronological",
  "maxVisibleCompleted": 5,
  "completedCollapseKey": "ctrl+shift+c"
}
```

## Verification

- `npm run check`
- `npm test`

Both passed: 255 test files and 4,782 tests.
