### PR TITLE
feat(rpiv-advisor): optional Claude Code subscription backend

### DIFF
--- a/packages/rpiv-advisor/CHANGELOG.md
+++ b/packages/rpiv-advisor/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Optional Claude Code subscription backend: a hand-edited `modelKey` of `claude-code/claude-opus-5` or `claude-code/claude-fable-5` sends each `advisor()` call through a fresh Agent SDK query. The `/advisor` picker and `completeSimple` path are unchanged.
+- Optional Claude Code subscription backend: a hand-edited `modelKey` of `claude-code/claude-opus-5` or `claude-code/claude-fable-5` sends each `advisor()` call through a fresh Agent SDK query. The `/advisor` picker and `completeSimple` path are unchanged. The Claude CLI is resolved from PATH, and Pi `minimal` effort is sent as Agent SDK `low`.
 
 ## [2.6.0] - 2026-08-15
 

--- a/packages/rpiv-advisor/CHANGELOG.md
+++ b/packages/rpiv-advisor/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Optional Claude Code subscription backend: a hand-edited `modelKey` of `claude-code/claude-opus-5` or `claude-code/claude-fable-5` sends each `advisor()` call through a fresh Agent SDK query. The `/advisor` picker and `completeSimple` path are unchanged.
+
 ## [2.6.0] - 2026-08-15
 
 ### Added

--- a/packages/rpiv-advisor/README.md
+++ b/packages/rpiv-advisor/README.md
@@ -98,7 +98,7 @@ write leaves your previous selection untouched and tells you so.
 To bill the reviewer against a Claude Code subscription instead of a Pi
 registry model, hand-edit `modelKey` to `claude-code/claude-opus-5` or
 `claude-code/claude-fable-5`. That path is not in the `/advisor` picker.
-It needs a logged-in `claude` CLI (`claude auth login --claudeai`) and the
+It needs a logged-in `claude` CLI on PATH (`claude auth login --claudeai`) and the
 optional `@anthropic-ai/claude-agent-sdk` peer. Each `advisor()` call starts
 a fresh isolated query; `/advisor` still only lists authenticated Pi models.
 
@@ -112,8 +112,8 @@ a fresh isolated query; `/advisor` still only lists authenticated Pi models.
 - A [Pi Agent](https://github.com/badlogic/pi-mono) host — the extension loads
   through Pi's extension manifest. No native dependencies.
 - An authenticated provider for the **reviewer** model, resolved through Pi's
-  model registry — or, for a hand-edited `claude-code/*` key, a logged-in
-  Claude Code CLI plus the optional `@anthropic-ai/claude-agent-sdk` peer.
+  model registry — or, for a hand-edited `claude-code/*` key, a `claude` CLI on
+  PATH plus the optional `@anthropic-ai/claude-agent-sdk` peer.
 - An interactive terminal for `/advisor`.
 
 ## Troubleshooting

--- a/packages/rpiv-advisor/README.md
+++ b/packages/rpiv-advisor/README.md
@@ -95,6 +95,13 @@ write leaves your previous selection untouched and tells you so.
 `/advisor` only rewrites `modelKey` and `effort`, so hand-edited keys —
 `disabledForModels` and the `guidance` overrides — survive every save.
 
+To bill the reviewer against a Claude Code subscription instead of a Pi
+registry model, hand-edit `modelKey` to `claude-code/claude-opus-5` or
+`claude-code/claude-fable-5`. That path is not in the `/advisor` picker.
+It needs a logged-in `claude` CLI (`claude auth login --claudeai`) and the
+optional `@anthropic-ai/claude-agent-sdk` peer. Each `advisor()` call starts
+a fresh isolated query; `/advisor` still only lists authenticated Pi models.
+
 ## Reference
 
 - [Configuration](https://github.com/juicesharp/rpiv-mono/blob/main/packages/rpiv-advisor/docs/configuration.md) — config file resolution, every key, blocklist matching rules, guidance overrides, and the full notification catalogue.
@@ -105,7 +112,8 @@ write leaves your previous selection untouched and tells you so.
 - A [Pi Agent](https://github.com/badlogic/pi-mono) host — the extension loads
   through Pi's extension manifest. No native dependencies.
 - An authenticated provider for the **reviewer** model, resolved through Pi's
-  model registry.
+  model registry — or, for a hand-edited `claude-code/*` key, a logged-in
+  Claude Code CLI plus the optional `@anthropic-ai/claude-agent-sdk` peer.
 - An interactive terminal for `/advisor`.
 
 ## Troubleshooting
@@ -115,6 +123,8 @@ write leaves your previous selection untouched and tells you so.
 | The `/advisor` picker offers only **No advisor** | No provider is authenticated in Pi | Run Pi's `/login` for a provider, then re-run `/advisor` |
 | `Advisor (<model>) has no API key available.` comes back as the tool result | Credentials for the reviewer's provider no longer resolve | Re-authenticate that provider with `/login` |
 | `/advisor requires interactive mode` | Running under `pi --print …` or RPC | Run Pi interactively |
+| `Advisor requires an active Claude subscription login.` | A `claude-code/*` key is set but `claude auth status` is not `claude.ai` / firstParty | Run `claude auth login --claudeai`, then retry |
+| `Claude Code advisor requires the optional @anthropic-ai/claude-agent-sdk dependency.` | The optional peer is not installed | Install `@anthropic-ai/claude-agent-sdk` next to rpiv-advisor |
 
 ## Related
 

--- a/packages/rpiv-advisor/advisor.execute.test.ts
+++ b/packages/rpiv-advisor/advisor.execute.test.ts
@@ -34,6 +34,7 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
 
 import { completeSimple } from "@earendil-works/pi-ai/compat";
 import { buildSessionContext } from "@earendil-works/pi-coding-agent";
+import { claudeCodeAdvisorModel } from "./advisor/claude-code.js";
 import { registerAdvisorTool, setAdvisorModel } from "./advisor/index.js";
 
 function resp(input: { text?: string; stopReason?: "done" | "aborted" | "error" | "toolUse"; errorMessage?: string }) {
@@ -261,6 +262,23 @@ describe("executeAdvisor — auth envelopes", () => {
 		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
 		expect(r?.content[0]).toMatchObject({ text: expect.stringContaining("bad config") });
 		expect(r?.details).toMatchObject({ errorMessage: "bad config", advisorModel: "a:m" });
+	});
+
+	it("routes a Claude Code assignment around completeSimple and registry auth", async () => {
+		setAdvisorModel(claudeCodeAdvisorModel("claude-opus-5"));
+		const { pi, captured } = createMockPi();
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx();
+		const getApiKeyAndHeaders = ctx.modelRegistry.getApiKeyAndHeaders as ReturnType<typeof vi.fn>;
+
+		const r = await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+
+		expect(completeSimple).not.toHaveBeenCalled();
+		expect(getApiKeyAndHeaders).not.toHaveBeenCalled();
+		expect(r?.details).toMatchObject({
+			advisorModel: "claude-code:claude-opus-5",
+			errorMessage: expect.stringMatching(/claude|Claude|ENOENT|subscription/),
+		});
 	});
 
 	it("returns no-api-key envelope when auth.ok but apiKey is missing", async () => {

--- a/packages/rpiv-advisor/advisor.restore.test.ts
+++ b/packages/rpiv-advisor/advisor.restore.test.ts
@@ -253,3 +253,29 @@ describe("restoreAdvisorState", () => {
 		});
 	});
 });
+
+describe("restoreAdvisorState — claude-code backend", () => {
+	it("restores a hand-edited Claude Code key without consulting the registry", () => {
+		writeConfig({ modelKey: "claude-code/claude-opus-5", effort: "high" });
+		const { pi, captured } = createMockPi();
+		const ctx = createMockCtx({ hasUI: true });
+		const find = vi.fn(() => undefined);
+		ctx.modelRegistry = { ...ctx.modelRegistry, find } as never;
+		restoreAdvisorState(ctx, pi);
+		expect(find).not.toHaveBeenCalled();
+		expect(getAdvisorModel()).toMatchObject({ provider: "claude-code", id: "claude-opus-5" });
+		expect(getAdvisorEffort()).toBe("high");
+		expect(captured.activeTools).toContain("advisor");
+	});
+
+	it("still treats an unknown claude-code id as a missing registry model", () => {
+		writeConfig({ modelKey: "claude-code/claude-sonnet-5" });
+		const { pi, captured } = createMockPi();
+		pi.setActiveTools(["advisor", "other"]);
+		const ctx = createMockCtx({ hasUI: true });
+		ctx.modelRegistry = { ...ctx.modelRegistry, find: vi.fn(() => undefined) } as never;
+		restoreAdvisorState(ctx, pi);
+		expect(getAdvisorModel()).toBeUndefined();
+		expect(captured.activeTools).toEqual(["other"]);
+	});
+});

--- a/packages/rpiv-advisor/advisor/claude-code.test.ts
+++ b/packages/rpiv-advisor/advisor/claude-code.test.ts
@@ -1,3 +1,6 @@
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -10,6 +13,8 @@ import {
 	consultClaudeCodeAdvisor,
 	formatClaudeCodePrompt,
 	isClaudeCodeAdvisorKey,
+	mapClaudeCodeEffort,
+	resolveClaudeCodeExecutable,
 	validateClaudeCodeRuntime,
 } from "./claude-code.js";
 import { ADVISOR_SYSTEM_PROMPT } from "./prompt.js";
@@ -84,6 +89,30 @@ describe("buildClaudeCodeSdkOptions", () => {
 			restoreEnv("ANTHROPIC_API_KEY", previous.apiKey);
 			restoreEnv("ANTHROPIC_AUTH_TOKEN", previous.authToken);
 			restoreEnv("CLAUDE_CODE_OAUTH_TOKEN", previous.oauthToken);
+		}
+	});
+});
+
+describe("mapClaudeCodeEffort", () => {
+	it("maps Pi minimal onto the lowest Agent SDK effort and leaves unset effort unset", () => {
+		expect(mapClaudeCodeEffort("minimal")).toBe("low");
+		expect(mapClaudeCodeEffort("high")).toBe("high");
+		expect(mapClaudeCodeEffort(undefined)).toBeUndefined();
+	});
+});
+
+describe("resolveClaudeCodeExecutable", () => {
+	it("prefers an executable found on PATH over the ~/.local/bin fallback", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "claude-code-path-"));
+		const executable = join(directory, "claude");
+		await writeFile(executable, "#!/bin/sh\n");
+		await chmod(executable, 0o755);
+		const previousPath = process.env.PATH;
+		process.env.PATH = directory;
+		try {
+			await expect(resolveClaudeCodeExecutable()).resolves.toBe(executable);
+		} finally {
+			restoreEnv("PATH", previousPath);
 		}
 	});
 });
