### PR TITLE
fix(rpiv-voice): darwin-x64 (Intel Mac) mic capture via @audio/mic fallback shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,101 @@
 				"node": "18.20.8 || ^20.3.0 || >=22.0.0"
 			}
 		},
+		"node_modules/@audio/mic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@audio/mic/-/mic-1.1.1.tgz",
+			"integrity": "sha512-yO72Fep3q/dnOgo4QgW1BN6KUj+Rd73Fm06K6LjgDSpN87i1+F5mAG5vlP1K8ZWMGyMOzdYPAQkwR7RizEARUQ==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/audiojs"
+			},
+			"optionalDependencies": {
+				"@audio/mic-darwin-arm64": ">=0.0.0",
+				"@audio/mic-darwin-x64": ">=0.0.0",
+				"@audio/mic-linux-arm64": ">=0.0.0",
+				"@audio/mic-linux-x64": ">=0.0.0",
+				"@audio/mic-win32-x64": ">=0.0.0"
+			}
+		},
+		"node_modules/@audio/mic-darwin-arm64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@audio/mic-darwin-arm64/-/mic-darwin-arm64-1.1.2.tgz",
+			"integrity": "sha512-dyFgkb//8I03yVDdHyT1Lirv/XD+hMKOaqkcjz1mPic9WgPBeV057/h/nTEs4m1iNbVduX5Qs4CqFy0kB6daQA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/audiojs"
+			}
+		},
+		"node_modules/@audio/mic-darwin-x64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@audio/mic-darwin-x64/-/mic-darwin-x64-1.1.2.tgz",
+			"integrity": "sha512-FBgY8zxTZKU7U97rJliJnUSYzNpujQZhY7IqKAGI9chw/5zHS2/xE5IobFPKMyAWc+DYI+Huj/PmWZTUak9acA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/audiojs"
+			}
+		},
+		"node_modules/@audio/mic-linux-arm64": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/@audio/mic-linux-arm64/-/mic-linux-arm64-0.0.0.tgz",
+			"integrity": "sha512-K3FSUz3a0MvO5VSLTKdNB89oEf/T0tyHrpb2BSml6XfWJJQBqjWzUryspkYOQEP6s3RwSVccvBsZpWk4l5FKvg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@audio/mic-linux-x64": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/@audio/mic-linux-x64/-/mic-linux-x64-0.0.0.tgz",
+			"integrity": "sha512-GWeDN9fGajLPPGL4xPMQFK0mJqQ+QprM9Q00lnd///JYkNc8JY4iwFH6zqDv0+arBw2ry3YRDd5/VZihgPdYog==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@audio/mic-win32-x64": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/@audio/mic-win32-x64/-/mic-win32-x64-0.0.0.tgz",
+			"integrity": "sha512-WGhmtwPqUrbdO216eR01GKKf00rq4gs/Y8CQP5HuV/bLR7I2zM8Di58hp3AuE/8FXJwAhfXfBH0QE4rZAc0m0A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -1448,7 +1543,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "dist/cli.js"
+				"pi-ai": "./dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -6948,6 +7043,7 @@
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
 			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -7234,6 +7330,7 @@
 			"version": "6.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
 			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"nice-try": "^1.0.4",
@@ -7250,6 +7347,7 @@
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
@@ -7493,6 +7591,7 @@
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
 			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
@@ -8535,6 +8634,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -9946,6 +10046,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nlcst-to-string": {
@@ -10285,6 +10386,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -10986,6 +11088,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^1.0.0"
@@ -10998,6 +11101,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -11564,6 +11668,7 @@
 			"version": "8.10.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
 			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.19.0"
@@ -12115,6 +12220,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -12248,6 +12354,7 @@
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
 			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"license": "ISC",
+			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -12550,6 +12657,9 @@
 				"@juicesharp/rpiv-config": "^2.6.0",
 				"decibri": "^3.4.0",
 				"sherpa-onnx-node": "^1.13.0"
