### PR TITLE
fix(rpiv-todo): sanitize terminal control characters

### DIFF
--- a/packages/rpiv-todo/package.json
+++ b/packages/rpiv-todo/package.json
@@ -48,7 +48,8 @@
 		"state/task-graph.ts",
 		"tool/response-envelope.ts",
 		"tool/types.ts",
-		"view/format.ts"
+		"view/format.ts",
+		"view/sanitize.ts"
 	],
 	"pi": {
 		"extensions": [

--- a/packages/rpiv-todo/tool/response-envelope.ts
+++ b/packages/rpiv-todo/tool/response-envelope.ts
@@ -1,6 +1,7 @@
 import type { TaskState } from "../state/state.js";
 import type { Op } from "../state/state-reducer.js";
 import { deriveBlocks } from "../state/task-graph.js";
+import { sanitizeTerminalText } from "../view/sanitize.js";
 import type { Task, TaskAction, TaskDetails, TaskMutationParams } from "./types.js";
 
 /**
@@ -10,8 +11,8 @@ import type { Task, TaskAction, TaskDetails, TaskMutationParams } from "./types.
  */
 function formatListLine(t: Task): string {
 	const block = t.blockedBy?.length ? ` ⛓ ${t.blockedBy.map((id) => `#${id}`).join(",")}` : "";
-	const form = t.status === "in_progress" && t.activeForm ? ` (${t.activeForm})` : "";
-	return `[${t.status}] #${t.id} ${t.subject}${form}${block}`;
+	const form = t.status === "in_progress" && t.activeForm ? ` (${sanitizeTerminalText(t.activeForm)})` : "";
+	return `[${t.status}] #${t.id} ${sanitizeTerminalText(t.subject)}${form}${block}`;
 }
 
 /**
@@ -21,9 +22,9 @@ function formatListLine(t: Task): string {
  */
 function formatGetLines(task: Task, state: TaskState): string {
 	const blocks = deriveBlocks(state.tasks).get(task.id) ?? [];
-	const lines = [`#${task.id} [${task.status}] ${task.subject}`];
-	if (task.description) lines.push(`  description: ${task.description}`);
-	if (task.activeForm) lines.push(`  activeForm: ${task.activeForm}`);
+	const lines = [`#${task.id} [${task.status}] ${sanitizeTerminalText(task.subject)}`];
+	if (task.description) lines.push(`  description: ${sanitizeTerminalText(task.description)}`);
+	if (task.activeForm) lines.push(`  activeForm: ${sanitizeTerminalText(task.activeForm)}`);
 	if (task.blockedBy?.length) {
 		lines.push(`  blockedBy: ${task.blockedBy.map((id) => `#${id}`).join(", ")}`);
 	}
@@ -46,7 +47,7 @@ export function formatContent(op: Op, state: TaskState): string {
 			const t = state.tasks.find((x) => x.id === op.taskId);
 			// Defensive — `op.taskId` always resolves on success path.
 			if (!t) return `Created #${op.taskId}`;
-			return `Created #${t.id}: ${t.subject} (pending)`;
+			return `Created #${t.id}: ${sanitizeTerminalText(t.subject)} (pending)`;
 		}
 		case "update": {
 			if (!op.changed) {
@@ -56,7 +57,7 @@ export function formatContent(op: Op, state: TaskState): string {
 			return `Updated #${op.id}${transition}`;
 		}
 		case "delete":
-			return `Deleted #${op.id}: ${op.subject}`;
+			return `Deleted #${op.id}: ${sanitizeTerminalText(op.subject)}`;
 		case "clear":
 			return `Cleared ${op.count} tasks`;
 		case "list": {

--- a/packages/rpiv-todo/tool/response-envelope.ts
+++ b/packages/rpiv-todo/tool/response-envelope.ts
@@ -31,7 +31,7 @@ function formatGetLines(task: Task, state: TaskState): string {
 	if (blocks.length) {
 		lines.push(`  blocks: ${blocks.map((id) => `#${id}`).join(", ")}`);
 	}
-	if (task.owner) lines.push(`  owner: ${task.owner}`);
+	if (task.owner) lines.push(`  owner: ${sanitizeTerminalText(task.owner)}`);
 	return lines.join("\n");
 }
 

--- a/packages/rpiv-todo/view/format.ts
+++ b/packages/rpiv-todo/view/format.ts
@@ -2,9 +2,9 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { formatStatusLabel } from "../state/i18n-bridge.js";
 import { selectTaskSubjectById } from "../state/selectors.js";
-import { sanitizeTerminalText } from "./sanitize.js";
 import type { TaskState } from "../state/state.js";
 import type { Task, TaskAction, TaskDetails, TaskMutationParams, TaskStatus } from "../tool/types.js";
+import { sanitizeTerminalText } from "./sanitize.js";
 
 // Re-export so legacy import paths (todo.ts, tests) continue to resolve;
 // the canonical definition lives in the i18n bridge.

--- a/packages/rpiv-todo/view/format.ts
+++ b/packages/rpiv-todo/view/format.ts
@@ -2,6 +2,7 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { formatStatusLabel } from "../state/i18n-bridge.js";
 import { selectTaskSubjectById } from "../state/selectors.js";
+import { sanitizeTerminalText } from "./sanitize.js";
 import type { TaskState } from "../state/state.js";
 import type { Task, TaskAction, TaskDetails, TaskMutationParams, TaskStatus } from "../tool/types.js";
 
@@ -72,7 +73,7 @@ export function formatOverlayTaskLine(t: Task, theme: Theme, showId: boolean): s
 	const glyph = overlayStatusGlyph(t.status, theme);
 	const subjectColor =
 		t.status === "in_progress" ? "accent" : t.status === "completed" || t.status === "deleted" ? "muted" : "text";
-	let subject = theme.fg(subjectColor, t.subject);
+	let subject = theme.fg(subjectColor, sanitizeTerminalText(t.subject));
 	if (t.status === "completed" || t.status === "deleted") {
 		subject = theme.strikethrough(subject);
 	}
@@ -80,7 +81,7 @@ export function formatOverlayTaskLine(t: Task, theme: Theme, showId: boolean): s
 	if (showId) line += ` ${theme.fg("dim", `#${t.id}`)}`;
 	line += ` ${subject}`;
 	if (t.status === "in_progress" && t.activeForm) {
-		line += ` ${theme.fg("muted", `(${t.activeForm})`)}`;
+		line += ` ${theme.fg("muted", `(${sanitizeTerminalText(t.activeForm)})`)}`;
 	}
 	if (t.blockedBy && t.blockedBy.length > 0) {
 		line += ` ${theme.fg("muted", `⛓ ${t.blockedBy.map((id) => `#${id}`).join(",")}`)}`;
@@ -93,9 +94,9 @@ export function formatOverlayTaskLine(t: Task, theme: Theme, showId: boolean): s
  * indented bullet prefix). Pre-refactor `todo.ts:670-674`.
  */
 export function formatCommandTaskLine(t: Task, glyph: string): string {
-	const form = t.status === "in_progress" && t.activeForm ? ` (${t.activeForm})` : "";
+	const form = t.status === "in_progress" && t.activeForm ? ` (${sanitizeTerminalText(t.activeForm)})` : "";
 	const block = t.blockedBy?.length ? `    ⛓ ${t.blockedBy.map((id) => `#${id}`).join(",")}` : "";
-	return `  ${glyph} #${t.id} ${t.subject}${form}${block}`;
+	return `  ${glyph} #${t.id} ${sanitizeTerminalText(t.subject)}${form}${block}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,13 +117,13 @@ export function renderTodoCall(
 	let text = theme.fg("toolTitle", theme.bold("todo ")) + theme.fg("muted", glyph);
 
 	if (args.action === "create" && args.subject) {
-		text += ` ${theme.fg("dim", args.subject)}`;
+		text += ` ${theme.fg("dim", sanitizeTerminalText(args.subject))}`;
 	} else if (
 		(args.action === "update" || args.action === "get" || args.action === "delete") &&
 		args.id !== undefined
 	) {
 		const subject = selectTaskSubjectById(state, args.id);
-		text += ` ${theme.fg("accent", subject ?? `#${args.id}`)}`;
+		text += ` ${theme.fg("accent", subject ? sanitizeTerminalText(subject) : `#${args.id}`)}`;
 	} else if (args.action === "list" && args.status) {
 		text += ` ${theme.fg("muted", formatStatusLabel(args.status))}`;
 	}

--- a/packages/rpiv-todo/view/sanitize.test.ts
+++ b/packages/rpiv-todo/view/sanitize.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeTerminalText } from "./sanitize.js";
+
+describe("sanitizeTerminalText", () => {
+	it("removes terminal control characters", () => {
+		expect(sanitizeTerminalText("safe\u001b[31mred\u001b[0m\u009b2J")).toBe("safe[31mred[0m2J");
+	});
+
+	it("keeps task fields on one terminal line", () => {
+		expect(sanitizeTerminalText("one\ntwo\tthree\r")).toBe("one two three ");
+	});
+});

--- a/packages/rpiv-todo/view/sanitize.ts
+++ b/packages/rpiv-todo/view/sanitize.ts
@@ -1,0 +1,10 @@
+/**
+ * Remove terminal control characters from model-controlled task text before
+ * it reaches Pi's terminal renderer. Newlines and tabs become spaces so task
+ * fields cannot change the layout or emit terminal commands.
+ */
+export function sanitizeTerminalText(value: string): string {
+	return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, (character) =>
+		character === "\n" || character === "\r" || character === "\t" ? " " : "",
+	);
+}


### PR DESCRIPTION
## Summary

- add shared sanitization for terminal control characters in model-controlled text
- apply it to overlay, command, tool-call, and response-envelope task output
- add regression tests for ANSI/C1 controls and line-breaking controls

Fixes #151

## Validation

- `npm install --ignore-scripts --no-audit --no-fund`
- `npm test -- packages/rpiv-todo/view/sanitize.test.ts packages/rpiv-todo/view/format.test.ts packages/rpiv-todo/tool/response-envelope.test.ts`
- 3 test files passed, 23 tests passed