@@ -171,6 +200,111 @@ describe("consultClaudeCodeAdvisor", () => {
 		expect(queryFactory).not.toHaveBeenCalled();
 		expect(result.details.errorMessage).toMatch(/Claude subscription login/);
 		expect(result.content[0]).toMatchObject({ type: "text" });
+	});
+
+	it("sends mapped Agent SDK effort, including Pi minimal as low", async () => {
+		const queryFactory: ClaudeCodeQueryFactory = vi.fn(() => queryFrom([successResult()]));
+		await consultClaudeCodeAdvisor({
+			advisor: claudeCodeAdvisorModel("claude-opus-5"),
+			effort: "minimal",
+			messages: [userMessage],
+			cwd: "/repo",
+			deps: {
+				queryFactory,
+				executable: "/bin/claude",
+				runtimeInspector: async () => ({
+					loggedIn: true,
+					authMethod: "claude.ai",
+					apiProvider: "firstParty",
+					version: "2.1.0",
+				}),
+			},
+		});
+		const options = vi.mocked(queryFactory).mock.calls[0]?.[0].options;
+		expect(options?.effort).toBe("low");
+	});
+
+	it("returns a cancelled envelope only when the caller aborted the signal", async () => {
+		const signal = AbortSignal.abort();
+		const queryFactory = vi.fn(async () => {
+			throw new Error("Advisor SDK process exited unexpectedly");
+		});
+		const result = await consultClaudeCodeAdvisor({
+			advisor: claudeCodeAdvisorModel("claude-opus-5"),
+			effort: "high",
+			messages: [userMessage],
+			cwd: "/repo",
+			signal,
+			deps: {
+				queryFactory,
+				executable: "/bin/claude",
+				runtimeInspector: async () => ({
+					loggedIn: true,
+					authMethod: "claude.ai",
+					apiProvider: "firstParty",
+					version: "2.1.0",
+				}),
+			},
+		});
+		expect(result.details.stopReason).toBe("aborted");
+		expect(result.content[0]).toMatchObject({
+			text: "Advisor call was cancelled before it completed.",
+		});
+	});
+
+	it("does not treat an unrelated aborted error as caller cancellation", async () => {
+		const result = await consultClaudeCodeAdvisor({
+			advisor: claudeCodeAdvisorModel("claude-opus-5"),
+			effort: "high",
+			messages: [userMessage],
+			cwd: "/repo",
+			deps: {
+				queryFactory: async () => {
+					throw new Error("operation aborted by provider");
+				},
+				executable: "/bin/claude",
+				runtimeInspector: async () => ({
+					loggedIn: true,
+					authMethod: "claude.ai",
+					apiProvider: "firstParty",
+					version: "2.1.0",
+				}),
+			},
+		});
+		expect(result.details.stopReason).toBeUndefined();
+		expect(result.details.errorMessage).toBe("operation aborted by provider");
+		expect(result.content[0]).toMatchObject({ text: "Advisor call threw: operation aborted by provider" });
+	});
+
+	it("closes the query and reports a non-success SDK result", async () => {
+		const query = queryFrom([
+			{
+				type: "result",
+				subtype: "error_during_execution",
+				errors: ["model overloaded"],
+			},
+		]);
+		const result = await consultClaudeCodeAdvisor({
+			advisor: claudeCodeAdvisorModel("claude-opus-5"),
+			effort: "high",
+			messages: [userMessage],
+			cwd: "/repo",
+			deps: {
+				queryFactory: () => query,
+				executable: "/bin/claude",
+				runtimeInspector: async () => ({
+					loggedIn: true,
+					authMethod: "claude.ai",
+					apiProvider: "firstParty",
+					version: "2.1.0",
+				}),
+			},
+		});
+		expect(query.close).toHaveBeenCalledTimes(1);
+		expect(result.details).toMatchObject({
+			stopReason: "error",
+			errorMessage: "model overloaded",
+		});
 	});
 
 	it("fails a managed refusal fallback instead of accepting another model", async () => {

--- a/packages/rpiv-advisor/advisor/claude-code.test.ts
+++ b/packages/rpiv-advisor/advisor/claude-code.test.ts
@@ -1,0 +1,207 @@
+import type { Message } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildClaudeCodeSdkOptions,
+	type ClaudeCodeQuery,
+	type ClaudeCodeQueryFactory,
+	type ClaudeCodeQueryMessage,
+	type ClaudeCodeQueryResult,
+	claudeCodeAdvisorModel,
+	consultClaudeCodeAdvisor,
+	formatClaudeCodePrompt,
+	isClaudeCodeAdvisorKey,
+	validateClaudeCodeRuntime,
+} from "./claude-code.js";
+import { ADVISOR_SYSTEM_PROMPT } from "./prompt.js";
+
+const userMessage: Message = {
+	role: "user",
+	content: [{ type: "text", text: "Please advise on the executor's situation above." }],
+	timestamp: Date.now(),
+};
+
+function queryFrom(messages: Array<ClaudeCodeQueryMessage | ClaudeCodeQueryResult>): ClaudeCodeQuery {
+	return {
+		async *[Symbol.asyncIterator]() {
+			for (const message of messages) yield message as never;
+		},
+		close: vi.fn(),
+	};
+}
+
+function successResult(overrides: Partial<ClaudeCodeQueryResult> = {}): ClaudeCodeQueryResult {
+	return {
+		type: "result",
+		subtype: "success",
+		result: "ship the smaller change",
+		stop_reason: "end_turn",
+		usage: { input_tokens: 10, output_tokens: 4, cache_read_input_tokens: 2, cache_creation_input_tokens: 1 },
+		total_cost_usd: 0.01,
+		...overrides,
+	};
+}
+
+describe("isClaudeCodeAdvisorKey", () => {
+	it("accepts only the two hand-edited Claude Code assignments", () => {
+		expect(isClaudeCodeAdvisorKey("claude-code", "claude-opus-5")).toBe(true);
+		expect(isClaudeCodeAdvisorKey("claude-code", "claude-fable-5")).toBe(true);
+		expect(isClaudeCodeAdvisorKey("claude-code", "claude-sonnet-5")).toBe(false);
+		expect(isClaudeCodeAdvisorKey("anthropic", "claude-opus-5")).toBe(false);
+	});
+});
+
+describe("buildClaudeCodeSdkOptions", () => {
+	it("pins isolation options and strips Anthropic credential overrides", () => {
+		const previous = {
+			apiKey: process.env.ANTHROPIC_API_KEY,
+			authToken: process.env.ANTHROPIC_AUTH_TOKEN,
+			oauthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+		};
+		process.env.ANTHROPIC_API_KEY = "api";
+		process.env.ANTHROPIC_AUTH_TOKEN = "auth";
+		process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth";
+		try {
+			const options = buildClaudeCodeSdkOptions({
+				model: "claude-opus-5",
+				effort: "high",
+				cwd: "/repo",
+				executable: "/bin/claude",
+				abortController: new AbortController(),
+			});
+			expect(options.model).toBe("claude-opus-5");
+			expect(options.effort).toBe("high");
+			expect(options.systemPrompt).toBe(ADVISOR_SYSTEM_PROMPT);
+			expect(options.tools).toEqual([]);
+			expect(options.skills).toEqual([]);
+			expect(options.settingSources).toEqual([]);
+			expect(options.persistSession).toBe(false);
+			expect(options.settings).toEqual({ disableBundledSkills: true, fallbackModel: [] });
+			expect(options.extraArgs).toEqual({ "disable-slash-commands": null });
+			expect((options.env as NodeJS.ProcessEnv).ANTHROPIC_API_KEY).toBeUndefined();
+			expect((options.env as NodeJS.ProcessEnv).ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+			expect((options.env as NodeJS.ProcessEnv).CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+		} finally {
+			restoreEnv("ANTHROPIC_API_KEY", previous.apiKey);
+			restoreEnv("ANTHROPIC_AUTH_TOKEN", previous.authToken);
+			restoreEnv("CLAUDE_CODE_OAUTH_TOKEN", previous.oauthToken);
+		}
+	});
+});
+
+describe("validateClaudeCodeRuntime", () => {
+	it("requires a first-party claude.ai login", () => {
+		expect(() =>
+			validateClaudeCodeRuntime({
+				loggedIn: true,
+				authMethod: "claude.ai",
+				apiProvider: "firstParty",
+				version: "2.1.0",
+			}),
+		).not.toThrow();
+		expect(() =>
+			validateClaudeCodeRuntime({
+				loggedIn: false,
+				authMethod: "claude.ai",
+				apiProvider: "firstParty",
+				version: "2.1.0",
+			}),
+		).toThrow(/Claude subscription login/);
+		expect(() =>
+			validateClaudeCodeRuntime({
+				loggedIn: true,
+				authMethod: "api-key",
+				apiProvider: "firstParty",
+				version: "2.1.0",
+			}),
+		).toThrow(/Claude subscription login/);
+	});
+});
+
+describe("formatClaudeCodePrompt", () => {
+	it("keeps the user-tail nudge from the shared branch assembly", () => {
+		expect(formatClaudeCodePrompt([userMessage])).toContain("Please advise on the executor's situation above.");
+	});
+});
+
+describe("consultClaudeCodeAdvisor", () => {
+	it("returns guidance from a successful isolated query and never retries", async () => {
+		const queryFactory: ClaudeCodeQueryFactory = vi.fn(() => queryFrom([successResult()]));
+		const result = await consultClaudeCodeAdvisor({
+			advisor: claudeCodeAdvisorModel("claude-opus-5"),
+			effort: "high",
+			messages: [userMessage],
+			cwd: "/repo",
+			deps: {
+				queryFactory,
+				runtimeInspector: async () => ({
+					loggedIn: true,
+					authMethod: "claude.ai",
+					apiProvider: "firstParty",
+					version: "2.1.0",
+				}),
+			},
+		});
+		expect(queryFactory).toHaveBeenCalledTimes(1);
+		expect(result.content[0]).toMatchObject({ type: "text", text: "ship the smaller change" });
+		expect(result.details).toMatchObject({
+			advisorModel: "claude-code:claude-opus-5",
+			effort: "high",
+			stopReason: "stop",
+		});
+		expect(result.details.usage).toMatchObject({ input: 10, output: 4, cacheRead: 2, cacheWrite: 1 });
+	});
+
+	it("fails closed when Claude Code is not logged in, before opening a query", async () => {
+		const queryFactory = vi.fn(() => queryFrom([successResult()]));
+		const result = await consultClaudeCodeAdvisor({
+			advisor: claudeCodeAdvisorModel("claude-fable-5"),
+			effort: "high",
+			messages: [userMessage],
+			cwd: "/repo",
+			deps: {
+				queryFactory,
+				runtimeInspector: async () => ({
+					loggedIn: false,
+					authMethod: "",
+					apiProvider: "",
+					version: "2.1.0",
+				}),
+			},
+		});
+		expect(queryFactory).not.toHaveBeenCalled();
+		expect(result.details.errorMessage).toMatch(/Claude subscription login/);
+		expect(result.content[0]).toMatchObject({ type: "text" });
+	});
+
+	it("fails a managed refusal fallback instead of accepting another model", async () => {
+		const result = await consultClaudeCodeAdvisor({
+			advisor: claudeCodeAdvisorModel("claude-opus-5"),
+			effort: "high",
+			messages: [userMessage],
+			cwd: "/repo",
+			deps: {
+				queryFactory: () =>
+					queryFrom([
+						{
+							type: "system",
+							subtype: "model_refusal_fallback",
+							original_model: "claude-opus-5",
+							fallback_model: "claude-sonnet-5",
+						},
+					]),
+				runtimeInspector: async () => ({
+					loggedIn: true,
+					authMethod: "claude.ai",
+					apiProvider: "firstParty",
+					version: "2.1.0",
+				}),
+			},
+		});
+		expect(result.details.errorMessage).toMatch(/model fallback/);
+	});
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
+}

--- a/packages/rpiv-advisor/advisor/claude-code.test.ts
+++ b/packages/rpiv-advisor/advisor/claude-code.test.ts
@@ -25,6 +25,31 @@ const userMessage: Message = {
 	timestamp: Date.now(),
 };
 
+const loggedInRuntime = {
+	loggedIn: true,
+	authMethod: "claude.ai",
+	apiProvider: "firstParty",
+	version: "2.1.0",
+} as const;
+
+function consultDeps(
+	overrides: {
+		queryFactory?: ClaudeCodeQueryFactory;
+		runtimeInspector?: () => Promise<{
+			loggedIn: boolean;
+			authMethod: string;
+			apiProvider: string;
+			version: string;
+		}>;
+	} = {},
+) {
+	return {
+		executable: "/bin/claude",
+		runtimeInspector: async () => loggedInRuntime,
+		...overrides,
+	};
+}
+
 function queryFrom(messages: Array<ClaudeCodeQueryMessage | ClaudeCodeQueryResult>): ClaudeCodeQuery {
 	return {
 		async *[Symbol.asyncIterator]() {
@@ -160,15 +185,7 @@ describe("consultClaudeCodeAdvisor", () => {
 			effort: "high",
 			messages: [userMessage],
 			cwd: "/repo",
-			deps: {
-				queryFactory,
-				runtimeInspector: async () => ({
-					loggedIn: true,
-					authMethod: "claude.ai",
-					apiProvider: "firstParty",
-					version: "2.1.0",
-				}),
-			},
+			deps: consultDeps({ queryFactory }),
 		});
 		expect(queryFactory).toHaveBeenCalledTimes(1);
 		expect(result.content[0]).toMatchObject({ type: "text", text: "ship the smaller change" });
@@ -187,7 +204,7 @@ describe("consultClaudeCodeAdvisor", () => {
 			effort: "high",
 			messages: [userMessage],
 			cwd: "/repo",
-			deps: {
+			deps: consultDeps({
 				queryFactory,
 				runtimeInspector: async () => ({
 					loggedIn: false,
@@ -195,7 +212,7 @@ describe("consultClaudeCodeAdvisor", () => {
 					apiProvider: "",
 					version: "2.1.0",
 				}),
-			},
+			}),
 		});
 		expect(queryFactory).not.toHaveBeenCalled();
 		expect(result.details.errorMessage).toMatch(/Claude subscription login/);
@@ -209,16 +226,7 @@ describe("consultClaudeCodeAdvisor", () => {
 			effort: "minimal",
 			messages: [userMessage],
 			cwd: "/repo",
-			deps: {
-				queryFactory,
-				executable: "/bin/claude",
-				runtimeInspector: async () => ({
-					loggedIn: true,
-					authMethod: "claude.ai",
-					apiProvider: "firstParty",
-					version: "2.1.0",
-				}),
-			},
+			deps: consultDeps({ queryFactory }),
 		});
 		const options = vi.mocked(queryFactory).mock.calls[0]?.[0].options;
 		expect(options?.effort).toBe("low");
@@ -235,16 +243,7 @@ describe("consultClaudeCodeAdvisor", () => {
 			messages: [userMessage],
 			cwd: "/repo",
 			signal,
-			deps: {
-				queryFactory,
-				executable: "/bin/claude",
-				runtimeInspector: async () => ({
-					loggedIn: true,
-					authMethod: "claude.ai",
-					apiProvider: "firstParty",
-					version: "2.1.0",
-				}),
-			},
+			deps: consultDeps({ queryFactory }),
 		});
 		expect(result.details.stopReason).toBe("aborted");
 		expect(result.content[0]).toMatchObject({
@@ -258,18 +257,11 @@ describe("consultClaudeCodeAdvisor", () => {
 			effort: "high",
 			messages: [userMessage],
 			cwd: "/repo",
-			deps: {
+			deps: consultDeps({
 				queryFactory: async () => {
 					throw new Error("operation aborted by provider");
 				},
-				executable: "/bin/claude",
-				runtimeInspector: async () => ({
-					loggedIn: true,
-					authMethod: "claude.ai",
-					apiProvider: "firstParty",
-					version: "2.1.0",
-				}),
-			},
+			}),
 		});
 		expect(result.details.stopReason).toBeUndefined();
 		expect(result.details.errorMessage).toBe("operation aborted by provider");
@@ -289,16 +281,7 @@ describe("consultClaudeCodeAdvisor", () => {
 			effort: "high",
 			messages: [userMessage],
 			cwd: "/repo",
-			deps: {
-				queryFactory: () => query,
-				executable: "/bin/claude",
-				runtimeInspector: async () => ({
-					loggedIn: true,
-					authMethod: "claude.ai",
-					apiProvider: "firstParty",
-					version: "2.1.0",
-				}),
-			},
+			deps: consultDeps({ queryFactory: () => query }),
 		});
 		expect(query.close).toHaveBeenCalledTimes(1);
 		expect(result.details).toMatchObject({
@@ -313,7 +296,7 @@ describe("consultClaudeCodeAdvisor", () => {
 			effort: "high",
 			messages: [userMessage],
 			cwd: "/repo",
-			deps: {
+			deps: consultDeps({
 				queryFactory: () =>
 					queryFrom([
 						{
@@ -323,13 +306,7 @@ describe("consultClaudeCodeAdvisor", () => {
 							fallback_model: "claude-sonnet-5",
 						},
 					]),
-				runtimeInspector: async () => ({
-					loggedIn: true,
-					authMethod: "claude.ai",
-					apiProvider: "firstParty",
-					version: "2.1.0",
-				}),
-			},
+			}),
 		});
 		expect(result.details.errorMessage).toMatch(/model fallback/);
 	});

--- a/packages/rpiv-advisor/advisor/claude-code.ts
+++ b/packages/rpiv-advisor/advisor/claude-code.ts
@@ -1,0 +1,425 @@
+/**
+ * claude-code — optional Claude Code subscription backend for advisor().
+ *
+ * A hand-edited modelKey of `claude-code/claude-opus-5` or
+ * `claude-code/claude-fable-5` bypasses Pi's model registry and AuthStorage.
+ * Each advisor() call starts a fresh Agent SDK query with tools disabled.
+ * Continuity, task budgets, and the /advisor picker are unchanged and still
+ * belong to the completeSimple path.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { Api, Message, Model, StopReason, ThinkingLevel, Usage } from "@earendil-works/pi-ai";
+import type { AgentToolResult } from "@earendil-works/pi-coding-agent";
+import { ADVISOR_SYSTEM_PROMPT } from "./prompt.js";
+
+/** Synthetic provider id for the Claude Code subscription backend. */
+export const CLAUDE_CODE_PROVIDER = "claude-code";
+
+/** Claude Code model ids accepted as an advisor assignment. */
+export const CLAUDE_CODE_MODELS = ["claude-opus-5", "claude-fable-5"] as const;
+
+export type ClaudeCodeModelId = (typeof CLAUDE_CODE_MODELS)[number];
+
+const CLAUDE_CODE_MODEL_SET = new Set<string>(CLAUDE_CODE_MODELS);
+const SANITIZED_CREDENTIALS = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
+const CLAUDE_EXECUTABLE = join(homedir(), ".local", "bin", "claude");
+
+export interface ClaudeCodeRuntimeStatus {
+	loggedIn: boolean;
+	authMethod: string;
+	apiProvider: string;
+	version: string;
+}
+
+export interface ClaudeCodeQueryResult {
+	type: "result";
+	subtype: string;
+	result?: string;
+	stop_reason?: string | null;
+	errors?: string[];
+	usage?: {
+		input_tokens?: number;
+		output_tokens?: number;
+		cache_read_input_tokens?: number;
+		cache_creation_input_tokens?: number;
+	};
+	total_cost_usd?: number;
+}
+
+export interface ClaudeCodeQueryMessage {
+	type: string;
+	subtype?: string;
+	error?: string;
+	original_model?: string;
+	fallback_model?: string;
+}
+
+export interface ClaudeCodeQuery extends AsyncIterable<ClaudeCodeQueryMessage | ClaudeCodeQueryResult> {
+	close(): void;
+}
+
+export type ClaudeCodeQueryFactory = (params: {
+	prompt: string;
+	options: Record<string, unknown>;
+}) => ClaudeCodeQuery | Promise<ClaudeCodeQuery>;
+
+export type ClaudeCodeRuntimeInspector = (executable: string) => Promise<ClaudeCodeRuntimeStatus>;
+
+export interface ClaudeCodeConsultDeps {
+	queryFactory?: ClaudeCodeQueryFactory;
+	runtimeInspector?: ClaudeCodeRuntimeInspector;
+	executable?: string;
+}
+
+export interface ClaudeCodeAdvisorDetails {
+	advisorModel?: string;
+	effort?: ThinkingLevel;
+	usage?: Usage;
+	stopReason?: StopReason;
+	errorMessage?: string;
+}
+
+/**
+ * True when provider/modelId names an allowed Claude Code advisor assignment.
+ * Unknown model ids under the claude-code prefix stay on the registry path.
+ */
+export function isClaudeCodeAdvisorKey(provider: string, modelId: string): boolean {
+	return provider === CLAUDE_CODE_PROVIDER && CLAUDE_CODE_MODEL_SET.has(modelId);
+}
+
+/**
+ * Synthetic Model used so existing advisor state, blocklist, and result
+ * labels keep working. It is never looked up in Pi's registry and never
+ * passed to completeSimple.
+ */
+export function claudeCodeAdvisorModel(modelId: ClaudeCodeModelId): Model<Api> {
+	return {
+		id: modelId,
+		name: modelId,
+		api: "anthropic-messages",
+		provider: CLAUDE_CODE_PROVIDER,
+		baseUrl: "",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 32_000,
+	};
+}
+
+/** Runs one isolated Claude Code advisor turn and maps it onto the advisor result envelope. */
+export async function consultClaudeCodeAdvisor(input: {
+	advisor: Model<Api>;
+	effort: ThinkingLevel | undefined;
+	messages: Message[];
+	cwd: string;
+	signal?: AbortSignal;
+	deps?: ClaudeCodeConsultDeps;
+}): Promise<AgentToolResult<ClaudeCodeAdvisorDetails>> {
+	const advisorLabel = `${input.advisor.provider}:${input.advisor.id}`;
+	try {
+		const result = await runClaudeCodeQuery({
+			model: input.advisor.id,
+			effort: input.effort,
+			messages: input.messages,
+			cwd: input.cwd,
+			signal: input.signal,
+			deps: input.deps,
+		});
+		const usage = mapClaudeCodeUsage(result);
+		if (result.subtype !== "success") {
+			const message = result.errors?.join("; ") || result.subtype;
+			return buildClaudeCodeResult({
+				text: `Advisor call failed: ${message}`,
+				effort: input.effort,
+				advisorLabel,
+				usage,
+				stopReason: "error",
+				errorMessage: message,
+			});
+		}
+		const text = result.result?.trim() ?? "";
+		if (!text) {
+			return buildClaudeCodeResult({
+				text: "Advisor returned no text content.",
+				effort: input.effort,
+				advisorLabel,
+				usage,
+				stopReason: mapClaudeCodeStopReason(result.stop_reason),
+				errorMessage: "empty response",
+			});
+		}
+		return buildClaudeCodeResult({
+			text,
+			effort: input.effort,
+			advisorLabel,
+			usage,
+			stopReason: mapClaudeCodeStopReason(result.stop_reason),
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (input.signal?.aborted || /aborted/i.test(message)) {
+			return buildClaudeCodeResult({
+				text: "Advisor call was cancelled before it completed.",
+				effort: input.effort,
+				advisorLabel,
+				stopReason: "aborted",
+				errorMessage: message || "aborted",
+			});
+		}
+		return buildClaudeCodeResult({
+			text: `Advisor call threw: ${message}`,
+			effort: input.effort,
+			advisorLabel,
+			errorMessage: message,
+		});
+	}
+}
+
+export function buildClaudeCodeSdkOptions(input: {
+	model: string;
+	effort: ThinkingLevel | undefined;
+	cwd: string;
+	executable: string;
+	abortController: AbortController;
+}): Record<string, unknown> {
+	return {
+		abortController: input.abortController,
+		cwd: input.cwd,
+		effort: input.effort,
+		env: sanitizedChildEnvironment(),
+		extraArgs: { "disable-slash-commands": null },
+		model: input.model,
+		pathToClaudeCodeExecutable: input.executable,
+		persistSession: false,
+		settingSources: [],
+		settings: { disableBundledSkills: true, fallbackModel: [] },
+		skills: [],
+		strictMcpConfig: true,
+		systemPrompt: ADVISOR_SYSTEM_PROMPT,
+		tools: [],
+	};
+}
+
+export function validateClaudeCodeRuntime(status: ClaudeCodeRuntimeStatus): void {
+	if (!status.loggedIn || status.authMethod !== "claude.ai" || status.apiProvider !== "firstParty") {
+		throw new Error(
+			"Advisor requires an active Claude subscription login. Run `claude auth login --claudeai`, complete browser sign-in, then retry.",
+		);
+	}
+}
+
+export function formatClaudeCodePrompt(messages: Message[]): string {
+	return messages.map(formatClaudeCodeMessage).join("\n\n");
+}
+
+async function runClaudeCodeQuery(input: {
+	model: string;
+	effort: ThinkingLevel | undefined;
+	messages: Message[];
+	cwd: string;
+	signal?: AbortSignal;
+	deps?: ClaudeCodeConsultDeps;
+}): Promise<ClaudeCodeQueryResult> {
+	const executable = input.deps?.executable ?? CLAUDE_EXECUTABLE;
+	const inspect = input.deps?.runtimeInspector ?? inspectClaudeCodeRuntime;
+	const runtime = await inspect(executable);
+	validateClaudeCodeRuntime(runtime);
+
+	const abortController = new AbortController();
+	const onAbort = () => abortController.abort();
+	input.signal?.addEventListener("abort", onAbort, { once: true });
+	if (input.signal?.aborted) abortController.abort();
+
+	const queryFactory = input.deps?.queryFactory ?? defaultClaudeCodeQueryFactory;
+	const query = await queryFactory({
+		prompt: formatClaudeCodePrompt(input.messages),
+		options: buildClaudeCodeSdkOptions({
+			model: input.model,
+			effort: input.effort,
+			cwd: input.cwd,
+			executable,
+			abortController,
+		}),
+	});
+
+	try {
+		for await (const message of query) {
+			if (message.type === "system" && message.subtype === "model_refusal_fallback") {
+				throw new Error(
+					`Advisor attempted model fallback from ${message.original_model} to ${message.fallback_model}`,
+				);
+			}
+			if (message.type === "assistant" && "error" in message && message.error) {
+				throw new Error(`Advisor model failed: ${message.error}`);
+			}
+			if (message.type === "result") return message as ClaudeCodeQueryResult;
+		}
+		throw new Error("Advisor SDK process exited unexpectedly");
+	} finally {
+		input.signal?.removeEventListener("abort", onAbort);
+		query.close();
+		abortController.abort();
+	}
+}
+
+async function defaultClaudeCodeQueryFactory(params: {
+	prompt: string;
+	options: Record<string, unknown>;
+}): Promise<ClaudeCodeQuery> {
+	const sdk = await loadClaudeAgentSdk();
+	return sdk.query(params);
+}
+
+async function loadClaudeAgentSdk(): Promise<{
+	query: (params: { prompt: string; options: Record<string, unknown> }) => ClaudeCodeQuery;
+}> {
+	try {
+		const specifier = "@anthropic-ai/claude-agent-sdk";
+		return (await import(specifier)) as {
+			query: (params: { prompt: string; options: Record<string, unknown> }) => ClaudeCodeQuery;
+		};
+	} catch {
+		throw new Error(
+			"Claude Code advisor requires the optional @anthropic-ai/claude-agent-sdk dependency. Install it in the same Node environment as rpiv-advisor.",
+		);
+	}
+}
+
+export async function inspectClaudeCodeRuntime(executable: string): Promise<ClaudeCodeRuntimeStatus> {
+	const env = sanitizedChildEnvironment();
+	const execFileAsync = await loadExecFileAsync();
+	const [{ stdout: versionOutput }, auth] = await Promise.all([
+		execFileAsync(executable, ["--version"], { env }),
+		inspectClaudeAuthStatus(executable, env, execFileAsync),
+	]);
+	return {
+		loggedIn: auth.loggedIn === true,
+		authMethod: typeof auth.authMethod === "string" ? auth.authMethod : "",
+		apiProvider: typeof auth.apiProvider === "string" ? auth.apiProvider : "",
+		version: versionOutput.trim().split(" ")[0] ?? "",
+	};
+}
+
+type ExecFileAsync = (
+	file: string,
+	args: readonly string[],
+	opts: { env: NodeJS.ProcessEnv },
+) => Promise<{ stdout: string }>;
+
+async function loadExecFileAsync(): Promise<ExecFileAsync> {
+	const { execFile } = await import("node:child_process");
+	return promisify(execFile) as ExecFileAsync;
+}
+
+async function inspectClaudeAuthStatus(
+	executable: string,
+	env: NodeJS.ProcessEnv,
+	execFileAsync: ExecFileAsync,
+): Promise<Record<string, unknown>> {
+	try {
+		const { stdout } = await execFileAsync(executable, ["auth", "status", "--json"], { env });
+		return JSON.parse(stdout) as Record<string, unknown>;
+	} catch (error) {
+		const auth = parseLoggedOutClaudeAuthStatus(error);
+		if (auth) return auth;
+		throw error;
+	}
+}
+
+function parseLoggedOutClaudeAuthStatus(error: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(error) || typeof error.stdout !== "string") return undefined;
+	try {
+		const auth: unknown = JSON.parse(error.stdout);
+		if (
+			!isRecord(auth) ||
+			auth.loggedIn !== false ||
+			typeof auth.authMethod !== "string" ||
+			typeof auth.apiProvider !== "string"
+		) {
+			return undefined;
+		}
+		return auth;
+	} catch {
+		return undefined;
+	}
+}
+
+function sanitizedChildEnvironment(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	for (const name of SANITIZED_CREDENTIALS) delete env[name];
+	return env;
+}
+
+function formatClaudeCodeMessage(message: Message): string {
+	if (message.role === "user") {
+		const text = typeof message.content === "string" ? message.content : serializeContent(message.content);
+		return `User:\n${text}`;
+	}
+	if (message.role === "toolResult") {
+		return `Tool result (${message.toolName}):\n${serializeContent(message.content)}`;
+	}
+	return `Assistant:\n${serializeContent(message.content)}`;
+}
+
+function serializeContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return JSON.stringify(content);
+	return content
+		.map((block) => {
+			if (!isRecord(block)) return JSON.stringify(block);
+			if (block.type === "text" && typeof block.text === "string") return block.text;
+			if (block.type === "thinking" && typeof block.thinking === "string") return block.thinking;
+			if (block.type === "toolCall") return `toolCall ${String(block.name)} ${JSON.stringify(block.arguments)}`;
+			if (block.type === "image") return `[image ${String(block.mimeType)}]`;
+			return JSON.stringify(block);
+		})
+		.join("\n");
+}
+
+function mapClaudeCodeUsage(result: ClaudeCodeQueryResult): Usage | undefined {
+	if (!result.usage) return undefined;
+	const input = result.usage.input_tokens ?? 0;
+	const output = result.usage.output_tokens ?? 0;
+	const cacheRead = result.usage.cache_read_input_tokens ?? 0;
+	const cacheWrite = result.usage.cache_creation_input_tokens ?? 0;
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output + cacheRead + cacheWrite,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: result.total_cost_usd ?? 0 },
+	};
+}
+
+function mapClaudeCodeStopReason(stopReason: string | null | undefined): StopReason | undefined {
+	if (stopReason === "aborted") return "aborted";
+	if (stopReason === "error") return "error";
+	if (stopReason === "toolUse" || stopReason === "tool_use") return "toolUse";
+	if (stopReason === "length" || stopReason === "max_tokens") return "length";
+	if (stopReason == null) return undefined;
+	return "stop";
+}
+
+function buildClaudeCodeResult(opts: {
+	text: string;
+	effort: ThinkingLevel | undefined;
+	advisorLabel: string;
+	usage?: Usage;
+	stopReason?: StopReason;
+	errorMessage?: string;
+}): AgentToolResult<ClaudeCodeAdvisorDetails> {
+	const details: ClaudeCodeAdvisorDetails = { advisorModel: opts.advisorLabel, effort: opts.effort };
+	if (opts.usage !== undefined) details.usage = opts.usage;
+	if (opts.stopReason !== undefined) details.stopReason = opts.stopReason;
+	if (opts.errorMessage !== undefined) details.errorMessage = opts.errorMessage;
+	return { content: [{ type: "text", text: opts.text }], details };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/packages/rpiv-advisor/advisor/claude-code.ts
+++ b/packages/rpiv-advisor/advisor/claude-code.ts
@@ -4,12 +4,13 @@
  * A hand-edited modelKey of `claude-code/claude-opus-5` or
  * `claude-code/claude-fable-5` bypasses Pi's model registry and AuthStorage.
  * Each advisor() call starts a fresh Agent SDK query with tools disabled.
- * Continuity, task budgets, and the /advisor picker are unchanged and still
- * belong to the completeSimple path.
+ * The /advisor picker and completeSimple path are unchanged.
  */
 
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { promisify } from "node:util";
 import type { Api, Message, Model, StopReason, ThinkingLevel, Usage } from "@earendil-works/pi-ai";
 import type { AgentToolResult } from "@earendil-works/pi-coding-agent";
@@ -25,7 +26,10 @@ export type ClaudeCodeModelId = (typeof CLAUDE_CODE_MODELS)[number];
 
 const CLAUDE_CODE_MODEL_SET = new Set<string>(CLAUDE_CODE_MODELS);
 const SANITIZED_CREDENTIALS = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
-const CLAUDE_EXECUTABLE = join(homedir(), ".local", "bin", "claude");
+const CLAUDE_CODE_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
+const FALLBACK_CLAUDE_EXECUTABLE = join(homedir(), ".local", "bin", "claude");
+
+export type ClaudeCodeEffort = (typeof CLAUDE_CODE_EFFORTS)[number];
 
 export interface ClaudeCodeRuntimeStatus {
 	loggedIn: boolean;
@@ -88,6 +92,31 @@ export interface ClaudeCodeAdvisorDetails {
  */
 export function isClaudeCodeAdvisorKey(provider: string, modelId: string): boolean {
 	return provider === CLAUDE_CODE_PROVIDER && CLAUDE_CODE_MODEL_SET.has(modelId);
+}
+
+/**
+ * Maps a persisted advisor effort onto an Agent SDK effort value.
+ * Pi's `minimal` level has no SDK equivalent, so it becomes `low`.
+ * An unset effort is left unset so Claude Code uses its own default.
+ */
+export function mapClaudeCodeEffort(effort: ThinkingLevel | undefined): ClaudeCodeEffort | undefined {
+	if (effort === undefined) return undefined;
+	if (effort === "minimal") return "low";
+	return effort;
+}
+
+/** Resolves the Claude Code CLI from PATH, then `~/.local/bin/claude`. */
+export async function resolveClaudeCodeExecutable(): Promise<string> {
+	const names = process.platform === "win32" ? ["claude.exe", "claude.cmd", "claude"] : ["claude"];
+	for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+		if (!directory) continue;
+		for (const name of names) {
+			const candidate = join(directory, name);
+			if (await isExecutable(candidate)) return candidate;
+		}
+	}
+	if (await isExecutable(FALLBACK_CLAUDE_EXECUTABLE)) return FALLBACK_CLAUDE_EXECUTABLE;
+	throw new Error("Claude Code advisor requires a `claude` executable on PATH. Install Claude Code and retry.");
 }
 
 /**
@@ -161,7 +190,7 @@ export async function consultClaudeCodeAdvisor(input: {
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		if (input.signal?.aborted || /aborted/i.test(message)) {
+		if (input.signal?.aborted) {
 			return buildClaudeCodeResult({
 				text: "Advisor call was cancelled before it completed.",
 				effort: input.effort,
@@ -189,7 +218,7 @@ export function buildClaudeCodeSdkOptions(input: {
 	return {
 		abortController: input.abortController,
 		cwd: input.cwd,
-		effort: input.effort,
+		effort: mapClaudeCodeEffort(input.effort),
 		env: sanitizedChildEnvironment(),
 		extraArgs: { "disable-slash-commands": null },
 		model: input.model,
@@ -224,7 +253,7 @@ async function runClaudeCodeQuery(input: {
 	signal?: AbortSignal;
 	deps?: ClaudeCodeConsultDeps;
 }): Promise<ClaudeCodeQueryResult> {
-	const executable = input.deps?.executable ?? CLAUDE_EXECUTABLE;
+	const executable = input.deps?.executable ?? (await resolveClaudeCodeExecutable());
 	const inspect = input.deps?.runtimeInspector ?? inspectClaudeCodeRuntime;
 	const runtime = await inspect(executable);
 	validateClaudeCodeRuntime(runtime);
@@ -234,19 +263,19 @@ async function runClaudeCodeQuery(input: {
 	input.signal?.addEventListener("abort", onAbort, { once: true });
 	if (input.signal?.aborted) abortController.abort();
 
-	const queryFactory = input.deps?.queryFactory ?? defaultClaudeCodeQueryFactory;
-	const query = await queryFactory({
-		prompt: formatClaudeCodePrompt(input.messages),
-		options: buildClaudeCodeSdkOptions({
-			model: input.model,
-			effort: input.effort,
-			cwd: input.cwd,
-			executable,
-			abortController,
-		}),
-	});
-
+	let query: ClaudeCodeQuery | undefined;
 	try {
+		const queryFactory = input.deps?.queryFactory ?? defaultClaudeCodeQueryFactory;
+		query = await queryFactory({
+			prompt: formatClaudeCodePrompt(input.messages),
+			options: buildClaudeCodeSdkOptions({
+				model: input.model,
+				effort: input.effort,
+				cwd: input.cwd,
+				executable,
+				abortController,
+			}),
+		});
 		for await (const message of query) {
 			if (message.type === "system" && message.subtype === "model_refusal_fallback") {
 				throw new Error(
@@ -261,7 +290,7 @@ async function runClaudeCodeQuery(input: {
 		throw new Error("Advisor SDK process exited unexpectedly");
 	} finally {
 		input.signal?.removeEventListener("abort", onAbort);
-		query.close();
+		query?.close();
 		abortController.abort();
 	}
 }
@@ -422,4 +451,13 @@ function buildClaudeCodeResult(opts: {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
+}
+
+async function isExecutable(path: string): Promise<boolean> {
+	try {
+		await access(path, fsConstants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/packages/rpiv-advisor/advisor/execute.ts
+++ b/packages/rpiv-advisor/advisor/execute.ts
@@ -15,6 +15,7 @@ import {
 	type ExtensionAPI,
 	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { consultClaudeCodeAdvisor, isClaudeCodeAdvisorKey } from "./claude-code.js";
 import { ensureUserTailForAdvisor, stripInflightAdvisorCall } from "./context.js";
 import { getInventoryMessage } from "./inventory.js";
 import {
@@ -100,13 +101,20 @@ export async function executeAdvisor(
 		return buildErrorResult(undefined, effort, ERR_NO_MODEL, ERR_NO_MODEL_SELECTED);
 	}
 	const advisorLabel = `${advisor.provider}:${advisor.id}`;
+	const claudeCode = isClaudeCodeAdvisorKey(advisor.provider, advisor.id);
 
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(advisor);
-	if (!auth.ok) {
-		return buildErrorResult(advisorLabel, effort, errMisconfigured(advisorLabel, auth.error), auth.error);
-	}
-	if (!auth.apiKey) {
-		return buildErrorResult(advisorLabel, effort, errNoApiKey(advisorLabel), errNoApiKeyDetail(advisor.provider));
+	let authApiKey: string | undefined;
+	let authHeaders: Record<string, string> | undefined;
+	if (!claudeCode) {
+		const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(advisor);
+		if (!resolved.ok) {
+			return buildErrorResult(advisorLabel, effort, errMisconfigured(advisorLabel, resolved.error), resolved.error);
+		}
+		if (!resolved.apiKey) {
+			return buildErrorResult(advisorLabel, effort, errNoApiKey(advisorLabel), errNoApiKeyDetail(advisor.provider));
+		}
+		authApiKey = resolved.apiKey;
+		authHeaders = resolved.headers;
 	}
 
 	// Live-read every call — advisor runs mid-turn so any message_end snapshot
@@ -129,6 +137,16 @@ export async function executeAdvisor(
 	});
 
 	try {
+		if (claudeCode) {
+			return await consultClaudeCodeAdvisor({
+				advisor,
+				effort,
+				messages,
+				cwd: ctx.cwd,
+				signal,
+			});
+		}
+
 		// Prefer Pi's auth-aware runtime facade. Unlike the global compatibility
 		// function, it runs request preparation and applies credential-derived
 		// fields such as GitHub Copilot's OAuth-specific baseUrl. Do not pass the
@@ -138,7 +156,7 @@ export async function executeAdvisor(
 		const completeSimple = runtimeCompleteSimple ?? (await loadCompleteSimple());
 		const requestOptions = runtimeCompleteSimple
 			? { signal, reasoning: effort }
-			: { apiKey: auth.apiKey, headers: auth.headers, signal, reasoning: effort };
+			: { apiKey: authApiKey, headers: authHeaders, signal, reasoning: effort };
 
 		// Single dispatch point — both attempts reuse the SAME `messages` and
 		// `requestOptions`, so the retry cannot diverge from attempt 1. `tools: []`

--- a/packages/rpiv-advisor/advisor/index.ts
+++ b/packages/rpiv-advisor/advisor/index.ts
@@ -17,12 +17,14 @@
  *   context    — branch-message massaging
  *   prompt     — system-prompt loader
  *   execute    — the advisor side-call
+ *   claude-code — optional Claude Code subscription backend
  *   register   — advisor tool registration
  *   handlers   — mid-session lifecycle handlers
  *   restore    — session_start restoration
  *   command    — /advisor slash command
  */
 
+export { CLAUDE_CODE_MODELS, CLAUDE_CODE_PROVIDER, isClaudeCodeAdvisorKey } from "./claude-code.js";
 export { registerAdvisorCommand } from "./command.js";
 export { loadAdvisorConfig, saveAdvisorConfig } from "./config.js";
 export { ensureUserTailForAdvisor, stripInflightAdvisorCall } from "./context.js";

--- a/packages/rpiv-advisor/advisor/restore.ts
+++ b/packages/rpiv-advisor/advisor/restore.ts
@@ -6,6 +6,7 @@
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { modelKey, parseModelKey } from "@juicesharp/rpiv-config";
+import { type ClaudeCodeModelId, claudeCodeAdvisorModel, isClaudeCodeAdvisorKey } from "./claude-code.js";
 import { loadAdvisorConfig, validateDisabledForModels } from "./config.js";
 import { reconcileAdvisorTool } from "./handlers.js";
 import {
@@ -72,7 +73,9 @@ export function restoreAdvisorState(ctx: ExtensionContext, pi: ExtensionAPI): vo
 		restoreAnnounced = true;
 	};
 
-	const model = ctx.modelRegistry.find(parsed.provider, parsed.modelId);
+	const model = isClaudeCodeAdvisorKey(parsed.provider, parsed.modelId)
+		? claudeCodeAdvisorModel(parsed.modelId as ClaudeCodeModelId)
+		: ctx.modelRegistry.find(parsed.provider, parsed.modelId);
 	if (!model) {
 		deactivate();
 		notifyOnce(errModelUnavailable(config.modelKey), "warning");

--- a/packages/rpiv-advisor/docs/configuration.md
+++ b/packages/rpiv-advisor/docs/configuration.md
@@ -58,9 +58,10 @@ form the next time you save through `/advisor`.
 
 `claude-code/claude-opus-5` and `claude-code/claude-fable-5` are the only
 keys that skip Pi's model registry. They are restored as a synthetic reviewer
-and billed through the local Claude Code CLI. They are not offered by `/advisor`;
+and billed through the local Claude Code CLI on PATH. They are not offered by `/advisor`;
 choosing a picker model overwrites them. Unknown ids under `claude-code/` still
-look up the registry and disable the tool when the lookup misses.
+look up the registry and disable the tool when the lookup misses. Pi `minimal`
+effort is sent as Agent SDK `low`.
 
 ### `effort`
 

--- a/packages/rpiv-advisor/docs/configuration.md
+++ b/packages/rpiv-advisor/docs/configuration.md
@@ -56,6 +56,12 @@ Reads also accept the legacy colon form (`anthropic:claude-opus-4-5`); when both
 forms are present the slash form wins. A colon-form key is rewritten to slash
 form the next time you save through `/advisor`.
 
+`claude-code/claude-opus-5` and `claude-code/claude-fable-5` are the only
+keys that skip Pi's model registry. They are restored as a synthetic reviewer
+and billed through the local Claude Code CLI. They are not offered by `/advisor`;
+choosing a picker model overwrites them. Unknown ids under `claude-code/` still
+look up the registry and disable the tool when the lookup misses.
+
 ### `effort`
 
 Offered only for models whose registry entry reports reasoning support. The

--- a/packages/rpiv-advisor/docs/tool-reference.md
+++ b/packages/rpiv-advisor/docs/tool-reference.md
@@ -86,6 +86,8 @@ set, meaning the executor model cannot see it and its `promptSnippet` /
 1. No advisor model is selected.
 2. `modelKey` is absent, unparseable, or names a model that is no longer in Pi's
    registry at restore time. The stale in-memory selection is cleared too.
+   `claude-code/claude-opus-5` and `claude-code/claude-fable-5` skip the registry
+   lookup and stay active.
 3. The current **executor** model matches a `disabledForModels` entry — see
    [configuration.md](./configuration.md#disabledformodels).
 
@@ -138,3 +140,9 @@ real failure surfaces instead of being masked.
 
 If neither entrypoint exposes it, the call throws
 `pi-ai does not expose completeSimple on /compat or the package root — unsupported host pi-ai version`.
+
+A hand-edited `claude-code/*` reviewer skips `completeSimple`. Each `advisor()`
+call starts a fresh `@anthropic-ai/claude-agent-sdk` query with `tools: []`,
+no persisted session, and credentials taken from the local `claude` CLI rather
+than Pi `AuthStorage`. The conversation branch is still assembled the same way
+as the registry path (inventory prefix, compacted context, tail massage).

--- a/packages/rpiv-advisor/docs/tool-reference.md
+++ b/packages/rpiv-advisor/docs/tool-reference.md
@@ -144,5 +144,6 @@ If neither entrypoint exposes it, the call throws
 A hand-edited `claude-code/*` reviewer skips `completeSimple`. Each `advisor()`
 call starts a fresh `@anthropic-ai/claude-agent-sdk` query with `tools: []`,
 no persisted session, and credentials taken from the local `claude` CLI rather
-than Pi `AuthStorage`. The conversation branch is still assembled the same way
+than Pi `AuthStorage`. The CLI is resolved from PATH. Pi `minimal` effort is
+sent as Agent SDK `low`. The conversation branch is still assembled the same way
 as the registry path (inventory prefix, compacted context, tail massage).

--- a/packages/rpiv-advisor/package.json
+++ b/packages/rpiv-advisor/package.json
@@ -49,8 +49,14 @@
 		"typebox": "^1.1.24"
 	},
 	"peerDependencies": {
+		"@anthropic-ai/claude-agent-sdk": "*",
 		"@earendil-works/pi-ai": "*",
 		"@earendil-works/pi-coding-agent": "*",
 		"@earendil-works/pi-tui": "*"
+	},
+	"peerDependenciesMeta": {
+		"@anthropic-ai/claude-agent-sdk": {
+			"optional": true
+		}
 	}
 }


### PR DESCRIPTION
Related: #167 (optional backend half).

## What

Optional Claude Code subscription backend for `advisor()`. A hand-edited `modelKey` of `claude-code/claude-opus-5` or `claude-code/claude-fable-5` skips Pi's model registry and AuthStorage and sends each `advisor()` call through a fresh Agent SDK query.

The `/advisor` picker and the existing `completeSimple` path are unchanged. Unknown ids under `claude-code/` still look up the registry and disable the tool when the lookup misses.

```json
{
  "modelKey": "claude-code/claude-opus-5",
  "effort": "high"
}
```

Requirements for that key only:

- logged-in `claude` CLI (`claude auth login --claudeai`, firstParty)
- optional peer `@anthropic-ai/claude-agent-sdk`

Each call is isolated (`tools: []`, no persisted session, no fallback). This is not the full `claude-code` Pi provider proposed in #115.

## Why

Pi's Anthropic path is API-key / extra-usage billed. A Claude Code login can review against the subscription instead, without making Claude a privileged picker entry.

## Test plan

- [x] `npx vitest run packages/rpiv-advisor` (214)
- [x] full repo coverage hook (4876)
- [ ] maintainer: hand-edit `claude-code/claude-opus-5`, confirm `advisor()` does not call `completeSimple` / AuthStorage
- [ ] maintainer: `/advisor` still only lists authenticated Pi models