+			},
+			"optionalDependencies": {
+				"@audio/mic": "^1.1.1"
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",

--- a/packages/rpiv-voice/audio/decibri-audiomic-shim.test.ts
+++ b/packages/rpiv-voice/audio/decibri-audiomic-shim.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+	reads: [] as MockRead[],
+	lastOpts: null as Record<string, unknown> | null,
+}));
+
+// Mirrors the self-contained listener-registry convention already used in
+// mic-source.test.ts's `vi.mock("decibri", ...)` factory: vi.mock factories
+// are hoisted above imports and cannot reference this file's imports.
+//
+// Models @audio/mic's own callback-style `read(cb)` factory (not the
+// `/stream` Readable wrapper — the shim deliberately avoids that subpath,
+// see decibri-audiomic-shim.ts's file header for why). Each call to the
+// returned function registers ONE pending callback, matching the real
+// single-shot-per-call semantics; `emitChunk`/`emitError`/`emitEnd` below
+// resolve the most recently registered pending callback, and `close` mirrors
+// the real `read.close()`.
+type ReadCb = (err: Error | null, chunk?: Buffer | Uint8Array | null) => void;
+class MockRead {
+	close = vi.fn();
+	private pending: ReadCb | null = null;
+	call(cb: ReadCb): void {
+		this.pending = cb;
+	}
+	emitChunk(chunk: Buffer): void {
+		const cb = this.pending;
+		this.pending = null;
+		cb?.(null, chunk);
+	}
+	emitError(err: Error): void {
+		const cb = this.pending;
+		this.pending = null;
+		cb?.(err, null);
+	}
+	emitEnd(): void {
+		const cb = this.pending;
+		this.pending = null;
+		cb?.(null, null);
+	}
+}
+
+vi.mock("@audio/mic", () => ({
+	default: vi.fn((opts: Record<string, unknown>) => {
+		state.lastOpts = opts;
+		const mockRead = new MockRead();
+		state.reads.push(mockRead);
+		const read = ((cb: ReadCb | null) => {
+			if (cb === null) {
+				mockRead.close();
+				return;
+			}
+			mockRead.call(cb);
+		}) as unknown as { (cb: ReadCb | null): void; close: () => void };
+		read.close = mockRead.close;
+		return read;
+	}),
+}));
+
+import AudioMicDecibriShim from "./decibri-audiomic-shim.js";
+
+function lastRead(): MockRead {
+	const r = state.reads[state.reads.length - 1];
+	if (!r) throw new Error("no read() call registered yet");
+	return r;
+}
+
+async function flush(): Promise<void> {
+	await new Promise((r) => setImmediate(r));
+}
+
+describe("AudioMicDecibriShim", () => {
+	beforeEach(() => {
+		state.reads = [];
+		state.lastOpts = null;
+	});
+
+	it("rejects when vad is requested (no VAD support in the @audio/mic backend)", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 16000, channels: 1, vad: true });
+		const err = await new Promise<Error>((resolve) => shim.once("error", resolve));
+		expect(err.message).toMatch(/vad/i);
+	});
+
+	it("rejects when channels is not 1", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 48000, channels: 2, vad: false });
+		const err = await new Promise<Error>((resolve) => shim.once("error", resolve));
+		expect(err.message).toMatch(/channels/i);
+	});
+
+	it("rejects on invalid sampleRate", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 0, channels: 1, vad: false });
+		const err = await new Promise<Error>((resolve) => shim.once("error", resolve));
+		expect(err.message).toMatch(/sampleRate/i);
+	});
+
+	it("opens @audio/mic with the requested sampleRate, mono, 16-bit", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 48000, channels: 1, vad: false });
+		await flush();
+		expect(state.lastOpts).toMatchObject({ sampleRate: 48000, channels: 1, bitDepth: 16 });
+		shim.stop();
+	});
+
+	it("converts framesPerBuffer (samples) to bufferSize (ms) correctly", async () => {
+		// 4800 samples at 48000 Hz = 100 ms
+		const shim = new AudioMicDecibriShim({ sampleRate: 48000, channels: 1, framesPerBuffer: 4800, vad: false });
+		await flush();
+		expect(state.lastOpts).toMatchObject({ bufferSize: 100 });
+		shim.stop();
+	});
+
+	it("forwards data events and keeps reading (pump loop) until stopped", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 48000, channels: 1, vad: false });
+		await flush();
+		const chunks: Buffer[] = [];
+		shim.on("data", (c: Buffer) => chunks.push(c));
+		lastRead().emitChunk(Buffer.from([1, 2, 3, 4]));
+		await flush();
+		lastRead().emitChunk(Buffer.from([5, 6]));
+		expect(chunks).toEqual([Buffer.from([1, 2, 3, 4]), Buffer.from([5, 6])]);
+		shim.stop();
+	});
+
+	it("stop() calls read.close() — this is what actually stops the native device", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 48000, channels: 1, vad: false });
+		await flush();
+		shim.stop();
+		expect(lastRead().close).toHaveBeenCalledTimes(1);
+	});
+
+	it("stop() is safe to call multiple times", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 48000, channels: 1, vad: false });
+		await flush();
+		shim.stop();
+		expect(() => shim.stop()).not.toThrow();
+		expect(lastRead().close).toHaveBeenCalledTimes(1);
+	});
+
+	it("a null chunk (device closed) ends the pump loop without emitting further data", async () => {
+		const shim = new AudioMicDecibriShim({ sampleRate: 48000, channels: 1, vad: false });
+		await flush();
+		const events: string[] = [];
+		shim.on("end", () => events.push("end"));
+		shim.on("close", () => events.push("close"));
+		lastRead().emitEnd();
+		expect(events).toEqual(["end", "close"]);
+	});
+});

