### PR TITLE
feat(rpiv-ask-user-question): emit herdr:blocked so Herdr notifies

### DIFF
--- a/packages/rpiv-ask-user-question/CHANGELOG.md
+++ b/packages/rpiv-ask-user-question/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Dual-emit `herdr:blocked` (`{ active, label }`) alongside `rpiv:ask-user:blocked` so Herdr's official Pi integration marks the pane blocked — toast, sound, sidebar — while the questionnaire waits.
+
 ## [2.5.2] - 2026-08-14
 
 ### Fixed

--- a/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.execute.test.ts
@@ -287,12 +287,18 @@ describe("ask_user_question.execute — event emission", () => {
 		});
 
 		expect(mockEmit).toHaveBeenNthCalledWith(2, "rpiv:ask-user:blocked", { active: true });
-		expect(mockEmit).toHaveBeenNthCalledWith(3, "rpiv:ask-user:blocked", { active: false });
+		expect(mockEmit).toHaveBeenNthCalledWith(3, "herdr:blocked", {
+			active: true,
+			label: "Which library?",
+		});
+		expect(mockEmit).toHaveBeenNthCalledWith(4, "rpiv:ask-user:blocked", { active: false });
+		expect(mockEmit).toHaveBeenNthCalledWith(5, "herdr:blocked", { active: false, label: undefined });
 
-		// Both start events are emitted before the dialog; the clear follows it.
+		// Prompt + both blocked-start events fire before the dialog; clears follow it.
 		expect(mockEmit.mock.invocationCallOrder[0]).toBeLessThan(custom.mock.invocationCallOrder[0]);
 		expect(mockEmit.mock.invocationCallOrder[1]).toBeLessThan(custom.mock.invocationCallOrder[0]);
-		expect(mockEmit.mock.invocationCallOrder[2]).toBeGreaterThan(custom.mock.invocationCallOrder[0]);
+		expect(mockEmit.mock.invocationCallOrder[2]).toBeLessThan(custom.mock.invocationCallOrder[0]);
+		expect(mockEmit.mock.invocationCallOrder[3]).toBeGreaterThan(custom.mock.invocationCallOrder[0]);
 	});
 
 	it("clears ask-user blocked lifecycle after cancellation and UI rejection", async () => {
@@ -329,6 +335,12 @@ describe("ask_user_question.execute — event emission", () => {
 			["rpiv:ask-user:blocked", { active: false }],
 			["rpiv:ask-user:blocked", { active: true }],
 			["rpiv:ask-user:blocked", { active: false }],
+		]);
+		expect(mockEmit.mock.calls.filter(([name]) => name === "herdr:blocked")).toEqual([
+			["herdr:blocked", { active: true, label: "Which library?" }],
+			["herdr:blocked", { active: false, label: undefined }],
+			["herdr:blocked", { active: true, label: "Which library?" }],
+			["herdr:blocked", { active: false, label: undefined }],
 		]);
 	});
 

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -42,9 +42,15 @@ function emitAskUserPromptEvent(pi: ExtensionAPI, params: QuestionParams): void 
 	pi.events.emit(ASK_USER_PROMPT_EVENT, payload);
 }
 
-function emitAskUserBlockedEvent(pi: ExtensionAPI, active: boolean): void {
+/** Official Herdr Pi integration (`herdr-agent-state`) listens only for this. */
+const HERDR_BLOCKED_EVENT = "herdr:blocked" as const;
+
+function emitAskUserBlockedEvent(pi: ExtensionAPI, active: boolean, label?: string): void {
 	const payload: AskUserBlockedEventPayload = { active };
 	pi.events.emit(ASK_USER_BLOCKED_EVENT, payload);
+	// Dual-emit: Herdr marks the pane blocked (toast/sound) from this channel.
+	// No-op outside Herdr — the official plugin never registers a listener.
+	pi.events.emit(HERDR_BLOCKED_EVENT, { active, label: active ? label : undefined });
 }
 
 /** Canonical tool name — single source of truth shared with the reconcile module. */
@@ -170,8 +176,10 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 			// the sequential dialog walker up front, skipping the TUI render-graph
 			// import entirely; RPC builds that predate ctx.mode are caught by the
 			// custom()-resolved-undefined backstop below. See ./rpc-fallback.ts.
+			const blockLabel = typed.questions[0]?.question;
+
 			if ((ctx as { mode?: string }).mode === "rpc" && hasDialogUI(ctx.ui)) {
-				emitAskUserBlockedEvent(pi, true);
+				emitAskUserBlockedEvent(pi, true, blockLabel);
 				try {
 					return buildQuestionnaireResponse(await runRpcQuestionnaire(ctx.ui, typed), typed);
 				} finally {
@@ -230,7 +238,7 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 				});
 			}
 
-			emitAskUserBlockedEvent(pi, true);
+			emitAskUserBlockedEvent(pi, true, blockLabel);
 			try {
 				const result = await ctx.ui.custom<QuestionnaireResult>(
 					(tui, theme, keybindings, done) => {

--- a/packages/rpiv-ask-user-question/docs/tool-schema.md
+++ b/packages/rpiv-ask-user-question/docs/tool-schema.md
@@ -119,3 +119,7 @@ process or network boundary stay cheap.
 Stability policy for the `rpiv:*` namespace: channel names are immutable, payload changes
 are append-only and always optional, payloads stay JSON-safe, and any breaking change ships
 as a new channel (e.g. `rpiv:ask-user:prompt.v2`) rather than a version field.
+
+The same wait also dual-emits `herdr:blocked` with `{ active, label }`, where `label` is
+the first question's text while `active` is true. Herdr's official Pi integration listens
+only for that channel; emitting it is a no-op outside Herdr.

--- a/packages/rpiv-ask-user-question/rpc-fallback.test.ts
+++ b/packages/rpiv-ask-user-question/rpc-fallback.test.ts
@@ -104,6 +104,10 @@ describe("ask_user_question.execute — RPC dialog walker (ctx.mode === 'rpc')",
 		const select = vi.fn(async (_t: string, options: string[]) => options[0]);
 		await run(tool, SINGLE, ctxRpc({ select }));
 		expect(captured.eventsEmitted.get("rpiv:ask-user:blocked")).toEqual([{ active: true }, { active: false }]);
+		expect(captured.eventsEmitted.get("herdr:blocked")).toEqual([
+			{ active: true, label: SINGLE.questions[0].question },
+			{ active: false, label: undefined },
+		]);
 	});
 
 	it("appends the 'Type something.' sentinel row sourced from ROW_INTENT_META", async () => {


### PR DESCRIPTION
## Why

When Pi runs inside [Herdr](https://herdr.dev), the official integration (`herdr-agent-state`) is the lifecycle authority. It only marks a pane `blocked` (toast, sound, sidebar) on `herdr:blocked`.

`ask_user_question` already emits `rpiv:ask-user:blocked`, which Herdr never sees. The pane stays working/idle, so a questionnaire waiting for input produces no Herdr notification.

This is the same interop `pi-ask-herdr` already uses.

## What

Dual-emit `herdr:blocked` next to `rpiv:ask-user:blocked`:

- `{ active: true, label: <first question> }` when the dialog opens
- `{ active: false, label: undefined }` in `finally`

No Herdr socket code. Outside Herdr the extra event is a no-op.

## Test plan

- [x] `ask-user-question.execute.test.ts` and `rpc-fallback.test.ts` cover the dual-emit
- [x] Verified live with a local 8-line bridge that re-emits the same event; Herdr toasted