### PR TITLE
feat: support Pi max thinking level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
 			],
 			"devDependencies": {
 				"@biomejs/biome": "2.5.5",
-				"@earendil-works/pi-ai": "0.80.5",
-				"@earendil-works/pi-coding-agent": "0.80.5",
-				"@earendil-works/pi-tui": "0.80.5",
+				"@earendil-works/pi-ai": "0.80.6",
+				"@earendil-works/pi-coding-agent": "0.80.6",
+				"@earendil-works/pi-tui": "0.80.6",
 				"@types/node": "22.20.1",
 				"@vitest/coverage-v8": "4.1.10",
 				"husky": "9.1.7",
@@ -915,9 +915,9 @@
 			]
 		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.5",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.5.tgz",
-			"integrity": "sha512-+7UODYKu4o/X8sxTHG8HEV3+O+dOYKg5MeO3MJIFQ+wu65pIWDhjZGc759uWsRr79AhV7MSJEe4GWnFn4l68gw==",
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+			"integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
@@ -946,15 +946,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.80.5",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.5.tgz",
-			"integrity": "sha512-GPYFuHw1BN+3m5Gzw1HGH41WdFDzbplLauS0zYSf1ZOkgKFd6wtEAcjchB/vmz9YtTGbQOwECbsVj6GxZxungA==",
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+			"integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
 			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.80.5",
-				"@earendil-works/pi-ai": "^0.80.5",
-				"@earendil-works/pi-tui": "^0.80.5",
+				"@earendil-works/pi-agent-core": "^0.80.6",
+				"@earendil-works/pi-ai": "^0.80.6",
+				"@earendil-works/pi-tui": "^0.80.6",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "5.6.2",
 				"cross-spawn": "7.0.6",
@@ -1417,11 +1417,11 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.80.5",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.5.tgz",
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.5",
+				"@earendil-works/pi-ai": "^0.80.6",
 				"ignore": "7.0.5",
 				"typebox": "1.1.38",
 				"yaml": "2.9.0"
@@ -1431,8 +1431,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-			"version": "0.80.5",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.5.tgz",
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
 			"license": "MIT",
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.91.1",
@@ -1455,8 +1455,8 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.5",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.5.tgz",
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
@@ -2779,9 +2779,9 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.80.5",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.5.tgz",
-			"integrity": "sha512-raxEUD2CvCDNJuOWEAI+xD7vmxCrGH0NYb31+GQDdL1q9WXn5+uNLgP1vkJfOsTvf9k5zU5sNFA06oBIcWSYtQ==",
+			"version": "0.80.6",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+			"integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
 			"license": "MIT",
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
@@ -6948,6 +6948,7 @@
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
 			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -7234,6 +7235,7 @@
 			"version": "6.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
 			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"nice-try": "^1.0.4",
@@ -7250,6 +7252,7 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
@@ -7493,6 +7496,7 @@
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
 			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -8535,6 +8539,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -9946,6 +9951,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nlcst-to-string": {
@@ -10285,6 +10291,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -10986,6 +10993,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^1.0.0"
@@ -10998,6 +11006,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -11564,6 +11573,7 @@
 			"version": "8.10.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
 			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.19.0"
@@ -12115,6 +12125,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.5",
-		"@earendil-works/pi-ai": "0.80.5",
-		"@earendil-works/pi-coding-agent": "0.80.5",
-		"@earendil-works/pi-tui": "0.80.5",
+		"@earendil-works/pi-ai": "0.80.6",
+		"@earendil-works/pi-coding-agent": "0.80.6",
+		"@earendil-works/pi-tui": "0.80.6",
 		"typebox": "1.3.6",
 		"@types/node": "22.20.1",
 		"@vitest/coverage-v8": "4.1.10",
@@ -42,8 +42,8 @@
 		"npm": ">=11.0.0"
 	},
 	"overrides": {
-		"@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.5",
-		"@mariozechner/pi-ai": "npm:@earendil-works/pi-ai@0.80.5",
-		"@mariozechner/pi-tui": "npm:@earendil-works/pi-tui@0.80.5"
+		"@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.6",
+		"@mariozechner/pi-ai": "npm:@earendil-works/pi-ai@0.80.6",
+		"@mariozechner/pi-tui": "npm:@earendil-works/pi-tui@0.80.6"
 	}
 }

--- a/packages/rpiv-advisor/CHANGELOG.md
+++ b/packages/rpiv-advisor/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Offer Pi's `max` thinking level for advisor models that advertise support and recognize it in effort-based blocklist policies.
+
 ## [2.5.2] - 2026-08-14
 
 ## [2.5.1] - 2026-08-14