--- a/packages/rpiv-voice/audio/decibri-audiomic-shim.ts
+++ b/packages/rpiv-voice/audio/decibri-audiomic-shim.ts
@@ -1,0 +1,182 @@
+// decibri-compatible constructor backed by @audio/mic (miniaudio.h via
+// N-API), used only as a fallback when the real `decibri` npm package's
+// native addon fails to load — today, that's darwin-x64 (Intel Mac) only,
+// since decibri ships no prebuilt for that target and the maintainer has
+// explicitly declined to add one (decibri/decibri issue #15, closed,
+// citing Apple ending Intel Mac support and an upstream ort-sys blocker).
+//
+// Implements the exact subset of decibri's constructor contract that
+// mic-source.ts consumes (see `DecibriCtor`/`DecibriRaw` there).
+//
+// Uses @audio/mic's BASE export (the `read(cb)` callback factory), not its
+// `/stream` Readable-wrapper subpath. This is deliberate, not a style
+// choice: `@audio/mic/stream`'s `Readable.from(read)` wraps an async
+// iterator that only implements `next()` (see @audio/mic's index.js —
+// `read[Symbol.asyncIterator]` has no `return`/`throw`). Node's
+// `Readable.from` can only forward a `.destroy()` call into iterator cleanup
+// by calling `iterator.return()`, which doesn't exist here — so
+// `stream.destroy()` silently does NOT reach the underlying
+// `device.close()`, meaning the native capture device and its libuv worker
+// thread (native/mic.c's `read_execute`, which blocks in a `while (!closed)`
+// loop) never actually stop. Using the base factory directly and driving our
+// own read loop keeps the `read.close()` handle reachable from `stop()`,
+// which is the only thing that actually calls `ma_device_stop` +
+// `ma_device_uninit`.
+//
+// Intentionally does NOT implement Silero VAD passthrough: @audio/mic's
+// miniaudio backend has no VAD of its own. When `opts.vad` is requested this
+// class rejects (async `error` event) so mic-source.ts's EXISTING
+// silero-passthrough -> resample-rms fallback (already shipped — see
+// juicesharp/rpiv-mono issue #46) takes over unmodified. This is a
+// deliberate design choice, not a rate limitation: @audio/mic's miniaudio
+// backend can actually deliver clean 16kHz audio from any device via its
+// internal resampler (verified by reading native/mic.c — config.sampleRate is
+// passed straight to ma_device_init, which auto-converts when the backend's
+// native rate differs, unlike decibri/cpal which fails outright on an
+// unsupported rate). We reject anyway because we have no VAD to satisfy the
+// `speech`/`silence` event contract silero-passthrough mode implies.
+import { EventEmitter } from "node:events";
+
+// Matches @audio/mic's own index.d.ts `ReadFn` shape (not re-imported to
+// avoid a hard type-only dependency edge; keep in sync if @audio/mic changes
+// this shape).
+interface AudioMicReadFn {
+	(cb: (err: Error | null, chunk?: Buffer | Uint8Array | null) => void): void;
+	(cb: null): void;
+	close(): void;
+}
+
+export default class AudioMicDecibriShim extends EventEmitter {
+	// CoreAudio can take a short moment to fully release an input device
+	// after a previous session's stop()/close() — native mic_close() calls
+	// ma_device_stop() + ma_device_uninit() synchronously, but the underlying
+	// HAL device teardown is not guaranteed instantaneous on every
+	// device/driver combination. A rapid /voice → exit → /voice cycle can hit
+	// this window and fail ma_device_init() on the second open with no
+	// automatic recovery (observed live on darwin-x64: second invocation
+	// throws "Microphone unavailable", and repeated fast cycling has also
+	// crashed the process outright — consistent with a native-level race, not
+	// just a JS-level error). Retry the open a few times with a short backoff
+	// before giving up.
+	private static readonly OPEN_RETRY_DELAYS_MS = [150, 300, 600, 1000];
+
+	private stopped = false;
+	private readHandle: AudioMicReadFn | null = null;
+
+	constructor(opts: Record<string, unknown>) {
+		super();
+		const sampleRate = Number(opts.sampleRate);
+		const channels = Number(opts.channels ?? 1);
+		const framesPerBuffer = opts.framesPerBuffer != null ? Number(opts.framesPerBuffer) : undefined;
+		const vad = Boolean(opts.vad);
+
+		if (vad) {
+			// See file header: intentional rejection, not a real limitation.
+			queueMicrotask(() =>
+				this.emit("error", new Error("decibri-audiomic-shim: vad is not supported by the @audio/mic fallback")),
+			);
+			return;
+		}
+		if (channels !== 1) {
+			queueMicrotask(() =>
+				this.emit("error", new Error(`decibri-audiomic-shim: channels must be 1, got ${channels}`)),
+			);
+			return;
+		}
+		if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+			queueMicrotask(() =>
+				this.emit("error", new Error(`decibri-audiomic-shim: invalid sampleRate ${String(opts.sampleRate)}`)),
+			);
+			return;
+		}
+
+		// @audio/mic's bufferSize option is milliseconds; mic-source.ts's
+		// framesPerBuffer is a sample count. Convert so chunk cadence stays
+		// consistent with the ~100ms cadence the rest of the pipeline expects.
+		// Clamped to @audio/mic's own accepted range (10-2000ms, confirmed in
+		// its native/mic.c `mic_open` clamp) as a sane guard.
+		const bufferSizeMs =
+			framesPerBuffer != null && framesPerBuffer > 0
+				? Math.max(10, Math.min(2000, Math.round((framesPerBuffer / sampleRate) * 1000)))
+				: undefined;
+
+		this.start({ sampleRate, bufferSizeMs }).catch((err) => this.emit("error", err));
+	}
+
+	private async start(opts: { sampleRate: number; bufferSizeMs?: number }): Promise<void> {
+		const { default: mic } = await import("@audio/mic");
+		const micOpts = {
+			sampleRate: opts.sampleRate,
+			channels: 1,
+			bitDepth: 16 as const,
+			...(opts.bufferSizeMs != null ? { bufferSize: opts.bufferSizeMs } : {}),
+		};
+
+		const delays = AudioMicDecibriShim.OPEN_RETRY_DELAYS_MS;
+		let read: AudioMicReadFn | undefined;
+		let lastErr: unknown;
+		for (let attempt = 0; attempt <= delays.length; attempt++) {
+			if (this.stopped) return;
+			try {
+				read = mic(micOpts) as AudioMicReadFn;
+				break;
+			} catch (err) {
+				lastErr = err;
+				const delay = delays[attempt];
+				if (delay == null) break; // out of retries
+				await new Promise((r) => setTimeout(r, delay));
+			}
+		}
+		if (!read) {
+			throw lastErr instanceof Error
+				? lastErr
+				: new Error(`decibri-audiomic-shim: mic open failed: ${String(lastErr)}`);
+		}
+
+		if (this.stopped) {
+			// stop() was called synchronously before the dynamic import/retry
+			// loop resolved; close immediately instead of starting capture.
+			read.close();
+			return;
+		}
+
+		this.readHandle = read;
+		this.pump(read);
+	}
+
+	// @audio/mic's callback-style `read(cb)` performs exactly ONE async read
+	// per call (confirmed in its miniaudio backend: one `addon.readAsync`
+	// call, single-shot) — continuous capture requires re-invoking `read(cb)`
+	// from inside the previous callback. This mirrors the pattern its own
+	// `stream.js`/`Readable.from` uses internally via the async-iterator's
+	// repeated `next()` calls, just without going through the broken destroy
+	// path described in the file header.
+	private pump(read: AudioMicReadFn): void {
+		read((err, chunk) => {
+			if (this.stopped) return;
+			if (err) {
+				this.emit("error", err);
+				return;
+			}
+			if (!chunk) {
+				// Device closed (either we called stop() mid-read, or the
+				// device was lost) — miniaudio.js's backend delivers a null
+				// chunk with no error in this case.
+				this.emit("end");
+				this.emit("close");
+				return;
+			}
+			this.emit(
+				"data",
+				Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+			);
+			this.pump(read);
+		});
+	}
+
+	stop(): void {
+		if (this.stopped) return;
+		this.stopped = true;
+		this.readHandle?.close();
+	}
+}

