### PR TITLE
feat(rpiv-ask-user-question): emit terminal attention

### DIFF
--- a/packages/rpiv-ask-user-question/README.md
+++ b/packages/rpiv-ask-user-question/README.md
@@ -27,6 +27,8 @@ Nothing to set up — the tool is live as soon as Pi restarts. Hand the model a 
 
 Rather than picking a strategy on your behalf, the model calls `ask_user_question` and a dialog takes over the bottom of your terminal. Move with `↑`/`↓`, choose with `Enter`, press `n` to attach a note, or land on the `Type something.` row to answer in your own words. While typing, `Shift+Enter` adds a line, `Ctrl+G` opens Pi's configured external editor, and `Ctrl+U` clears the draft; browsing another option and returning keeps what you wrote. `Esc` abandons the questionnaire entirely.
 
+When the questionnaire begins waiting in an interactive TTY, it emits one standard terminal BEL (`\x07`). Your terminal configuration determines whether that appears as an audible alert, a visual alert, or nothing; redirected and non-TTY output is untouched.
+
 ![Single question in the dialog: the tab strip reads Feature Type, Design Tab, Testing, Release, Submit; the question Which real development task are we planning right now? sits above four numbered options — Bug fix (Recommended), New feature, Refactor, Perf tuning — each with a one-line description, followed by the appended Type something. row](https://raw.githubusercontent.com/juicesharp/rpiv-mono/main/packages/rpiv-ask-user-question/docs/single-question.jpg)
 
 When the model asks several things at once, `Tab` moves between them and a Submit tab reviews everything before it goes back:

--- a/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
@@ -26,6 +26,24 @@ const BASE_PARAMS = {
 	],
 };
 