--- a/packages/rpiv-advisor/README.md
+++ b/packages/rpiv-advisor/README.md
@@ -78,7 +78,7 @@ write leaves your previous selection untouched and tells you so.
 | Key | What it does | Default |
 | --- | --- | --- |
 | `modelKey` | The reviewer model, as `"provider/modelId"`. Written by `/advisor`. | absent — advisor off |
-| `effort` | Reasoning effort for the reviewer: `minimal`, `low`, `medium`, `high`, `xhigh`. Written by `/advisor`. | absent — no reasoning sent |
+| `effort` | Reasoning effort for the reviewer: `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Written by `/advisor`; only levels supported by the selected model are offered. | absent — no reasoning sent |
 | `disabledForModels` | Executor models the advisor is stripped for. Plain strings block at any effort; `{ "model": "…", "minEffort": "…" }` blocks only at or above that effort. | `[]` |
 
 ```json

--- a/packages/rpiv-advisor/advisor.command.test.ts
+++ b/packages/rpiv-advisor/advisor.command.test.ts
@@ -1,4 +1,4 @@
-import type { Api, Model } from "@earendil-works/pi-ai";
+import { type Api, getSupportedThinkingLevels, type Model } from "@earendil-works/pi-ai";
 import { createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -26,6 +26,12 @@ const modelR = {
 	provider: "anthropic",
 	id: "opus-thinking",
 	name: "Opus Thinking",
+	reasoning: true,
+} as unknown as Model<Api>;
+const modelMax = {
+	provider: "openai",
+	id: "gpt-max",
+	name: "GPT Max",
 	reasoning: true,
 } as unknown as Model<Api>;
 const modelBlocked = { provider: "anthropic", id: "sonnet", name: "Sonnet" } as unknown as Model<Api>;
@@ -120,6 +126,21 @@ describe("/advisor — non-reasoning model", () => {
 });
 
 describe("/advisor — reasoning model", () => {
+	it("offers max when the selected model reports support", async () => {
+		vi.mocked(getSupportedThinkingLevels).mockReturnValueOnce(["off", "low", "medium", "high", "max"]);
+		vi.mocked(showAdvisorPicker).mockResolvedValueOnce("openai/gpt-max");
+		vi.mocked(showEffortPicker).mockResolvedValueOnce(null);
+		const { captured } = register();
+		const ctx = createMockCtx({ hasUI: true, models: [modelMax] });
+
+		await captured.commands.get("advisor")?.handler("", ctx as never);
+
+		const values = vi.mocked(showEffortPicker).mock.calls[0]?.[1].map((item) => item.value);
+		expect(values).toContain("max");
+		expect(values?.[0]).toBe("__off__");
+		expect(values).not.toContain("off");
+	});
+
 	it("returns early when effort picker is cancelled", async () => {
 		vi.mocked(showAdvisorPicker).mockResolvedValueOnce("anthropic/opus-thinking");
 		vi.mocked(showEffortPicker).mockResolvedValueOnce(null);

--- a/packages/rpiv-advisor/advisor.config.test.ts
+++ b/packages/rpiv-advisor/advisor.config.test.ts
@@ -89,10 +89,12 @@ describe("validateDisabledForModels", () => {
 			validateDisabledForModels([
 				{ model: "anthropic:opus", minEffort: "minimal" },
 				{ model: "anthropic:opus", minEffort: "xhigh" },
+				{ model: "anthropic:opus", minEffort: "max" },
 			]),
 		).toEqual([
 			{ model: "anthropic:opus", minEffort: "minimal" },
 			{ model: "anthropic:opus", minEffort: "xhigh" },
+			{ model: "anthropic:opus", minEffort: "max" },
 		]);
 	});
 

--- a/packages/rpiv-advisor/advisor.policy.test.ts
+++ b/packages/rpiv-advisor/advisor.policy.test.ts
@@ -50,6 +50,7 @@ describe("isModelBlocked", () => {
 	it("returns true when executor effort above threshold", () => {
 		setDisabledForModels([{ model: "anthropic:sonnet", minEffort: "high" }]);
 		expect(isModelBlocked(sonnet, "xhigh")).toBe(true);
+		expect(isModelBlocked(sonnet, "max")).toBe(true);
 	});
 
 	it("returns false when executor effort below threshold", () => {

--- a/packages/rpiv-advisor/advisor/command.ts
+++ b/packages/rpiv-advisor/advisor/command.ts
@@ -15,7 +15,6 @@ import { saveAdvisorConfig } from "./config.js";
 import { reconcileAdvisorTool } from "./handlers.js";
 import {
 	ADVISOR_TOOL_NAME,
-	BASE_EFFORT_LEVELS,
 	CHECKMARK,
 	DEFAULT_EFFORT,
 	errSelectionNotFound,
@@ -27,7 +26,6 @@ import {
 	NO_ADVISOR_VALUE,
 	OFF_VALUE,
 	RECOMMENDED_EFFORT_SUFFIX,
-	XHIGH_EFFORT_LEVEL,
 } from "./messages.js";
 import { isExecutorBlocked } from "./policy.js";
 import { getAdvisorEffort, getAdvisorModel, setAdvisorEffort, setAdvisorModel } from "./state.js";
@@ -46,9 +44,7 @@ function buildModelItems(availableModels: Model<Api>[], currentKey: string | und
 }
 
 function buildEffortItems(picked: Model<Api>): SelectItem[] {
-	const levels = getSupportedThinkingLevels(picked).includes("xhigh")
-		? [...BASE_EFFORT_LEVELS, XHIGH_EFFORT_LEVEL]
-		: BASE_EFFORT_LEVELS;
+	const levels = getSupportedThinkingLevels(picked).filter((level) => level !== "off");
 	return [
 		{ value: OFF_VALUE, label: "off" },
 		...levels.map((level) => ({

--- a/packages/rpiv-advisor/advisor/messages.ts
+++ b/packages/rpiv-advisor/advisor/messages.ts
@@ -15,9 +15,7 @@ export const NO_ADVISOR_VALUE = "__no_advisor__";
 export const OFF_VALUE = "__off__";
 
 // Effort levels
-export const BASE_EFFORT_LEVELS: ThinkingLevel[] = ["minimal", "low", "medium", "high"];
-export const XHIGH_EFFORT_LEVEL: ThinkingLevel = "xhigh";
-export const EFFORT_ORDINAL: readonly ThinkingLevel[] = ["minimal", "low", "medium", "high", "xhigh"];
+export const EFFORT_ORDINAL: readonly ThinkingLevel[] = ["minimal", "low", "medium", "high", "xhigh", "max"];
 export const DEFAULT_EFFORT: ThinkingLevel = "high";
 export const RECOMMENDED_EFFORT_SUFFIX = "  (recommended)";
 

--- a/packages/rpiv-advisor/docs/configuration.md
+++ b/packages/rpiv-advisor/docs/configuration.md
@@ -41,7 +41,7 @@ previous selection and the active tool list are left untouched.
 | Key | Type | Default | Written by |
 | --- | --- | --- | --- |
 | `modelKey` | `string` — `"provider/modelId"` | absent (advisor off) | `/advisor` |
-| `effort` | `"minimal" \| "low" \| "medium" \| "high" \| "xhigh"` | absent (no `reasoning` sent) | `/advisor` effort picker |
+| `effort` | `"minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "max"` | absent (no `reasoning` sent) | `/advisor` effort picker |
 | `disabledForModels` | `(string \| { model, minEffort? })[]` | `[]` | hand-edited |
 | `guidance.promptSnippet` | `string` | built-in snippet | hand-edited |
 | `guidance.promptGuidelines` | `string[]` | six built-in guidelines | hand-edited |
@@ -59,12 +59,12 @@ form the next time you save through `/advisor`.
 ### `effort`
 
 Offered only for models whose registry entry reports reasoning support. The
-picker lists `off`, `minimal`, `low`, `medium`, `high`, and adds `xhigh` when
-the picked model supports it. `high` is marked `(recommended)`. Choosing `off`
+picker lists `off` plus the levels Pi reports for the selected model, including
+`xhigh` or `max` when supported. `high` is marked `(recommended)`. Choosing `off`
 deletes the key, and no `reasoning` parameter is sent with the advisor call.
 
 `EFFORT_ORDINAL`, lowest to highest, is `minimal`, `low`, `medium`, `high`,
-`xhigh`. This ordering is what `minEffort` compares against.
+`xhigh`, `max`. This ordering is what `minEffort` compares against.
 
 ### `disabledForModels`
 

--- a/packages/rpiv-pi/CHANGELOG.md
+++ b/packages/rpiv-pi/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Support Pi's `max` thinking level in `models.json` and the `/rpiv-models` picker when the selected model advertises it.
+
 ## [2.5.2] - 2026-08-14
 
 ## [2.5.1] - 2026-08-14

--- a/packages/rpiv-pi/docs/models-config.md
+++ b/packages/rpiv-pi/docs/models-config.md
@@ -107,12 +107,12 @@ your current session model stays sovereign for anything you invoke by hand.
 
 ### Reasoning levels
 
-Six values are accepted in `thinking`: `off`, `minimal`, `low`, `medium`, `high`,
-`xhigh`. Omitting the field and setting it to `off` are different: omitting inherits the
+Seven values are accepted in `thinking`: `off`, `minimal`, `low`, `medium`, `high`,
+`xhigh`, `max`. Omitting the field and setting it to `off` are different: omitting inherits the
 session baseline, `off` explicitly disables reasoning. Anything else is warned about:
 
 ```
-[rpiv-pi] models.json: unknown thinking level "<v>" — valid values: off, minimal, low, medium, high, xhigh
+[rpiv-pi] models.json: unknown thinking level "<v>" — valid values: off, minimal, low, medium, high, xhigh, max
 ```
 
 ### Model key form

--- a/packages/rpiv-pi/extensions/rpiv-core/models-config.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/models-config.test.ts
@@ -261,6 +261,15 @@ describe("models-config", () => {
 			expect(loadModelsConfig().agents!["test-agent"]).toEqual({ model: "openai/gpt-5.5", thinking: "off" });
 		});
 
+		it("accepts Pi's 'max' thinking level", () => {
+			writeFileSync(
+				configFilePath,
+				JSON.stringify({ agents: { "test-agent": { model: "openai/gpt-5.5", thinking: "max" } } }),
+				"utf-8",
+			);
+			expect(loadModelsConfig().agents!["test-agent"]).toEqual({ model: "openai/gpt-5.5", thinking: "max" });
+		});
+
 		it("cascades defaults.thinking 'off' into a model-only entry", () => {
 			writeFileSync(
 				configFilePath,

--- a/packages/rpiv-pi/extensions/rpiv-core/models-config.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/models-config.ts
@@ -21,17 +21,17 @@ import { type Static, Type } from "typebox";
 // The host's setThinkingLevel (pi-agent-core ThinkingLevel) AND agent
 // frontmatter both accept "off" — "off" is a first-class level meaning "no
 // reasoning" (it's even the session default). models.json therefore persists
-// all SIX values. Note the distinction from ABSENCE: a missing `thinking`
+// all SEVEN values. Note the distinction from ABSENCE: a missing `thinking`
 // field means "inherit the session/baseline level"; an explicit "off" means
-// "disable reasoning". THINKING_LEVEL_VALUES (the 5 reasoning levels) is kept
+// "disable reasoning". THINKING_LEVEL_VALUES (the 6 reasoning levels) is kept
 // for surfaces that list only the graded levels (e.g. the picker).
 // ---------------------------------------------------------------------------
 
-/** The 5 graded reasoning levels (excludes "off"). */
-export const THINKING_LEVEL_VALUES = ["minimal", "low", "medium", "high", "xhigh"] as const;
+/** The 6 graded reasoning levels (excludes "off"). */
+export const THINKING_LEVEL_VALUES = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 export type ThinkingLevelValue = (typeof THINKING_LEVEL_VALUES)[number];
 
-/** All 6 persistable thinking values, including the explicit "off" (disable reasoning). */
+/** All 7 persistable thinking values, including the explicit "off" (disable reasoning). */
 export const MODEL_THINKING_LEVEL_VALUES = ["off", ...THINKING_LEVEL_VALUES] as const;
 export type ModelThinkingLevelValue = (typeof MODEL_THINKING_LEVEL_VALUES)[number];
 
@@ -56,8 +56,9 @@ const ThinkingLevelSchema = Type.Union(
 		Type.Literal("medium"),
 		Type.Literal("high"),
 		Type.Literal("xhigh"),
+		Type.Literal("max"),
 	] as const,
-	{ description: "Effort/thinking level: off | minimal | low | medium | high | xhigh" },
+	{ description: "Effort/thinking level: off | minimal | low | medium | high | xhigh | max" },
 );
 
 // Guard: schema literals must stay in lockstep with MODEL_THINKING_LEVEL_VALUES.

--- a/packages/rpiv-pi/extensions/rpiv-core/rpiv-models/units.test.ts
+++ b/packages/rpiv-pi/extensions/rpiv-core/rpiv-models/units.test.ts
@@ -4,9 +4,9 @@
  * by rpiv-models-command.test.ts; this file pins the building blocks directly.
  */
 
-import type { Api, Model } from "@earendil-works/pi-ai";
+import { type Api, getSupportedThinkingLevels, type Model } from "@earendil-works/pi-ai";
 import type { SelectItem } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ModelsConfigSchema } from "../models-config.js";
 import { buildEffortItems, buildModelItems, INHERIT_VALUE, loadRawConfig, scopeItems } from "./items.js";
 import {
@@ -128,6 +128,14 @@ describe("items — builders", () => {
 		expect(items[0].value).toBe(INHERIT_VALUE);
 		// Every offered value is a known sentinel or thinking level (never empty).
 		expect(items.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("buildEffortItems offers max only when the selected model supports it", () => {
+		const reasoningModel = model("openai", "gpt", "GPT", true);
+		vi.mocked(getSupportedThinkingLevels).mockReturnValueOnce(["off", "minimal", "low", "medium", "high", "max"]);
+
+		expect(buildEffortItems(reasoningModel).map((item) => item.value)).toContain("max");
+		expect(buildEffortItems(reasoningModel).map((item) => item.value)).not.toContain("max");
 	});
 
 	it("loadRawConfig returns an object (fail-soft to {} when no file exists)", () => {

--- a/packages/rpiv-site/CHANGELOG.md
+++ b/packages/rpiv-site/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Document Pi's model-specific `max` thinking level in the model-sizing guide.
+
 ## [2.5.2] - 2026-08-14
 
 ## [2.5.1] - 2026-08-14

--- a/packages/rpiv-site/src/content/docs/guides/right-size-the-model.md
+++ b/packages/rpiv-site/src/content/docs/guides/right-size-the-model.md
@@ -77,7 +77,7 @@ Each leaf is either a bare model string (`"z-ai/glm-5.2"`, which sets the model 
 
 ## Effort is its own dial
 
-Model and reasoning effort are separate axes, and the second one is easy to under-use. There are five graded levels (`minimal`, `low`, `medium`, `high`, `xhigh`) plus a real `off`. The distinction that trips people up:
+Model and reasoning effort are separate axes, and the second one is easy to under-use. There are six graded levels (`minimal`, `low`, `medium`, `high`, `xhigh`, `max`) plus a real `off`; `/rpiv-models` offers only the levels supported by the selected model. The distinction that trips people up:
 
 - **Omit `thinking` entirely** and the step inherits your session's baseline level. This is "I care about the model here, not the effort."
 - **Set `thinking: "off"`** and reasoning is *disabled* for that step. This is a deliberate "don't think, just do it," the right call for a mechanical `commit` or a script-shaped stage, where reasoning tokens are pure latency.

--- a/packages/rpiv-workflow/CHANGELOG.md
+++ b/packages/rpiv-workflow/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow hosts to carry Pi's `max` thinking level through workflow model selections.
+
 ## [2.5.2] - 2026-08-14
 
 ## [2.5.1] - 2026-08-14

--- a/packages/rpiv-workflow/docs/embedding.md
+++ b/packages/rpiv-workflow/docs/embedding.md
@@ -60,7 +60,7 @@ because rpiv-workflow must not import rpiv-pi.
 ```ts
 spawnChild<T>(options: {
   prompt: string;
-  model?: ModelSelection;              // { model?: string; thinking?: "off" | … | "xhigh" }
+  model?: ModelSelection;              // { model?: string; thinking?: "off" | … | "max" }
   signal?: AbortSignal;                // abort THIS child mid-flight
   reattach?: { sessionFile: string };  // open the persisted session in place
   fork?: { sessionFile: string };      // fork it into a new child (sessionPolicy: "continue")

--- a/packages/rpiv-workflow/host.ts
+++ b/packages/rpiv-workflow/host.ts
@@ -67,7 +67,7 @@ export type WorkflowLauncherContext = Omit<WorkflowHostContext, "spawnChild" | "
  */
 export interface ModelSelection {
 	model?: string;
-	thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 }
 
 /**


### PR DESCRIPTION
## Summary

- accept Pi's `max` thinking level in rpiv-pi model config and rpiv-workflow model selections
- surface model-supported levels from `getSupportedThinkingLevels()` in both `/rpiv-models` and `/advisor`
- order `max` above `xhigh` for advisor blocklist policies
- bump the pinned Pi development packages to 0.80.6 and update current docs and changelogs

This completes the rpiv-core/rpiv-workflow follow-up identified in the maintainer review of #114 and reapplies that PR's advisor capability approach on current main.

## Verification

- `npm test` — 256 files, 4,848 tests passed
- `npm run check`
- `npm run build:site` — 77 pages built