--- a/packages/rpiv-voice/audio/mic-source-fallback.test.ts
+++ b/packages/rpiv-voice/audio/mic-source-fallback.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("decibri", () => {
+	throw new Error("Cannot find module 'decibri' (simulated darwin-x64 native addon load failure)");
+});
+
+vi.mock("./decibri-audiomic-shim.js", () => {
+	type Listener = (...args: unknown[]) => void;
+	class MockShim {
+		opts: Record<string, unknown>;
+		stop = vi.fn();
+		_listeners: Record<string, Listener[]> = {};
+		constructor(opts: Record<string, unknown>) {
+			this.opts = opts;
+			// Mirrors the real shim's behavior: reject on vad:true, succeed
+			// (emit data) on vad:false — simulates the built-in-mic fallback
+			// path from issue #46 without depending on the real @audio/mic
+			// package.
+			if (opts.vad) {
+				queueMicrotask(() => this.emit("error", new Error("shim: vad not supported")));
+			} else {
+				queueMicrotask(() => this.emit("data", Buffer.from([1, 2, 3, 4])));
+			}
+		}
+		on(event: string, fn: Listener): this {
+			// Plain 3-line form, not `(this._listeners[event] ??= []).push(fn)` —
+			// the latter trips this repo's biome noAssignInExpressions rule
+			// (enforced with --error-on-warnings in the pre-commit hook; confirmed
+			// by a real run that failed to commit over exactly this). Matches the
+			// exact style already used in mic-source.test.ts's own MockMic.
+			const list = this._listeners[event] ?? [];
+			list.push(fn);
+			this._listeners[event] = list;
+			return this;
+		}
+		once(event: string, fn: Listener): this {
+			// Tag the wrapper with `.listener` pointing at the original fn,
+			// mirroring Node's real EventEmitter. mic-source.ts's settle()
+			// calls raw.removeListener(event, onError) with the ORIGINAL
+			// callback reference, not this wrapper — real EventEmitter matches
+			// through this tag. Without it, removeListener silently no-ops
+			// against a once()-registered listener and settle() would throw
+			// (confirmed by a real run: "raw.removeListener is not a function"
+			// without this fix entirely; even WITH a naive removeListener that
+			// only matches by direct reference, it would still silently fail
+			// to actually remove a once()-wrapped listener without this tag).
+			const wrap: Listener & { listener?: Listener } = (...args) => {
+				this._listeners[event] = (this._listeners[event] ?? []).filter((f) => f !== wrap);
+				fn(...args);
+			};
+			wrap.listener = fn;
+			return this.on(event, wrap);
+		}
+		removeListener(event: string, fn: Listener): this {
+			this._listeners[event] = (this._listeners[event] ?? []).filter(
+				(f) => f !== fn && (f as Listener & { listener?: Listener }).listener !== fn,
+			);
+			return this;
+		}
+		emit(event: string, ...args: unknown[]): void {
+			for (const fn of [...(this._listeners[event] ?? [])]) fn(...args);
+		}
+	}
+	return { default: MockShim };
+});
+
+vi.mock("./error-log.js", () => ({
+	appendErrorLog: vi.fn(),
+	appendDiagnosticLog: vi.fn(),
+}));
+
+import { appendDiagnosticLog } from "./error-log.js";
+import { createMic } from "./mic-source.js";
+
+describe("createMic() fallback to decibri-audiomic-shim", () => {
+	it("falls back to the shim when decibri fails to load, and resolves via Strategy 2", async () => {
+		const mic = await createMic();
+		expect(mic).toBeTruthy();
+		expect(appendDiagnosticLog).toHaveBeenCalledWith("mic.backend", "audiomic-shim (decibri unavailable)");
+		// Strategy 1 (vad:true, 16kHz) was attempted against the shim first
+		// and rejected, then Strategy 2 (vad:false, fallback rate) succeeded —
+		// mirrors the exact built-in-mic fallback path from issue #46, just
+		// routed through the shim instead of the real decibri addon.
+		expect(appendDiagnosticLog).toHaveBeenCalledWith("mic.path", expect.stringMatching(/^resample-rms@\d+Hz$/));
+		mic.stop();
+	});
+});

