### PR TITLE
Clarify todo guidance for tracked tasks

### DIFF
--- a/packages/rpiv-todo/todo.guidance.test.ts
+++ b/packages/rpiv-todo/todo.guidance.test.ts
@@ -16,6 +16,14 @@ beforeEach(() => {
 	// test/setup.ts rmSyncs CONFIG_PATH in shared beforeEach
 });
 
+describe("DEFAULT_PROMPT_GUIDELINES — task tracking scope", () => {
+	it("applies lifecycle instructions only to tracked tasks", () => {
+		const guidance = DEFAULT_PROMPT_GUIDELINES.join("\n");
+		expect(guidance).toContain("When starting any tracked task");
+		expect(guidance).not.toContain("When starting any task");
+	});
+});
+
 describe("registerTodoTool — guidance overrides", () => {
 	it("uses built-in defaults when no config file exists", () => {
 		const { pi, captured } = createMockPi();

--- a/packages/rpiv-todo/todo.ts
+++ b/packages/rpiv-todo/todo.ts
@@ -55,7 +55,7 @@ export { TOOL_NAME } from "./tool/types.js";
 export const DEFAULT_PROMPT_SNIPPET = "Manage a task list to track multi-step progress";
 export const DEFAULT_PROMPT_GUIDELINES: string[] = [
 	"Use `todo` for complex work with 3+ steps, when the user gives you a list of tasks, or immediately after receiving new instructions to capture requirements. Skip it for single trivial tasks and purely conversational requests.",
-	"When starting any task, mark it in_progress BEFORE beginning work. Mark it completed IMMEDIATELY when done — never batch completions. Exactly one task should be in_progress at a time.",
+	"When starting any tracked task, mark it in_progress BEFORE beginning work. Mark it completed IMMEDIATELY when done — never batch completions. Exactly one task should be in_progress at a time.",
 	"Never mark a task completed if tests are failing, the implementation is partial, or you hit unresolved errors — keep it in_progress and create a new task for the blocker instead.",
 	"Task status is a 4-state machine: pending → in_progress → completed, plus deleted as a tombstone. Pass activeForm (present-continuous label, e.g. 'researching existing tool') when marking in_progress.",
 	'To change a task\'s status, call update with the task id and the target status, e.g. {"action":"update","id":3,"status":"completed"} or {"action":"update","id":3,"status":"in_progress","activeForm":"writing tests"}. status is the field that changes the task; an update without a mutable field (status or another) is rejected.',


### PR DESCRIPTION
The todo prompt says to save the tool for work with 3+ steps, but the next line starts with "When starting any task." Models can read that as a reason to make a todo list for every task, including one-step work.

This changes "any task" to "any tracked task" so the lifecycle instructions only apply after a task is already in the todo list. I also added a small regression test for the wording.

Fixes #154

Tests: `npm run check` and `npm run coverage` (4,759 tests passed)