+function mockStdout(isTTY: boolean | (() => boolean)) {
+	const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	const isTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(
+		process.stdout,
+		"isTTY",
+		typeof isTTY === "function" ? { get: isTTY, configurable: true } : { value: isTTY, configurable: true },
+	);
+	return {
+		stdoutWrite,
+		restore: () => {
+			stdoutWrite.mockRestore();
+			if (isTtyDescriptor) Object.defineProperty(process.stdout, "isTTY", isTtyDescriptor);
+			else delete (process.stdout as { isTTY?: boolean }).isTTY;
+		},
+	};
+}
+
 describe("ask_user_question.execute — early returns", () => {
 	it("returns cancelled result + ERROR_NO_UI when !hasUI", async () => {
 		const tool = register();
@@ -79,6 +97,119 @@ describe("ask_user_question.execute — early returns", () => {
 		);
 		expect(r?.details).toMatchObject({ cancelled: true, error: "too_many_questions" });
 		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("At most") });
+	});
+});
+
+describe("ask_user_question.execute — terminal attention", () => {
+	it("writes exactly one BEL after blocked=true and immediately before the TUI wait", async () => {
+		const stdout = mockStdout(true);
+		try {
+			const mockEmit = vi.fn();
+			const { pi, captured } = createMockPi({
+				events: { emit: mockEmit, on: vi.fn(() => () => {}) },
+			});
+			registerAskUserQuestionTool(pi);
+			const tool = captured.tools.get("ask_user_question")!;
+			const custom = vi.fn(async () => ({ answers: [], cancelled: true }));
+			const ctx = createMockCtx({ hasUI: true, ui: { custom } as never });
+
+			await tool.execute?.("tc", BASE_PARAMS as never, undefined as never, undefined as never, ctx as never);
+
+			expect(stdout.stdoutWrite).toHaveBeenCalledTimes(1);
+			expect(stdout.stdoutWrite).toHaveBeenCalledWith("\x07");
+			expect(mockEmit).toHaveBeenNthCalledWith(2, "rpiv:ask-user:blocked", { active: true });
+			expect(mockEmit).toHaveBeenNthCalledWith(3, "rpiv:ask-user:blocked", { active: false });
+			expect(mockEmit.mock.invocationCallOrder[1]).toBeLessThan(stdout.stdoutWrite.mock.invocationCallOrder[0]);
+			expect(stdout.stdoutWrite.mock.invocationCallOrder[0]).toBeLessThan(custom.mock.invocationCallOrder[0]);
+		} finally {
+			stdout.restore();
+		}
+	});
+
+	it("does not write BEL for non-TTY, no-UI, or invalid requests", async () => {
+		const tool = register();
+		const ttyStdout = mockStdout(true);
+		try {
+			const noUi = createMockCtx({ hasUI: false });
+			await tool.execute?.("tc", BASE_PARAMS as never, undefined as never, undefined as never, noUi as never);
+
+			const invalid = createMockCtx({ hasUI: true, ui: { custom: vi.fn() } as never });
+			await tool.execute?.(
+				"tc",
+				{ questions: [] } as never,
+				undefined as never,
+				undefined as never,
+				invalid as never,
+			);
+
+			expect(ttyStdout.stdoutWrite).not.toHaveBeenCalled();
+		} finally {
+			ttyStdout.restore();
+		}
+
+		const nonTtyStdout = mockStdout(false);
+		try {
+			const custom = vi.fn(async () => ({ answers: [], cancelled: true }));
+			const nonTty = createMockCtx({ hasUI: true, ui: { custom } as never });
+			await tool.execute?.("tc", BASE_PARAMS as never, undefined as never, undefined as never, nonTty as never);
+
+			expect(nonTtyStdout.stdoutWrite).not.toHaveBeenCalled();
+		} finally {
+			nonTtyStdout.restore();
+		}
+	});
+
+	it("swallows a synchronous write failure and still clears blocked state", async () => {
+		const stdout = mockStdout(true);
+		stdout.stdoutWrite.mockImplementation(() => {
+			throw new Error("EPIPE");
+		});
+		try {
+			const mockEmit = vi.fn();
+			const { pi, captured } = createMockPi({
+				events: { emit: mockEmit, on: vi.fn(() => () => {}) },
+			});
+			registerAskUserQuestionTool(pi);
+			const tool = captured.tools.get("ask_user_question")!;
+			const custom = vi.fn(async () => ({
+				cancelled: false,
+				answers: [{ questionIndex: 0, question: "Which?", kind: "option", answer: "A" }],
+			}));
+			const ctx = createMockCtx({ hasUI: true, ui: { custom } as never });
+
+			const result = await tool.execute?.(
+				"tc",
+				BASE_PARAMS as never,
+				undefined as never,
+				undefined as never,
+				ctx as never,
+			);
+
+			expect(result?.details).toMatchObject({ cancelled: false });
+			expect(stdout.stdoutWrite).toHaveBeenCalledWith("\x07");
+			expect(mockEmit).toHaveBeenNthCalledWith(2, "rpiv:ask-user:blocked", { active: true });
+			expect(mockEmit).toHaveBeenNthCalledWith(3, "rpiv:ask-user:blocked", { active: false });
+		} finally {
+			stdout.restore();
+		}
+	});
+
+	it("swallows a failing TTY lookup and still opens the questionnaire", async () => {
+		const stdout = mockStdout(() => {
+			throw new Error("TTY lookup failed");
+		});
+		try {
+			const tool = register();
+			const custom = vi.fn(async () => ({ answers: [], cancelled: true }));
+			const ctx = createMockCtx({ hasUI: true, ui: { custom } as never });
+
+			await tool.execute?.("tc", BASE_PARAMS as never, undefined as never, undefined as never, ctx as never);
+
+			expect(custom).toHaveBeenCalledOnce();
+			expect(stdout.stdoutWrite).not.toHaveBeenCalled();
+		} finally {
+			stdout.restore();
+		}
 	});
 });
 

--- a/packages/rpiv-ask-user-question/ask-user-question.session-load.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.session-load.test.ts
@@ -31,6 +31,20 @@ function ctxWithCustom(result: QuestionnaireResult | null) {
 	return createMockCtx({ hasUI: true, ui: { custom } as never });
 }
 
+function mockStdout(isTTY: boolean) {
+	const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	const isTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(process.stdout, "isTTY", { value: isTTY, configurable: true });
+	return {
+		stdoutWrite,
+		restore: () => {
+			stdoutWrite.mockRestore();
+			if (isTtyDescriptor) Object.defineProperty(process.stdout, "isTTY", isTtyDescriptor);
+			else delete (process.stdout as { isTTY?: boolean }).isTTY;
+		},
+	};
+}
+
 beforeEach(() => {
 	vi.resetModules();
 });
