### PR TITLE
fix(rpiv-todo): follow Pi tool expansion mode

### DIFF
--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The todo overlay now follows Pi's tool-output expansion mode: expanding shows every task instead of retaining the `+N more` summary, while collapsing reapplies `maxWidgetLines`.
+
 ## [2.6.1] - 2026-08-17
 
 ### Added

--- a/packages/rpiv-todo/README.md
+++ b/packages/rpiv-todo/README.md
@@ -80,7 +80,7 @@ Optional. Create `~/.config/rpiv-todo/config.json` (or
 
 | Setting | What it does | Default |
 | --- | --- | --- |
-| `maxWidgetLines` | Content rows the overlay may use, heading included. Minimum `3`. Applies on the next repaint. | `12` |
+| `maxWidgetLines` | Content rows the overlay may use, heading included. Minimum `3`. Applies on the next repaint. Pi's tool-output expansion mode shows all tasks. | `12` |
 | `collapseKey` | Key that collapses and expands the panel, in Pi keybinding form (`alt+o`, `ctrl+shift+t`). Set `"off"` to register no shortcut. Needs `/reload` to rebind. | `"ctrl+shift+t"` |
 | `guidance` | Replaces the built-in instructions the extension gives the model about when and how to use the todo list. Needs `/reload`. | _(built-ins)_ |
 

--- a/packages/rpiv-todo/docs/configuration.md
+++ b/packages/rpiv-todo/docs/configuration.md
@@ -54,6 +54,8 @@ blank spacer sits outside the budget, so `12` renders up to 13 terminal rows.
 - No ceiling.
 - Read fresh on every render, so a change takes effect on the next repaint —
   no `/reload`.
+- Pi's tool-output expansion mode (`ctrl+o` by default) temporarily overrides
+  this budget and shows every task; collapsing restores the configured budget.
 
 ## `collapseKey`
 

--- a/packages/rpiv-todo/docs/overlay.md
+++ b/packages/rpiv-todo/docs/overlay.md
@@ -61,9 +61,11 @@ against it. When there are more tasks than fit:
    truncated;
 4. the last row becomes `+N more (X completed, Y pending)`.
 
-Unfinished work is therefore the last thing to disappear. See
-[configuration.md](./configuration.md#maxwidgetlines) for the budget's floor and
-reload semantics.
+Use Pi's tool-output expansion shortcut (`ctrl+o` by default) to expand the
+widget and show every task. Collapsing Pi's tool output reapplies the configured
+row budget. Unfinished work is therefore the last thing to disappear in the
+compact view. See [configuration.md](./configuration.md#maxwidgetlines) for the
+budget's floor and reload semantics.
 
 ## Completed tasks fading out
 

--- a/packages/rpiv-todo/todo-overlay.render.test.ts
+++ b/packages/rpiv-todo/todo-overlay.render.test.ts
@@ -23,7 +23,10 @@ const identityTheme = {
 	strikethrough: (s: string) => s,
 };
 
-async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }>) {
+async function setup(
+	actions: Array<{ action: TaskAction; [k: string]: unknown }>,
+	uiOverrides: Partial<Omit<ExtensionUIContext, "theme">> = {},
+) {
 	__resetState();
 	setActiveRenderSession("test-session");
 	const { pi, captured } = createMockPi();
@@ -33,7 +36,7 @@ async function setup(actions: Array<{ action: TaskAction; [k: string]: unknown }
 	for (const p of actions) {
 		await tool.execute?.("tc", p as never, undefined as never, undefined as never, ctx as never);
 	}
-	const ui = createMockUI() as unknown as ExtensionUIContext;
+	const ui = createMockUI(uiOverrides) as unknown as ExtensionUIContext;
 	const overlay = new TodoOverlay();
 	overlay.setUICtx(ui);
 	overlay.update();
@@ -247,6 +250,34 @@ describe("TodoOverlay — overflow collapse", () => {
 		expect(lines[lines.length - 1]).toBe("");
 		expect(lines[lines.length - 2]).not.toContain("+");
 		expect(lines[lines.length - 2]).toContain("└─");
+	});
+
+	it("follows Pi's tool-output expansion mode and renders every task", async () => {
+		let toolsExpanded = false;
+		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
+		for (let i = 1; i <= 17; i++) actions.push({ action: "create", subject: `t${i}` });
+		const { widget } = await setup(actions, { getToolsExpanded: () => toolsExpanded });
+
+		const collapsed = widget.render(200).join("\n");
+		expect(collapsed).toContain("+7 more");
+		expect(collapsed).not.toContain("t17");
+
+		toolsExpanded = true;
+		const expanded = widget.render(200);
+		expect(expanded).toHaveLength(19); // heading + 17 tasks + trailing spacer
+		expect(expanded.join("\n")).toContain("t17");
+		expect(expanded.join("\n")).not.toContain(" more");
+		expect(expanded[expanded.length - 2]).toContain("└─");
+
+		toolsExpanded = false;
+		expect(widget.render(200).join("\n")).toContain("+7 more");
+	});
+
+	it("keeps the configured budget when the host has no expansion-state API", async () => {
+		const actions: Array<{ action: TaskAction; [k: string]: unknown }> = [];
+		for (let i = 1; i <= 17; i++) actions.push({ action: "create", subject: `t${i}` });
+		const { widget } = await setup(actions);
+		expect(widget.render(200).join("\n")).toContain("+7 more");
 	});
 });
 

--- a/packages/rpiv-todo/todo-overlay.ts
+++ b/packages/rpiv-todo/todo-overlay.ts
@@ -5,7 +5,7 @@
  * registration in widgetContainerAbove, register-once + requestRender()
  * refresh, configurable collapse-not-scroll (default 12 content rows via
  * getMaxWidgetLines(); plus a trailing spacer row so the widget renders up
- * to 13 lines), auto-hide when empty.
+ * to 13 lines), Pi tool-output expansion awareness, auto-hide when empty.
  *
  * Reads live state via `getRenderState()` (the ctx-less foreground slot) at render
  * time — NEVER `replayFromBranch` from `tool_execution_end` (branch is stale;
@@ -172,7 +172,11 @@ export class TodoOverlay {
 		const lines: string[] = [heading];
 		// Budget for content rows (heading + tasks/summary). The rendered widget is
 		// one line taller — withTrailingSpacer() appends a blank row below the panel.
-		const layout = selectOverlayLayout(overlayState, getMaxWidgetLines() - 1);
+		// Pi's global tool-output expansion mode is read on every render so its
+		// expand/collapse shortcut also expands this live widget. Optional chaining
+		// preserves compatibility with hosts predating getToolsExpanded().
+		const bodyBudget = this.uiCtx?.getToolsExpanded?.() === true ? overlayTasks.length : getMaxWidgetLines() - 1;
+		const layout = selectOverlayLayout(overlayState, bodyBudget);
 		for (const task of layout.visible) {
 			lines.push(truncate(`${theme.fg("dim", "├─")} ${formatOverlayTaskLine(task, theme, showIds)}`));
 		}


### PR DESCRIPTION
## Summary

- make the rpiv-todo overlay follow Pi's global tool-output expansion state
- show all tasks while expanded and restore `maxWidgetLines` when collapsed
- preserve compatibility with hosts without `getToolsExpanded()`
- add regression coverage and update package documentation

## Verification

- `npm run check:decision-codes`
- `npm run check`
- `npx vitest run packages/rpiv-todo`

Closes: N/A