### PR TITLE
fix(ask-user-question): use matchesKey for Space and n key to support Kitty keyboard protocol

### DIFF
--- a/packages/rpiv-ask-user-question/state/key-router.ts
+++ b/packages/rpiv-ask-user-question/state/key-router.ts
@@ -15,7 +15,6 @@ const KEYBIND_CLEAR = "tui.editor.deleteToLineStart";
 const KEYBIND_EXTERNAL_EDITOR = "app.editor.external";
 
 const NOTES_ACTIVATE_KEY = "n";
-const SPACE_KEY = " ";
 
 export type QuestionnaireAction =
 	| { kind: "nav"; nextIndex: number; inputValue: string }
@@ -254,7 +253,7 @@ export function routeKey(data: string, state: QuestionnaireState, runtime: Quest
 	// "Type something.") is irrelevant: the gate sits ABOVE the multi-select
 	// toggle block and the Next sentinel never activates inputMode, so `n` is
 	// neither swallowed earlier nor blocked by `blocksMultiToggle`.
-	if (data === NOTES_ACTIVATE_KEY) {
+	if (matchesKey(data, NOTES_ACTIVATE_KEY)) {
 		return { kind: "notes_enter" };
 	}
 
@@ -271,7 +270,7 @@ export function routeKey(data: string, state: QuestionnaireState, runtime: Quest
 		// Space toggles the focused row's checkbox. Suppressed on rows whose META declares
 		// `blocksMultiToggle` (the Next sentinel) or `activatesInputMode` (the "Type
 		// something." row — it is an inline input, not a checkable option).
-		if (data === SPACE_KEY) {
+		if (matchesKey(data, Key.space)) {
 			if (focusedMeta?.blocksMultiToggle) return { kind: "ignore" };
 			if (focusedMeta?.activatesInputMode) return { kind: "ignore" };
 			return { kind: "toggle", index: state.optionIndex };


### PR DESCRIPTION
## Summary

Fixes #171

Under Kitty keyboard protocol, terminals send CSI-u sequences instead of raw characters. The hardcoded `data === " "` and `data === "n"` comparisons fail in these terminals, making Space toggle and notes entry (`n` key) non-functional in the multi-select questionnaire.

## Changes

In `packages/rpiv-ask-user-question/state/key-router.ts`:

- `data === " "` → `matchesKey(data, Key.space)` — fixes Space toggle under Kitty protocol
- `data === "n"` → `matchesKey(data, "n")` — fixes notes entry under Kitty protocol
- Remove unused `const SPACE_KEY = " ";`

`matchesKey()` and `Key` are already imported and used throughout the file for other keys (Tab, arrow keys, etc.) — this just brings Space and n key in line with the existing pattern.

## Tested on

- Ghostty terminal with Kitty keyboard protocol enabled