@@ -47,14 +61,26 @@ describe("ask_user_question.execute — lazy session-graph load guards (#107)", 
 		});
 		const tool = await registerFresh();
 		const ctx = ctxWithCustom(null);
-		const r = await tool.execute?.("tc", BASE_PARAMS as never, undefined as never, undefined as never, ctx as never);
-		expect(r?.details).toMatchObject({ answers: [], cancelled: true, error: "session_load_failed" });
-		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("failed to load") });
-		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("restarting Pi") });
-		// Diagnostic suffix carries the underlying loader error. (vitest's mock
-		// layer rewrites the thrown message, so pin the marker, not the text.)
-		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("(cause:") });
-		expect(r?.content[0]).toMatchObject({ text: expect.not.stringContaining("declined") });
+		const stdout = mockStdout(true);
+		try {
+			const r = await tool.execute?.(
+				"tc",
+				BASE_PARAMS as never,
+				undefined as never,
+				undefined as never,
+				ctx as never,
+			);
+			expect(r?.details).toMatchObject({ answers: [], cancelled: true, error: "session_load_failed" });
+			expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("failed to load") });
+			expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("restarting Pi") });
+			// Diagnostic suffix carries the underlying loader error. (vitest's mock
+			// layer rewrites the thrown message, so pin the marker, not the text.)
+			expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("(cause:") });
+			expect(r?.content[0]).toMatchObject({ text: expect.not.stringContaining("declined") });
+			expect(stdout.stdoutWrite).not.toHaveBeenCalled();
+		} finally {
+			stdout.restore();
+		}
 	});
 
 	it("returns error: stale_module_cache when the namespace resolves without a constructable class", async () => {

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -61,6 +61,15 @@ const ERROR_SESSION_LOAD_FAILED =
 const ERROR_STALE_MODULE_CACHE =
 	"Error: the questionnaire UI cannot load — the host's module cache went stale after an earlier failed load (typically dependencies replaced on disk mid-session). This is unrecoverable within the current Pi process. The user never saw the questions — do NOT treat this as a decline. Ask the questions as plain chat text instead, and tell the user to restart Pi to restore this tool.";
 
+/** Emit one portable terminal attention signal without touching redirected output. */
+function emitTerminalAttention(): void {
+	try {
+		if (process.stdout.isTTY) process.stdout.write("\x07");
+	} catch {
+		// Terminal attention is best effort; the questionnaire must still proceed.
+	}
+}
+
 /** Delay before the background session-graph pre-warm; mirrors rpiv-workflow's /wf prewarm. */
 export const PREWARM_DELAY_MS = 2000;
 
@@ -173,6 +182,7 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 			if ((ctx as { mode?: string }).mode === "rpc" && hasDialogUI(ctx.ui)) {
 				emitAskUserBlockedEvent(pi, true);
 				try {
+					emitTerminalAttention();
 					return buildQuestionnaireResponse(await runRpcQuestionnaire(ctx.ui, typed), typed);
 				} finally {
 					emitAskUserBlockedEvent(pi, false);
@@ -232,6 +242,7 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 
 			emitAskUserBlockedEvent(pi, true);
 			try {
+				emitTerminalAttention();
 				const result = await ctx.ui.custom<QuestionnaireResult>(
 					(tui, theme, keybindings, done) => {
 						const session = new QuestionnaireSession({

--- a/packages/rpiv-ask-user-question/docs/hosts.md
+++ b/packages/rpiv-ask-user-question/docs/hosts.md
@@ -11,6 +11,12 @@ render at all.
 | RPC / ACP host (VS Code pendant, Zed, Paseo) | `ask_user_question` in its tool list | A sequence of the host's own native select and input dialogs |
 | Non-interactive run (no UI) | Nothing — the tool is removed | Nothing |
 
+### Terminal attention
+
+After UI availability and questionnaire validation succeed, the package emits exactly one standard terminal BEL (`\x07`) immediately before the interactive wait begins. The signal is sent to `stdout` only when `process.stdout.isTTY` is true, so redirected output and non-TTY RPC streams stay untouched. A TTY-backed RPC dialog walker receives the same signal as the TUI path.
+
+The BEL is best effort: if the synchronous terminal write fails, the questionnaire continues and its existing prompt/blocked lifecycle and result envelope are unchanged. The terminal configuration decides whether the BEL is audible, visual, or ignored. No BEL is emitted for missing UI, invalid questionnaires, or a failed TUI session load.
+
 ### Non-interactive runs
 
 A `before_agent_start` hook reconciles the active tool set against `ctx.hasUI` before every

--- a/packages/rpiv-ask-user-question/rpc-fallback.test.ts
+++ b/packages/rpiv-ask-user-question/rpc-fallback.test.ts
@@ -30,6 +30,20 @@ function ctxRpc(opts: { select?: SelectFn; input?: InputFn } = {}) {
 	});
 }
 
+function mockStdout(isTTY: boolean) {
+	const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	const isTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(process.stdout, "isTTY", { value: isTTY, configurable: true });
+	return {
+		stdoutWrite,
+		restore: () => {
+			stdoutWrite.mockRestore();
+			if (isTtyDescriptor) Object.defineProperty(process.stdout, "isTTY", isTtyDescriptor);
+			else delete (process.stdout as { isTTY?: boolean }).isTTY;
+		},
+	};
+}
+
 const SINGLE = {
 	questions: [
 		{
@@ -104,6 +118,45 @@ describe("ask_user_question.execute — RPC dialog walker (ctx.mode === 'rpc')",
 		const select = vi.fn(async (_t: string, options: string[]) => options[0]);
 		await run(tool, SINGLE, ctxRpc({ select }));
 		expect(captured.eventsEmitted.get("rpiv:ask-user:blocked")).toEqual([{ active: true }, { active: false }]);
+	});
+
+	it("writes exactly one BEL after blocked=true and before the first RPC dialog", async () => {
+		const stdout = mockStdout(true);
+		try {
+			const mockEmit = vi.fn();
+			const { pi, captured } = createMockPi({
+				events: { emit: mockEmit, on: vi.fn(() => () => {}) },
+			});
+			registerAskUserQuestionTool(pi);
+			const tool = captured.tools.get("ask_user_question")!;
+			const select = vi.fn(async (_t: string, options: string[]) => options[0]);
+
+			await run(tool, SINGLE, ctxRpc({ select }));
+
+			expect(stdout.stdoutWrite).toHaveBeenCalledTimes(1);
+			expect(stdout.stdoutWrite).toHaveBeenCalledWith("\x07");
+			expect(mockEmit).toHaveBeenNthCalledWith(2, "rpiv:ask-user:blocked", { active: true });
+			expect(mockEmit).toHaveBeenNthCalledWith(3, "rpiv:ask-user:blocked", { active: false });
+			expect(mockEmit.mock.invocationCallOrder[1]).toBeLessThan(stdout.stdoutWrite.mock.invocationCallOrder[0]);
+			expect(stdout.stdoutWrite.mock.invocationCallOrder[0]).toBeLessThan(select.mock.invocationCallOrder[0]);
+		} finally {
+			stdout.restore();
+		}
+	});
+
+	it("does not write BEL when RPC stdout is not a TTY", async () => {
+		const stdout = mockStdout(false);
+		try {
+			const tool = register();
+			const select = vi.fn(async (_t: string, options: string[]) => options[0]);
+
+			await run(tool, SINGLE, ctxRpc({ select }));
+
+			expect(select).toHaveBeenCalledOnce();
+			expect(stdout.stdoutWrite).not.toHaveBeenCalled();
+		} finally {
+			stdout.restore();
+		}
 	});
 
 	it("appends the 'Type something.' sentinel row sourced from ROW_INTENT_META", async () => {


### PR DESCRIPTION
## Summary
- emit one best-effort terminal BEL when `ask_user_question` transitions into a TTY-backed wait
- preserve the existing prompt/blocked lifecycle, suppress output on non-TTY streams, and keep synchronous write failures non-fatal
- document terminal-owned audible/visual behavior and cover TUI, RPC, non-TTY, and failed-session paths

Closes #140

## Verification
- `npm test -- packages/rpiv-ask-user-question/ask-user-question.execute.test.ts packages/rpiv-ask-user-question/rpc-fallback.test.ts packages/rpiv-ask-user-question/ask-user-question.session-load.test.ts` — 45 passed
- `npm test` — 256 files, 4,839 tests passed
- `npm run check`
- `git diff --check`