--- a/packages/rpiv-voice/audio/mic-source.ts
+++ b/packages/rpiv-voice/audio/mic-source.ts
@@ -80,9 +80,7 @@ interface DecibriCtor {
 type MicMode = "silero-passthrough" | "resample-rms";
 
 export async function createMic(): Promise<DecibriLike> {
-	// decibri ships as CJS (`module.exports = Decibri`); under ESM the ctor lands on `.default`.
-	const mod = (await import("decibri")) as { default: DecibriCtor };
-	const Decibri = mod.default;
+	const Decibri = await loadDecibriCtor();
 
 	// Strategy 1: 16 kHz with Silero. If the device accepts 16 kHz capture
 	// (USB headsets, AirPods, most external mics), this is strictly better
@@ -111,6 +109,68 @@ export async function createMic(): Promise<DecibriLike> {
 			}
 		}
 		throw lastError;
+	}
+}
+
+// decibri ships no darwin-x64 (Intel Mac) prebuilt native addon as of this
+// writing. On that one platform, import("decibri") throws at the native-
+// addon-load step. Fall back to a local compatibility shim built on
+// @audio/mic (miniaudio backend, ships a darwin-x64 prebuilt) so darwin-x64
+// users get the same resample-rms fallback quality that built-in-mic users
+// already get today (see issue #46 in juicesharp/rpiv-mono — this reuses
+// that exact code path, unmodified). Every other platform is unaffected:
+// import("decibri") succeeds there and this catch branch never runs.
+//
+// Resolution is memoized at module scope (once per process), not
+// re-attempted on every createMic() call. Observed live: on darwin-x64, the
+// first /voice invocation in a process correctly falls back to the shim and
+// works, but repeated /voice invocations within the SAME long-lived process
+// intermittently produced "Decibri is not a constructor" with no shim
+// fallback log line at all — consistent with import("decibri")'s cached
+// module-evaluation state behaving inconsistently across repeated dynamic
+// import() calls in a long-lived process (a standalone isolated test showed
+// consistent throwing across 5 repeats, but pi's actual extension runtime
+// environment did not reproduce that consistency across the many other
+// operations happening in a real session). Resolving once and reusing the
+// result removes any possibility of that inconsistency recurring. The
+// `typeof … !== "function"` guards are defense-in-depth: they turn a
+// silent malformed-export case into a clear, immediately-thrown diagnostic
+// instead of a cryptic "X is not a constructor" surfacing later inside
+// openMicAtRate's `new Decibri(opts)` call.
+let cachedDecibriCtor: Promise<DecibriCtor> | null = null;
+
+async function loadDecibriCtor(): Promise<DecibriCtor> {
+	if (!cachedDecibriCtor) {
+		cachedDecibriCtor = resolveDecibriCtor().catch((err) => {
+			// Do not memoize a rejection — a transient failure (e.g. the shim's
+			// own dynamic import racing something at startup) shouldn't
+			// permanently poison every later call in the process.
+			cachedDecibriCtor = null;
+			throw err;
+		});
+	}
+	return cachedDecibriCtor;
+}
+
+async function resolveDecibriCtor(): Promise<DecibriCtor> {
+	try {
+		// decibri ships as CJS (`module.exports = Decibri`); under ESM the ctor lands on `.default`.
+		const mod = (await import("decibri")) as { default: DecibriCtor };
+		if (typeof mod.default !== "function") {
+			throw new Error("decibri module loaded but its default export is not a constructor");
+		}
+		return mod.default;
+	} catch (err) {
+		try {
+			const shim = (await import("./decibri-audiomic-shim.js")) as { default: DecibriCtor };
+			if (typeof shim.default !== "function") {
+				throw new Error("decibri-audiomic-shim loaded but its default export is not a constructor");
+			}
+			appendDiagnosticLog("mic.backend", "audiomic-shim (decibri unavailable)");
+			return shim.default;
+		} catch {
+			throw err instanceof Error ? err : new Error(String(err)); // surface the original decibri load failure, not the shim's
+		}
 	}
 }
 

