### PR TITLE
fix(rpiv-ask-user-question): rebalance previews after resize

### DIFF
--- a/packages/rpiv-ask-user-question/CHANGELOG.md
+++ b/packages/rpiv-ask-user-question/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Preview questionnaires now rebalance after terminal resizing: option descriptions gain useful width without exceeding half the dialog, while content-sized previews align with the right edge.
+
 ## [2.3.1] - 2026-07-31
 
 ## [2.3.0] - 2026-07-31

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-layout-decider.test.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-layout-decider.test.ts
@@ -149,12 +149,9 @@ describe("crossTabPreviewBudget", () => {
 
 describe("crossTabLeftWidthWithDonation", () => {
 	// 26-char label → labelDriven = 26 + 5 (prefix) + 2 (confirmed) = 33 > MIN_LEFT(30).
-	// Required to escape the compact-content guard so the donation path is exercised.
 	const LONG_LABEL = "Verbose Descriptive Option";
 
-	it("short labels (labelDriven ≤ MIN_LEFT) suppress donation — compact-content guard", () => {
-		// npm/yarn-style: short labels signal compact UI. Even with very narrow previews,
-		// donation would inject dead space between options and the box. Skip it.
+	it("short labels still donate newly available width", () => {
 		const tabs = [{ multiSelect: false }];
 		const itemsByTab = [[opt("npm"), opt("yarn")]];
 		const qs = [
@@ -163,22 +160,21 @@ describe("crossTabLeftWidthWithDonation", () => {
 				{ label: "yarn", preview: "yarn install" },
 			]),
 		];
-		const result = crossTabLeftWidthWithDonation(tabs, itemsByTab, qs, 200);
-		expect(result).toBe(MIN_LEFT);
+		const labelDriven = crossTabMaxLeftWidth(tabs, itemsByTab, 200);
+		expect(labelDriven).toBe(MIN_LEFT);
+		expect(crossTabLeftWidthWithDonation(tabs, itemsByTab, qs, 200)).toBe(Math.floor(200 * MAX_LEFT_RATIO));
 	});
 
-	it("no previews + long labels → donation hits ceiling (MIN_PREVIEW_WIDTH floor binds the budget)", () => {
+	it("donation uses the tighter of the ratio and preview-safety ceilings", () => {
 		const tabs = [{ multiSelect: false }];
 		const itemsByTab = [[opt(LONG_LABEL), opt("B")]];
 		const qs = [question([{ label: LONG_LABEL }, { label: "B" }])];
 		const labelDriven = crossTabMaxLeftWidth(tabs, itemsByTab, 120);
 		expect(labelDriven).toBeGreaterThan(MIN_LEFT);
 		const result = crossTabLeftWidthWithDonation(tabs, itemsByTab, qs, 120);
-		// MIN_PREVIEW_WIDTH is the budget floor, so donation still engages —
-		// result is the ceiling (paneWidth − GAP − MIN_PREVIEW_WIDTH).
-		expect(result).toBeGreaterThanOrEqual(labelDriven);
-		const ceiling = 120 - PREVIEW_COLUMN_GAP - MIN_PREVIEW_WIDTH;
-		expect(result).toBe(ceiling);
+		const previewSafetyCeiling = 120 - PREVIEW_COLUMN_GAP - MIN_PREVIEW_WIDTH;
+		const ratioCeiling = Math.floor(120 * MAX_LEFT_RATIO);
+		expect(result).toBe(Math.min(previewSafetyCeiling, ratioCeiling));
 	});
 
 	it("long labels + narrow previews → slack donation engaged", () => {

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-layout-decider.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-layout-decider.ts
@@ -139,17 +139,19 @@ export function crossTabPreviewBudget(questions: readonly QuestionData[], paneWi
  *   1. `labelDriven` = `crossTabMaxLeftWidth(tabs, itemsByTab, paneWidth)`
  *   2. `previewBudget` = `crossTabPreviewBudget(questions, paneWidth)`
  *   3. `slackDonation` = `paneWidth − GAP − previewBudget`
- *   4. Return `min(max(labelDriven, slackDonation), ceiling)` where `ceiling = paneWidth − GAP − MIN_PREVIEW_WIDTH`
+ *   4. Return `min(max(labelDriven, slackDonation), ceiling)` where `ceiling` is the
+ *      tighter of the preview-width safety limit and `MAX_LEFT_RATIO`
  *
  * Invariants:
  *   - Floor: result ≥ MIN_LEFT (labelDriven ≥ MIN_LEFT)
+ *   - Options cap: left column ≤ paneWidth × MAX_LEFT_RATIO
  *   - Preview floor: right column ≥ MIN_PREVIEW_WIDTH (ceiling enforces this)
  *   - Cross-tab stability: both reductions are tab-independent
  *   - Determinism: pure of (questions, itemsByTab, paneWidth)
  *
  * `crossTabMaxLeftWidth` is NOT replaced — it continues to exist as the primitive.
- * `MAX_LEFT_RATIO` caps the label-driven path inside `adaptiveLeftWidth`; donation
- * operates above the cap when preview slack is available.
+ * Donation obeys the same `MAX_LEFT_RATIO` cap as the label-driven path; the preview
+ * composer right-aligns narrower boxes inside the remaining column.
  */
 export function crossTabLeftWidthWithDonation(
 	tabs: ReadonlyArray<{ multiSelect?: boolean }>,
@@ -158,13 +160,11 @@ export function crossTabLeftWidthWithDonation(
 	paneWidth: number,
 ): number {
 	const labelDriven = crossTabMaxLeftWidth(tabs, itemsByTab, paneWidth);
-	// Compact-content guard: labels at MIN_LEFT fit below the floor, so widening
-	// the column would only inject dead space between the option list and the
-	// preview box. Skip donation and preserve the compact intent.
-	if (labelDriven <= MIN_LEFT) return labelDriven;
 	const previewBudget = crossTabPreviewBudget(questions, paneWidth);
 	const slackDonation = paneWidth - PREVIEW_COLUMN_GAP - previewBudget;
-	const ceiling = paneWidth - PREVIEW_COLUMN_GAP - MIN_PREVIEW_WIDTH;
+	const previewSafetyCeiling = paneWidth - PREVIEW_COLUMN_GAP - MIN_PREVIEW_WIDTH;
+	const ratioCeiling = Math.floor(paneWidth * MAX_LEFT_RATIO);
+	const ceiling = Math.min(previewSafetyCeiling, ratioCeiling);
 	return Math.min(Math.max(labelDriven, slackDonation), Math.max(1, ceiling));
 }
 

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-pane.test.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-pane.test.ts
@@ -129,16 +129,21 @@ describe("PreviewPane.render — layout switching", () => {
 		expect(trailing).toBeLessThanOrEqual(MAX_PREVIEW_HEIGHT_STACKED);
 	});
 
-	it("width 99 → stacked, width 100 → side-by-side (threshold boundary)", () => {
-		const narrow = makePane(question, () => 99);
-		narrow.optionListView.setProps({ selectedIndex: 0, focused: true, inputBuffer: "" });
-		const narrowLines = narrow.pane.render(99);
+	it("a resize from width 99 to 100 switches from stacked to right-aligned side-by-side", () => {
+		let terminalWidth = 99;
+		const view = makePane(question, () => terminalWidth);
+		view.pane.setGlobalLeftWidth((w) =>
+			crossTabLeftWidthWithDonation([{ multiSelect: false }], [view.items], [question], w),
+		);
+		view.optionListView.setProps({ selectedIndex: 0, focused: true, inputBuffer: "" });
+		const narrowLines = view.pane.render(99);
 		expect(narrowLines.findIndex((l) => /MD\[\d+\]:/.test(l))).toBeGreaterThan(0);
 
-		const wide = makePane(question, () => PREVIEW_MIN_WIDTH);
-		wide.optionListView.setProps({ selectedIndex: 0, focused: true, inputBuffer: "" });
-		const wideLines = wide.pane.render(PREVIEW_MIN_WIDTH);
+		terminalWidth = PREVIEW_MIN_WIDTH;
+		const wideLines = view.pane.render(PREVIEW_MIN_WIDTH);
 		expect(wideLines.some((l) => /MD\[\d+\]:/.test(l))).toBe(true);
+		const previewTop = wideLines.find((line) => line.includes("┌"));
+		expect(visibleWidth(previewTop!)).toBe(PREVIEW_MIN_WIDTH);
 	});
 });
 
@@ -377,7 +382,7 @@ describe("PreviewPane.maxNaturalHeight", () => {
 	});
 });
 
-describe("PreviewPane — left-aligned preview with top/left padding (side-by-side only)", () => {
+describe("PreviewPane — right-aligned preview with a bounded options column", () => {
 	const question: QuestionData = {
 		question: "pick",
 		header: "pick",
@@ -391,13 +396,11 @@ describe("PreviewPane — left-aligned preview with top/left padding (side-by-si
 		return joined.filter((l) => /MD\[\d+\]:/.test(l));
 	}
 
-	// Spec: preview content is NO LONGER horizontally centered. The MD marker should land at
-	// the same X-column whether the body is short or long — because both leftMargin slabs are
-	// fixed (options column max-width + gap + PREVIEW_PADDING_LEFT).
-	it("side-by-side preview lines have a fixed left-padding offset, NOT a content-dependent center margin", () => {
+	it("content-sized preview boxes share the right edge while retaining their natural widths", () => {
 		const short = makePane(question, () => 120);
 		short.optionListView.setProps({ selectedIndex: 0, focused: true, inputBuffer: "" });
-		const shortMD = extractPreviewColumnLines(short.pane.render(120))[0].indexOf("MD[");
+		const shortLines = short.pane.render(120);
+		const shortMD = extractPreviewColumnLines(shortLines)[0].indexOf("MD[");
 
 		const longQ: QuestionData = {
 			question: "pick",
@@ -409,9 +412,12 @@ describe("PreviewPane — left-aligned preview with top/left padding (side-by-si
 		};
 		const long = makePane(longQ, () => 120);
 		long.optionListView.setProps({ selectedIndex: 0, focused: true, inputBuffer: "" });
-		const longMD = extractPreviewColumnLines(long.pane.render(120))[0].indexOf("MD[");
+		const longLines = long.pane.render(120);
+		const longMD = extractPreviewColumnLines(longLines)[0].indexOf("MD[");
 
-		expect(shortMD).toBe(longMD);
+		expect(visibleWidth(shortLines.find((line) => line.includes("┌"))!)).toBe(120);
+		expect(visibleWidth(longLines.find((line) => line.includes("┌"))!)).toBe(120);
+		expect(shortMD).toBeGreaterThan(longMD);
 	});
 
 	it("side-by-side: adaptive left width adjusts options column based on label content", () => {
@@ -479,13 +485,11 @@ describe("PreviewPane — left-aligned preview with top/left padding (side-by-si
 });
 
 describe("PreviewPane — slack donation to left column", () => {
-	// 26-char label → labelDriven > MIN_LEFT, escapes the compact-content guard so
-	// donation actually engages. Short labels would suppress donation by design (Stage 5).
+	// 26-char label → labelDriven > MIN_LEFT, used where the label-driven path
+	// itself must exceed the floor.
 	const LONG_LABEL = "Verbose Descriptive Option";
 
-	it("short labels (compact-content guard) → no donation, MD at MIN_LEFT-based offset", () => {
-		// npm/yarn-style: 1-char labels signal compact UI. Even with a tiny preview that
-		// could donate huge slack, the compact guard returns labelDriven=MIN_LEFT(30).
+	it("short labels donate slack and move the preview to the right", () => {
 		const compactQ: QuestionData = {
 			question: "pick",
 			header: "pick",
@@ -501,14 +505,12 @@ describe("PreviewPane — slack donation to left column", () => {
 		pane.setGlobalLeftWidth((w) => crossTabLeftWidthWithDonation(tabs, itemsByTab, questions, w));
 		optionListView.setProps({ selectedIndex: 0, focused: true, inputBuffer: "" });
 
-		const result = crossTabLeftWidthWithDonation(tabs, itemsByTab, questions, 200);
-		expect(result).toBe(MIN_LEFT);
+		const donatedLeft = crossTabLeftWidthWithDonation(tabs, itemsByTab, questions, 200);
+		expect(donatedLeft).toBe(Math.floor(200 * MAX_LEFT_RATIO));
 
 		const lines = pane.render(200);
-		const mdLine = lines.find((l) => /MD\[\d+\]:/.test(l));
-		expect(mdLine).toBeDefined();
-		// MD starts at: MIN_LEFT(30) + gap(2) + pad(1) + border(1) + innerPad(1) = 35.
-		expect(mdLine!.indexOf("MD[")).toBe(MIN_LEFT + PREVIEW_COLUMN_GAP + 1 + 2);
+		const previewTop = lines.find((line) => line.includes("┌"));
+		expect(visibleWidth(previewTop!)).toBe(200);
 	});
 
 	it("long labels + narrow previews → donation engaged, MD at wider offset", () => {
@@ -533,14 +535,12 @@ describe("PreviewPane — slack donation to left column", () => {
 		const lines = pane.render(120);
 		const mdLine = lines.find((l) => /MD\[\d+\]:/.test(l));
 		expect(mdLine).toBeDefined();
-		// At width 120, donation widens left column to the ceiling:
-		//   previewBudget = 45 (MIN_PREVIEW_WIDTH floor), slackDonation = 120 − 2 − 45 = 73
-		//   labelDriven = 33 (26 + 5 + 2), result = min(max(33, 73), 73) = 73
-		// Expected MD offset: left(73) + gap(2) + pad(1) + "│"(1) + " "(1) = 78.
+		// Donation wants 73 columns, but the 50% ratio caps the options column at 60.
+		// The narrow preview is then right-aligned inside the remaining column.
 		const donatedLeft = crossTabLeftWidthWithDonation(tabs, itemsByTab, questions, 120);
-		expect(donatedLeft).toBe(73);
-		const expectedIdx = 73 + PREVIEW_COLUMN_GAP + 1 + 2;
-		expect(mdLine!.indexOf("MD[")).toBe(expectedIdx);
+		expect(donatedLeft).toBe(Math.floor(120 * MAX_LEFT_RATIO));
+		const previewTop = lines.find((line) => line.includes("┌"));
+		expect(visibleWidth(previewTop!)).toBe(120);
 	});
 
 	it("long labels + wide previews → donation suppressed, MD at label-driven offset", () => {

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-pane.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-pane.ts
@@ -220,7 +220,10 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 			this.props.focused,
 			this.props.notesVisible,
 		);
-		const pad = " ".repeat(PREVIEW_PADDING_LEFT);
-		return contentLines.map((l) => (l === "" ? "" : `${pad}${l}`));
+		const boxWidth = Math.max(1, visibleWidth(contentLines[0] ?? ""));
+		const paddingLeft = Math.max(PREVIEW_PADDING_LEFT, colWidth - boxWidth);
+		const pad = " ".repeat(paddingLeft);
+		const available = Math.max(1, colWidth - paddingLeft);
+		return contentLines.map((line) => (line === "" ? "" : `${pad}${truncateToWidth(line, available, "")}`));
 	}
 }


### PR DESCRIPTION
## Summary

Fix the live resize behavior of `ask_user_question` dialogs with ASCII diagram previews.

Closes #145.

## Changes

- Allow the preview layout to rebalance after crossing into side-by-side mode.
- Apply the existing 50% options-column cap to donated width.
- Right-align content-sized diagram previews within the remaining column.
- Add resize and alignment regression coverage.
- Document the fix in the package changelog.

## Result

At narrow widths, the existing stacked layout is unchanged. At wide widths, the options remain bounded, the diagram tracks the right edge, and a flexible gutter absorbs the remaining space between them.

## Verification

- `npm run check`
- `npm test -- --run packages/rpiv-ask-user-question` — 584 tests passed
- `npm run coverage` — 255 files, 4,755 tests passed
- `git diff --check`
- Manual comparison while resizing both terminal panes

## Recording

The installed extension is on the left; this branch is on the right.

<details>
<summary>View recording</summary>

![Comparison while resizing both terminal panes](https://raw.githubusercontent.com/jeremy0dell/rpiv-mono/issue-assets/.github/issue-assets/ask-user-question-responsive-preview.gif)

</details>

[Download the MP4](https://raw.githubusercontent.com/jeremy0dell/rpiv-mono/issue-assets/.github/issue-assets/ask-user-question-responsive-preview.mp4)