--- a/packages/rpiv-voice/package.json
+++ b/packages/rpiv-voice/package.json
@@ -33,6 +33,7 @@
 	},
 	"files": [
 		"index.ts",
+		"audio/decibri-audiomic-shim.ts",
 		"audio/error-log.ts",
 		"audio/hallucination-filter.ts",
 		"audio/mic-source.ts",
@@ -85,6 +86,9 @@
 		"@juicesharp/rpiv-config": "^2.6.0",
 		"sherpa-onnx-node": "^1.13.0",
 		"decibri": "^3.4.0"
+	},
+	"optionalDependencies": {
+		"@audio/mic": "^1.1.1"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*",


### PR DESCRIPTION
## An Intel Mac is not junk

A 2019–2020 Intel MacBook Pro is completely capable of running Pi Agent as a
daily driver — including a real local-AI support stack running alongside it in
Docker: [SearXNG](https://github.com/searxng/searxng) for local metasearch,
[Hindsight](https://github.com/luxus/pi-hindsight) plus its own Postgres
database for persistent agent memory, and a local reranking model for
Hindsight via [`michaelf34/infinity:latest-cpu`](https://github.com/michaelfeil/infinity)
— all running comfortably on stock Intel hardware, no GPU required.

Treating that hardware as obsolete because one dependency (`decibri`) dropped
darwin-x64 support would mean losing `/voice` entirely on a machine that's
otherwise doing real, current work. This PR keeps `/voice` working there
without asking anyone to replace working hardware.

## Root cause

`decibri` ships prebuilt native addons for `win32-x64`, `darwin-arm64`,
`linux-x64`, and `linux-arm64` — across every published version, including the
`3.4.x` line this project depends on. There is no darwin-x64 build, and there
won't be one: the maintainer has already explicitly declined to add it
upstream. See closed issue
[decibri/decibri#15](https://github.com/decibri/decibri/issues/15)
("Request: add darwin-x64 (Intel Mac) prebuilt binaries"), closed by the
maintainer citing Apple ending Intel Mac support and an unrelated upstream
blocker (the `ort-sys` crate, used for ONNX Runtime, ships no darwin-x64
prebuilts either).

On darwin-x64, `import("decibri")` throws at the native-addon-load step, and
`/voice` fails with "Microphone unavailable."

## The replacement: `@audio/mic`

We evaluated the realistic options for a darwin-x64-capable mic-capture
backend and landed on [`@audio/mic`](https://github.com/audiojs/mic)
(published on npm as `@audio/mic`):

- **Actually maintained.** Zero open issues, ever, matching `darwin` or `x64`
  in its issue tracker — a clean, actively-published project, not an
  abandoned one.
- **Ships a real darwin-x64 prebuilt.** `@audio/mic-darwin-x64` (currently
  `1.1.2`) is published as a proper platform-specific `optionalDependency`,
  `os`/`cpu` restricted, following the same standard prebuild pattern
  `decibri` itself uses.
- **Same underlying approach as decibri.** Wraps [miniaudio.h](https://github.com/mackron/miniaudio)
  as a native N-API addon — comparable architecture to decibri's own
  cpal-based native addon, not a heavier or fundamentally different runtime.
  No Python, no subprocess spawning, no extra system dependencies.
- **Verified against the wrong assumption up front.** miniaudio auto-converts
  between the device's native sample rate and whatever rate you request
  (confirmed by reading its native source directly:
  `config.sampleRate` is passed straight to `ma_device_init`, which handles
  the conversion internally) — unlike decibri/cpal, which fails outright when
  a device doesn't natively support the requested rate. That difference is
  what already caused the built-in-mic capture issue this project fixed in
  #46, and it's the exact failure mode `@audio/mic` avoids by design.

Other options were considered and rejected: `decibri-cli`'s own darwin
universal2 binary technically covers Intel, but the CLI is file-output-only
(its WAV writer seeks back to patch the header on finalize, which breaks on
non-seekable output like a pipe) — not viable for the real-time streaming
`/voice` needs, and would have required child-process lifecycle management
for no real benefit over a proper native addon.

## Minimizing the change

The goal was the smallest, most reviewable diff possible — not a rewrite.

1. **New, isolated file only:** `audio/decibri-audiomic-shim.ts` implements
   the exact same `DecibriCtor`/`DecibriRaw` constructor contract that
   `mic-source.ts` already expects from `decibri` itself. Nothing outside
   this one file needs to know it exists.

2. **One small, additive change to `mic-source.ts`:** `loadDecibriCtor()`
   tries the real `decibri` import first, exactly as before; only on failure
   does it fall back to the new shim. Every other platform is completely
   unaffected — `import("decibri")` succeeds there and the fallback branch
   never runs.

3. **Zero changes to core VAD/capture logic.** `pickCaptureRates()`,
   `openMicAtRate()`, `MicAdapterBase`, `SileroPassthroughAdapter`, and
   `ResamplingRmsAdapter` are all untouched. The shim doesn't implement Silero
   VAD (the miniaudio backend has none) — it deliberately rejects when
   `vad: true` is requested, which routes darwin-x64 through the *exact same*
   resample-rms fallback path already shipped and tested for built-in-mic
   support in #46. Darwin-x64 users get the same capture quality that
   built-in-mic users on any other platform already get today — not a new,
   separately-maintained code path.

4. **`@audio/mic` is an `optionalDependency`, not a `dependency`.** It never
   becomes mandatory anywhere. If its install fails on some platform for any
   reason, `npm install` simply skips it and every other platform continues
   to work exactly as before.

Net diff: one new ~180-line file, a ~15-line addition to `mic-source.ts`, and
a one-line `package.json` change.

## Testing

- Full existing test suite passes unmodified: 31 test files, 267 tests.
- Two new test files cover the shim in isolation and the fallback-wiring path
  in `mic-source.ts`.
- Verified live on real darwin-x64 (Intel Mac) hardware: `/voice` opens,
  captures real microphone audio, and transcribes correctly, including
  repeated `/voice` invocations within a single long-lived `pi` process
  (which surfaced two additional small, targeted fixes — a short retry-with-
  backoff on device open, since CoreAudio can take a moment to release a
  previous session's input device, and memoizing the decibri/shim resolution
  once per process, since re-resolving `import("decibri")` on every call
  intermittently produced an inconsistent result in a long-lived process).
