### PR TITLE
feat(rpiv-advisor): bound reviewer context

### DIFF
--- a/packages/rpiv-advisor/CHANGELOG.md
+++ b/packages/rpiv-advisor/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Bound advisor requests to the selected reviewer's context window, preserving compaction and prune summaries while capping large tool results and repairing tool-call/result pairing.
+- Added optional `contextBudget` settings with safe defaults for older configuration files.
+
 ## [2.6.4] - 2026-08-20
 
 ## [2.6.3] - 2026-08-20

--- a/packages/rpiv-advisor/README.md
+++ b/packages/rpiv-advisor/README.md
@@ -50,13 +50,14 @@ judgment. To turn it back off, run `/advisor` and choose **No advisor**.
   resumes. Nothing is injected into your transcript, and the default prompt
   guidelines tell the executor to restate the advisor's key guidance in its
   next visible reply, so you are not left with only a collapsed tool card.
-- **Nothing to type or paste** — the tool takes zero parameters. The whole
-  conversation branch is serialised and forwarded automatically: the task, every
-  tool call made, every result seen. That whole branch is billed against the
-  reviewer model on every call, so escalations are not free.
+- **Nothing to type or paste** — the tool takes zero parameters. It reads the
+  conversation branch automatically, then fits it to the reviewer model's context
+  budget. The retained task, tool calls, and results are billed against the reviewer
+  model on every call, so escalations are not free.
 - **The reviewer sees what survived compaction** — the branch is built from Pi's
   resolved LLM context, so compaction and branch summaries are forwarded instead
   of a stale raw replay.
+- **Long branches are bounded before review** — advisor context reserves space for the reviewer's response, caps large tool results, removes tool results covered by `pi-context-prune` summaries, and repairs tool-call/result pairing after trimming. Compaction and prune summaries remain verbatim.
 - **Any model can be the reviewer** — every model you're authenticated for is in
   the `/advisor` picker, found by fuzzy-typing. No provider is privileged.
 - **Pick once, it stays picked** — model and effort persist to `advisor.json`
@@ -80,6 +81,7 @@ write leaves your previous selection untouched and tells you so.
 | `modelKey` | The reviewer model, as `"provider/modelId"`. Written by `/advisor`. | absent — advisor off |
 | `effort` | Reasoning effort for the reviewer: `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Written by `/advisor`; only levels supported by the selected model are offered. | absent — no reasoning sent |
 | `disabledForModels` | Executor models the advisor is stripped for. Plain strings block at any effort; `{ "model": "…", "minEffort": "…" }` blocks only at or above that effort. | `[]` |
+| `contextBudget` | Optional bounded-context settings: `enabled`, `responseReserveTokens`, `keepFirst`, `keepLast`, and `toolResultMaxChars`. | enabled with safe defaults |
 
 ```json
 {

--- a/packages/rpiv-advisor/advisor.budget.test.ts
+++ b/packages/rpiv-advisor/advisor.budget.test.ts
@@ -1,0 +1,127 @@
+import { makeAssistantMessage, makeToolResult, makeUserMessage } from "@juicesharp/rpiv-test-utils";
+import { describe, expect, it } from "vitest";
+import {
+	applyContextBudget,
+	deriveAdvisorBudget,
+	dropPruneCoveredToolResults,
+	estimateTokens,
+	repairToolPairing,
+} from "./advisor/budget.js";
+import { ensureUserTailForAdvisor, getPruneCoveredToolCallIds } from "./advisor/context.js";
+
+const BUDGET = {
+	keepFirst: 4,
+	keepLast: 6,
+	toolResultMaxChars: 256,
+};
+
+describe("advisor context budget", () => {
+	it("uses a conservative token estimate and reserves output plus margin", () => {
+		expect(estimateTokens("a".repeat(300))).toBe(115);
+		expect(deriveAdvisorBudget(128_000, 4_096)).toBe(128_000 - 4_096 - 12_800);
+		expect(deriveAdvisorBudget(undefined, 4_096)).toBe(32_000 - 4_096 - 3_200);
+	});
+
+	it("preserves the complete prepared branch when it already fits", () => {
+		const messages = Array.from({ length: 12 }, (_, index) => makeUserMessage(`turn ${index}`));
+		const result = applyContextBudget(messages, { ...BUDGET, maxInputTokens: 10_000 });
+		expect(result.messages).toHaveLength(messages.length);
+		expect(result.dropped).toBe(0);
+	});
+
+	it("fits a 500k-character transcript within the requested budget", () => {
+		const messages = Array.from({ length: 100 }, (_, index) => makeUserMessage(`turn ${index} ${"x".repeat(5_000)}`));
+		const result = applyContextBudget(messages, { ...BUDGET, maxInputTokens: 2_000 });
+		expect(result.estimatedTokens).toBeLessThanOrEqual(2_000);
+		expect(result.dropped).toBeGreaterThan(0);
+	});
+
+	it("caps tool-result text before fitting", () => {
+		const result = applyContextBudget(
+			[
+				makeAssistantMessage({ toolCalls: [{ id: "call-1", name: "bash", arguments: {} }] }),
+				makeToolResult({ toolName: "bash", toolCallId: "call-1", text: "x".repeat(5_000) }),
+			],
+			{ ...BUDGET, maxInputTokens: 10_000 },
+		);
+		const toolResult = result.messages.find((message) => message.role === "toolResult");
+		const text =
+			toolResult?.role === "toolResult"
+				? (toolResult.content.find((block) => block.type === "text")?.text ?? "")
+				: "";
+		expect(text).toContain("advisor context truncated");
+		expect(text.length).toBeLessThan(300);
+	});
+
+	it("repairs orphan results and dangling tool calls", () => {
+		const assistant = makeAssistantMessage({
+			text: "attempted the command",
+			toolCalls: [{ id: "call-1", name: "bash", arguments: {} }],
+		});
+		const result = makeToolResult({ toolName: "bash", toolCallId: "call-1", text: "output" });
+		const danglingCall = repairToolPairing([assistant]);
+		const orphanResult = repairToolPairing([result]);
+		expect(danglingCall[0]?.role).toBe("assistant");
+		expect(
+			danglingCall[0]?.role === "assistant"
+				? danglingCall[0].content.some((block) => block.type === "toolCall")
+				: false,
+		).toBe(false);
+		expect(orphanResult).toEqual([]);
+		const paired = repairToolPairing([assistant, result]);
+		expect(paired).toHaveLength(2);
+	});
+
+	it("is idempotent", () => {
+		const messages = [
+			makeAssistantMessage({ toolCalls: [{ id: "call-1", name: "bash", arguments: {} }] }),
+			makeToolResult({ toolName: "bash", toolCallId: "call-1", text: "output" }),
+		];
+		const once = repairToolPairing(messages);
+		expect(repairToolPairing(once)).toEqual(once);
+	});
+
+	it("keeps compaction, branch, and prune summaries verbatim", () => {
+		const compaction = makeUserMessage(
+			"The conversation history before this point was compacted into the following summary:\n<summary>keep compaction</summary>",
+		);
+		const branch = makeUserMessage(
+			"The following is a summary of a branch that this conversation came back from:\n<summary>keep branch</summary>",
+		);
+		const prune = makeUserMessage("<context-prune-summary>\nkeep prune\n</context-prune-summary>");
+		const messages = [
+			compaction,
+			...Array.from({ length: 20 }, (_, index) => makeUserMessage(`old ${index} ${"x".repeat(2_000)}`)),
+			branch,
+			prune,
+		];
+		const result = applyContextBudget(messages, { ...BUDGET, maxInputTokens: 1_500 });
+		const serialized = JSON.stringify(result.messages);
+		expect(serialized).toContain("keep compaction");
+		expect(serialized).toContain("keep branch");
+		expect(serialized).toContain("keep prune");
+	});
+
+	it("drops prune-covered results while retaining the summary message", () => {
+		const result = makeToolResult({ toolName: "bash", toolCallId: "call-1", text: "raw output" });
+		const summary = makeUserMessage("<context-prune-summary>summary</context-prune-summary>");
+		const messages = dropPruneCoveredToolResults([summary, result], new Set(["call-1"]));
+		expect(messages).toEqual([summary]);
+	});
+
+	it("ensures the final message has a user role", () => {
+		const result = ensureUserTailForAdvisor([makeUserMessage("question"), makeAssistantMessage({ text: "answer" })]);
+		expect(result.at(-1)?.role).toBe("user");
+	});
+
+	it("reads pi-context-prune tool references from persisted summary metadata", () => {
+		const ids = getPruneCoveredToolCallIds([
+			{
+				type: "custom_message",
+				customType: "context-prune-summary",
+				details: { toolCallRefs: [{ shortId: "t1", toolCallId: "call-1" }], toolCallIds: ["call-2"] },
+			},
+		]);
+		expect([...ids]).toEqual(["call-1", "call-2"]);
+	});
+});

--- a/packages/rpiv-advisor/advisor.config.test.ts
+++ b/packages/rpiv-advisor/advisor.config.test.ts
@@ -1,7 +1,7 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
-import { validateDisabledForModels } from "./advisor/config.js";
+import { resolveAdvisorContextBudget, validateDisabledForModels } from "./advisor/config.js";
 import { loadAdvisorConfig, saveAdvisorConfig } from "./advisor/index.js";
 
 const CONFIG_PATH = join(process.env.HOME!, ".config", "rpiv-advisor", "advisor.json");
@@ -123,5 +123,35 @@ describe("validateDisabledForModels", () => {
 				"openai:gpt",
 			]),
 		).toEqual(["anthropic:opus", { model: "anthropic:sonnet", minEffort: "high" }, "openai:gpt"]);
+	});
+});
+
+describe("resolveAdvisorContextBudget", () => {
+	it("enables bounded context by default for an old config", () => {
+		expect(resolveAdvisorContextBudget(undefined)).toEqual({
+			enabled: true,
+			responseReserveTokens: 16_384,
+			keepFirst: 4,
+			keepLast: 24,
+			toolResultMaxChars: 12_000,
+		});
+	});
+
+	it("clamps invalid numeric values while preserving an explicit disable", () => {
+		expect(
+			resolveAdvisorContextBudget({
+				enabled: false,
+				responseReserveTokens: 1,
+				keepFirst: -1,
+				keepLast: 0,
+				toolResultMaxChars: 1,
+			}),
+		).toEqual({
+			enabled: false,
+			responseReserveTokens: 1_024,
+			keepFirst: 0,
+			keepLast: 1,
+			toolResultMaxChars: 256,
+		});
 	});
 });

--- a/packages/rpiv-advisor/advisor.execute.test.ts
+++ b/packages/rpiv-advisor/advisor.execute.test.ts
@@ -1,8 +1,10 @@
+import type { Message } from "@earendil-works/pi-ai";
 import {
 	buildSessionEntries,
 	createMockCtx,
 	createMockPi,
 	makeAssistantMessage,
+	makeToolResult,
 	makeUserMessage,
 } from "@juicesharp/rpiv-test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -151,6 +153,82 @@ describe("executeAdvisor — 4 StopReason branches", () => {
 		expect(serialized).toContain("post-compaction assistant");
 		expect(serialized).not.toContain("OLD RAW PRE-COMPACTION DETAIL");
 		expect(serialized).not.toContain("old raw assistant detail");
+	});
+
+	it("removes prune-covered raw results, preserves the summary, and repairs the tail", async () => {
+		setAdvisorModel({ provider: "a", id: "m", contextWindow: 32_000, maxTokens: 4_096 } as never);
+		vi.mocked(completeSimple).mockResolvedValueOnce(resp({ text: "advice" }) as never);
+		const prunedAssistant = makeAssistantMessage({
+			text: "ran the command",
+			toolCalls: [{ id: "call-pruned", name: "bash", arguments: {} }],
+		});
+		const prunedResult = makeToolResult({
+			toolName: "bash",
+			toolCallId: "call-pruned",
+			text: "RAW TOOL OUTPUT THAT MUST NOT BE FORWARDED",
+		});
+		const pruneSummaryEntry = {
+			type: "custom_message",
+			customType: "context-prune-summary",
+			content: "<context-prune-summary>summary of the raw output</context-prune-summary>",
+			details: { toolCallRefs: [{ shortId: "t1", toolCallId: "call-pruned" }] },
+		} as never;
+		vi.mocked(buildSessionContext).mockReturnValueOnce({
+			messages: [
+				makeUserMessage("task"),
+				prunedAssistant,
+				prunedResult,
+				makeUserMessage("<context-prune-summary>summary of the raw output</context-prune-summary>"),
+				makeAssistantMessage({
+					text: "current work",
+					toolCalls: [{ id: "advisor-inflight", name: "advisor", arguments: {} }],
+				}),
+			],
+			thinkingLevel: "off",
+			model: null,
+		} as ReturnType<typeof buildSessionContext>);
+		const { pi, captured } = createMockPi();
+		const ctx = createMockCtx({
+			branch: [...buildSessionEntries([makeUserMessage("task"), prunedAssistant, prunedResult]), pruneSummaryEntry],
+		});
+		registerAdvisorTool(pi);
+		const result = await captured.tools
+			.get("advisor")
+			?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+
+		const payload = vi.mocked(completeSimple).mock.calls[0]?.[1] as { messages?: Message[] };
+		const serialized = JSON.stringify(payload.messages);
+		expect(serialized).toContain("summary of the raw output");
+		expect(serialized).not.toContain("RAW TOOL OUTPUT THAT MUST NOT BE FORWARDED");
+		expect(serialized).not.toContain("call-pruned");
+		expect(serialized).not.toContain("advisor-inflight");
+		expect(payload.messages?.at(-1)?.role).toBe("user");
+		expect(result?.details).toMatchObject({ context: { enabled: true, pruneCoveredToolResults: 1 } });
+	});
+
+	it("prepends the tool inventory before the fitted branch", async () => {
+		setAdvisorModel({ provider: "a", id: "m", contextWindow: 32_000, maxTokens: 4_096 } as never);
+		vi.mocked(completeSimple).mockResolvedValueOnce(resp({ text: "advice" }) as never);
+		const { pi, captured } = createMockPi({
+			getAllTools: vi.fn(
+				() =>
+					[
+						{
+							name: "bash",
+							description: "run commands",
+							parameters: { type: "object" },
+							sourceInfo: { path: "/mock/bash" },
+						},
+					] as never,
+			),
+		});
+		registerAdvisorTool(pi);
+		const ctx = createMockCtx({ branch: buildSessionEntries([makeUserMessage("task")]) });
+		await captured.tools.get("advisor")?.execute?.("tc", {}, undefined as never, undefined as never, ctx);
+
+		const payload = vi.mocked(completeSimple).mock.calls[0]?.[1] as { messages?: Message[] };
+		expect(payload.messages?.[0]?.role).toBe("user");
+		expect(JSON.stringify(payload.messages?.[0])).toContain("Available Executor Tools");
 	});
 
 	it("aborted stopReason returns cancel envelope", async () => {

--- a/packages/rpiv-advisor/advisor/budget.ts
+++ b/packages/rpiv-advisor/advisor/budget.ts
@@ -1,0 +1,280 @@
+import type { Message, ToolResultMessage } from "@earendil-works/pi-ai";
+
+const CHARS_PER_TOKEN = 3;
+const TOKEN_SAFETY_FACTOR = 1.15;
+const DEFAULT_CONTEXT_WINDOW = 32_000;
+const MIN_INPUT_TOKENS = 1_024;
+const TRUNCATION_MARKER = "\n[advisor context truncated]";
+const OMITTED_MARKER = "[earlier advisor context omitted to fit the reviewer's context window]";
+
+export interface AdvisorContextBudgetOptions {
+	maxInputTokens: number;
+	keepFirst: number;
+	keepLast: number;
+	toolResultMaxChars: number;
+}
+
+export interface AdvisorContextBudgetResult {
+	messages: Message[];
+	dropped: number;
+	estimatedTokens: number;
+}
+
+/** Conservative, provider-independent token estimate for context budgeting. */
+// This deliberately errs higher than Pi's general chars/4 helper: advisor payloads are
+// dense with tool arguments, code, and serialized metadata, where under-counting can
+// recreate the context-window failure this budget is meant to prevent.
+export function estimateTokens(text: string): number {
+	if (!text) return 0;
+	return Math.ceil((text.length / CHARS_PER_TOKEN) * TOKEN_SAFETY_FACTOR);
+}
+
+/** Estimate the serialized size of one message. */
+export function estimateMessageTokens(message: Message): number {
+	return estimateTokens(JSON.stringify(message));
+}
+
+/**
+ * Derive the input budget from the reviewer's context window.
+ *
+ * Ten percent remains unused as a tokenizer/serialization safety margin. The
+ * reserve is capped at half the window so a small configured reserve cannot
+ * produce a negative budget.
+ */
+export function deriveAdvisorBudget(contextWindow: number | undefined, reserveTokens: number): number {
+	const window =
+		Number.isFinite(contextWindow) && (contextWindow ?? 0) > 0 ? Math.floor(contextWindow!) : DEFAULT_CONTEXT_WINDOW;
+	const reserve = Math.min(
+		Number.isFinite(reserveTokens) ? Math.max(0, Math.floor(reserveTokens)) : 0,
+		Math.floor(window / 2),
+	);
+	const margin = Math.floor(window * 0.1);
+	return Math.max(MIN_INPUT_TOKENS, window - reserve - margin);
+}
+
+/**
+ * Remove summarized tool results without mutating the session messages.
+ *
+ * pi-context-prune keeps the persisted summary and marks covered tool-call IDs
+ * in custom-message details. The caller supplies those IDs because the summary
+ * metadata is intentionally not part of LLM Message.
+ */
+export function dropPruneCoveredToolResults(
+	messages: Message[],
+	summarizedToolCallIds: ReadonlySet<string>,
+): Message[] {
+	if (summarizedToolCallIds.size === 0) return messages;
+	return messages.filter((message) => message.role !== "toolResult" || !summarizedToolCallIds.has(message.toolCallId));
+}
+
+/**
+ * Repair tool-call/result pairing after context filtering or truncation.
+ *
+ * Providers reject both orphan results and dangling tool calls. The operation is
+ * non-mutating and idempotent.
+ */
+export function repairToolPairing(messages: Message[]): Message[] {
+	const presentCallIds = new Set<string>();
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		for (const block of message.content) {
+			if (block.type === "toolCall" && typeof block.id === "string") presentCallIds.add(block.id);
+		}
+	}
+
+	const resolvedCallIds = new Set<string>();
+	for (const message of messages) {
+		if (message.role === "toolResult" && presentCallIds.has(message.toolCallId)) {
+			resolvedCallIds.add(message.toolCallId);
+		}
+	}
+
+	const repaired: Message[] = [];
+	for (const message of messages) {
+		if (message.role === "toolResult") {
+			if (presentCallIds.has(message.toolCallId)) repaired.push(message);
+			continue;
+		}
+
+		if (message.role === "assistant") {
+			const content = message.content.filter(
+				(block) => block.type !== "toolCall" || !block.id || resolvedCallIds.has(block.id),
+			);
+			if (content.length === 0) continue;
+			if (content.length !== message.content.length) repaired.push({ ...message, content });
+			else repaired.push(message);
+			continue;
+		}
+
+		repaired.push(message);
+	}
+	return repaired;
+}
+
+function textContent(message: Message): string {
+	if (message.role === "user") {
+		if (typeof message.content === "string") return message.content;
+		return message.content
+			.filter((block) => block.type === "text")
+			.map((block) => block.text)
+			.join("\n");
+	}
+	if (message.role === "toolResult") {
+		return message.content
+			.filter((block) => block.type === "text")
+			.map((block) => block.text)
+			.join("\n");
+	}
+	return "";
+}
+
+function isProtectedSummary(message: Message): boolean {
+	if (message.role !== "user") return false;
+	const text = textContent(message).trim();
+	return (
+		text.startsWith("The conversation history before this point was compacted into the following summary:") ||
+		text.startsWith("The following is a summary of a branch that this conversation came back from:") ||
+		text.startsWith("<context-prune-summary>")
+	);
+}
+
+function capToolResult(message: ToolResultMessage, maxChars: number): ToolResultMessage {
+	const limit = Math.max(1, Math.floor(maxChars));
+	let remaining = limit;
+	let truncated = false;
+	const content = [] as ToolResultMessage["content"];
+
+	for (const block of message.content) {
+		if (block.type !== "text") {
+			content.push(block);
+			continue;
+		}
+		if (remaining <= 0) {
+			truncated = true;
+			continue;
+		}
+		if (block.text.length <= remaining) {
+			content.push(block);
+			remaining -= block.text.length;
+			continue;
+		}
+
+		const keepChars = Math.max(0, remaining - TRUNCATION_MARKER.length);
+		content.push({ ...block, text: `${block.text.slice(0, keepChars).trimEnd()}${TRUNCATION_MARKER}` });
+		remaining = 0;
+		truncated = true;
+	}
+
+	if (content.length === 0) {
+		content.push({ type: "text", text: truncated ? TRUNCATION_MARKER.trim() : "[empty tool result]" });
+	}
+	return { ...message, content };
+}
+
+function prepareMessages(messages: Message[], toolResultMaxChars: number): Message[] {
+	const cloned = structuredClone(messages);
+	return cloned.map((message) =>
+		message.role === "toolResult" ? capToolResult(message, toolResultMaxChars) : message,
+	);
+}
+
+function omittedMarker(): Message {
+	return {
+		role: "user",
+		content: OMITTED_MARKER,
+		timestamp: Date.now(),
+	};
+}
+
+function selectedMessages(
+	source: Message[],
+	selected: ReadonlySet<number>,
+	omitted: number,
+	includeMarker: boolean,
+): Message[] {
+	const chronological = [...selected]
+		.sort((a, b) => a - b)
+		.map((index) => source[index])
+		.filter((message): message is Message => message !== undefined);
+	const repaired = repairToolPairing(chronological);
+	return includeMarker && omitted > 0 ? [omittedMarker(), ...repaired] : repaired;
+}
+
+function findRemovableIndex(
+	selected: ReadonlySet<number>,
+	protectedIndexes: ReadonlySet<number>,
+	length: number,
+	keepFirst: number,
+	keepLast: number,
+): number | undefined {
+	const headEnd = Math.min(length, Math.max(0, keepFirst));
+	const tailStart = Math.max(0, length - Math.max(0, keepLast));
+	const candidates = [...selected].filter((index) => !protectedIndexes.has(index));
+	const middle = candidates.filter((index) => index >= headEnd && index < tailStart).sort((a, b) => a - b);
+	const tail = candidates.filter((index) => index >= tailStart).sort((a, b) => a - b);
+	const head = candidates.filter((index) => index < headEnd).sort((a, b) => b - a);
+	return [...middle, ...tail, ...head][0];
+}
+
+/**
+ * Fit a branch to a conservative token budget while preserving summary messages.
+ *
+ * The function copies before capping, drops oldest non-summary context first, and
+ * repairs tool pairing after every candidate rebuild. It never changes session
+ * entries and is deterministic apart from timestamps on omission markers.
+ */
+export function applyContextBudget(messages: Message[], opts: AdvisorContextBudgetOptions): AdvisorContextBudgetResult {
+	if (messages.length === 0) return { messages: [], dropped: 0, estimatedTokens: 0 };
+
+	const prepared = prepareMessages(messages, opts.toolResultMaxChars);
+	const maxInputTokens = Math.max(0, Math.floor(opts.maxInputTokens));
+	const preparedEstimate = estimateMessages(prepared);
+	if (preparedEstimate <= maxInputTokens) {
+		const repaired = repairToolPairing(prepared);
+		return {
+			messages: repaired,
+			dropped: Math.max(0, prepared.length - repaired.length),
+			estimatedTokens: estimateMessages(repaired),
+		};
+	}
+	const protectedIndexes = new Set<number>();
+	for (let index = 0; index < prepared.length; index++) {
+		if (isProtectedSummary(prepared[index])) protectedIndexes.add(index);
+	}
+
+	const selected = new Set<number>(protectedIndexes);
+	const keepFirst = Math.max(0, Math.floor(opts.keepFirst));
+	const keepLast = Math.max(0, Math.floor(opts.keepLast));
+	for (let index = 0; index < Math.min(keepFirst, prepared.length); index++) selected.add(index);
+	for (let index = Math.max(0, prepared.length - keepLast); index < prepared.length; index++) selected.add(index);
+
+	let dropped = prepared.length - selected.size;
+	let includeMarker = dropped > 0;
+	let candidate = selectedMessages(prepared, selected, dropped, includeMarker);
+
+	while (estimateMessages(candidate) > maxInputTokens) {
+		if (includeMarker) {
+			includeMarker = false;
+			candidate = selectedMessages(prepared, selected, dropped, false);
+			continue;
+		}
+
+		const removable = findRemovableIndex(selected, protectedIndexes, prepared.length, keepFirst, keepLast);
+		if (removable === undefined) break;
+		selected.delete(removable);
+		dropped++;
+		includeMarker = true;
+		candidate = selectedMessages(prepared, selected, dropped, includeMarker);
+	}
+
+	const repaired = repairToolPairing(candidate);
+	return {
+		messages: repaired,
+		dropped: Math.max(dropped, prepared.length - repaired.length),
+		estimatedTokens: estimateMessages(repaired),
+	};
+}
+
+function estimateMessages(messages: Message[]): number {
+	return messages.reduce((total, message) => total + estimateMessageTokens(message), 0);
+}

--- a/packages/rpiv-advisor/advisor/config.ts
+++ b/packages/rpiv-advisor/advisor/config.ts
@@ -13,15 +13,71 @@ const ADVISOR_CONFIG_PATH = configPath("rpiv-advisor", "advisor.json");
 
 export type DisabledForModelsEntry = string | { model: string; minEffort?: GradedEffort };
 
+export interface AdvisorContextBudgetConfig {
+	enabled?: boolean;
+	responseReserveTokens?: number;
+	keepFirst?: number;
+	keepLast?: number;
+	toolResultMaxChars?: number;
+}
+
+export interface AdvisorContextBudget {
+	enabled: boolean;
+	responseReserveTokens: number;
+	keepFirst: number;
+	keepLast: number;
+	toolResultMaxChars: number;
+}
+
 interface AdvisorConfig {
 	modelKey?: string;
 	effort?: GradedEffort;
 	guidance?: GuidanceFields;
 	disabledForModels?: DisabledForModelsEntry[];
+	contextBudget?: AdvisorContextBudgetConfig;
 }
+
+const DEFAULT_CONTEXT_BUDGET: AdvisorContextBudget = {
+	enabled: true,
+	responseReserveTokens: 16_384,
+	keepFirst: 4,
+	keepLast: 24,
+	toolResultMaxChars: 12_000,
+};
 
 export function loadAdvisorConfig(): AdvisorConfig {
 	return loadJsonConfigWithLegacyFallback<AdvisorConfig>("rpiv-advisor", "advisor.json");
+}
+
+function boundedInteger(value: unknown, fallback: number, minimum: number, maximum: number): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+	return Math.min(maximum, Math.max(minimum, Math.floor(value)));
+}
+
+export function resolveAdvisorContextBudget(value: unknown): AdvisorContextBudget {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return { ...DEFAULT_CONTEXT_BUDGET };
+	const raw = value as AdvisorContextBudgetConfig;
+	return {
+		enabled: typeof raw.enabled === "boolean" ? raw.enabled : DEFAULT_CONTEXT_BUDGET.enabled,
+		responseReserveTokens: boundedInteger(
+			raw.responseReserveTokens,
+			DEFAULT_CONTEXT_BUDGET.responseReserveTokens,
+			1_024,
+			1_000_000,
+		),
+		keepFirst: boundedInteger(raw.keepFirst, DEFAULT_CONTEXT_BUDGET.keepFirst, 0, 1_000),
+		keepLast: boundedInteger(raw.keepLast, DEFAULT_CONTEXT_BUDGET.keepLast, 1, 1_000),
+		toolResultMaxChars: boundedInteger(
+			raw.toolResultMaxChars,
+			DEFAULT_CONTEXT_BUDGET.toolResultMaxChars,
+			256,
+			1_000_000,
+		),
+	};
+}
+
+export function getAdvisorContextBudget(): AdvisorContextBudget {
+	return resolveAdvisorContextBudget(loadAdvisorConfig().contextBudget);
 }
 
 export function validateDisabledForModels(value: unknown): DisabledForModelsEntry[] {

--- a/packages/rpiv-advisor/advisor/context.ts
+++ b/packages/rpiv-advisor/advisor/context.ts
@@ -8,6 +8,41 @@
 import type { Message } from "@earendil-works/pi-ai";
 import { ADVISOR_TOOL_NAME, MSG_ADVISOR_NUDGE } from "./messages.js";
 
+const CONTEXT_PRUNE_SUMMARY_TYPE = "context-prune-summary";
+
+/**
+ * Read pi-context-prune's persisted summary metadata without depending on that
+ * optional extension. Missing or legacy metadata is intentionally a no-op.
+ */
+export function getPruneCoveredToolCallIds(entries: readonly unknown[]): ReadonlySet<string> {
+	const ids = new Set<string>();
+	for (const entry of entries) {
+		if (!entry || typeof entry !== "object") continue;
+		const candidate = entry as { type?: unknown; customType?: unknown; details?: unknown };
+		if (
+			(candidate.type !== "custom_message" && candidate.type !== "custom") ||
+			candidate.customType !== CONTEXT_PRUNE_SUMMARY_TYPE
+		) {
+			continue;
+		}
+		if (!candidate.details || typeof candidate.details !== "object") continue;
+		const details = candidate.details as { toolCallRefs?: unknown; toolCallIds?: unknown };
+		if (Array.isArray(details.toolCallRefs)) {
+			for (const ref of details.toolCallRefs) {
+				if (!ref || typeof ref !== "object") continue;
+				const toolCallId = (ref as { toolCallId?: unknown }).toolCallId;
+				if (typeof toolCallId === "string" && toolCallId.length > 0) ids.add(toolCallId);
+			}
+		}
+		if (Array.isArray(details.toolCallIds)) {
+			for (const toolCallId of details.toolCallIds) {
+				if (typeof toolCallId === "string" && toolCallId.length > 0) ids.add(toolCallId);
+			}
+		}
+	}
+	return ids;
+}
+
 // Strip the executor's in-flight advisor() toolCall from the tail assistant
 // message. That call is what invoked *us* — there is no matching toolResult
 // yet, and providers (Anthropic, GLM/zai, OpenAI) reject payloads with orphan

--- a/packages/rpiv-advisor/advisor/execute.ts
+++ b/packages/rpiv-advisor/advisor/execute.ts
@@ -15,7 +15,16 @@ import {
 	type ExtensionAPI,
 	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { ensureUserTailForAdvisor, stripInflightAdvisorCall } from "./context.js";
+import {
+	applyContextBudget,
+	deriveAdvisorBudget,
+	dropPruneCoveredToolResults,
+	estimateMessageTokens,
+	estimateTokens,
+	repairToolPairing,
+} from "./budget.js";
+import { getAdvisorContextBudget } from "./config.js";
+import { ensureUserTailForAdvisor, getPruneCoveredToolCallIds, stripInflightAdvisorCall } from "./context.js";
 import { getInventoryMessage } from "./inventory.js";
 import {
 	ERR_ABORTED_DETAIL,
@@ -29,11 +38,20 @@ import {
 	errMisconfigured,
 	errNoApiKey,
 	errNoApiKeyDetail,
+	MSG_ADVISOR_NUDGE,
 	msgConsulting,
 } from "./messages.js";
 import { getRuntimeCompleteSimple, loadCompleteSimple } from "./pi-compat.js";
 import { ADVISOR_SYSTEM_PROMPT } from "./prompt.js";
 import { getAdvisorEffort, getAdvisorModel } from "./state.js";
+
+interface AdvisorContextDetails {
+	enabled: boolean;
+	dropped: number;
+	estimatedTokens: number;
+	maxInputTokens: number;
+	pruneCoveredToolResults: number;
+}
 
 interface AdvisorDetails {
 	advisorModel?: string;
@@ -41,6 +59,7 @@ interface AdvisorDetails {
 	usage?: Usage;
 	stopReason?: StopReason;
 	errorMessage?: string;
+	context?: AdvisorContextDetails;
 }
 
 // Extract the advisor's text content from a completeSimple response: concatenate
@@ -67,11 +86,13 @@ function buildAdvisorResult(opts: {
 	usage?: Usage;
 	stopReason?: StopReason;
 	errorMessage?: string;
+	context?: AdvisorContextDetails;
 }): AgentToolResult<AdvisorDetails> {
 	const details: AdvisorDetails = { effort: opts.effort };
 	if (opts.advisorLabel !== undefined) details.advisorModel = opts.advisorLabel;
 	if (opts.usage !== undefined) details.usage = opts.usage;
 	if (opts.stopReason !== undefined) details.stopReason = opts.stopReason;
+	if (opts.context !== undefined) details.context = opts.context;
 	if (opts.errorMessage !== undefined) details.errorMessage = opts.errorMessage;
 	return { content: [{ type: "text", text: opts.text }], details };
 }
@@ -81,8 +102,9 @@ function buildErrorResult(
 	effort: ThinkingLevel | undefined,
 	userText: string,
 	errorMessage: string,
+	context?: AdvisorContextDetails,
 ): AgentToolResult<AdvisorDetails> {
-	return buildAdvisorResult({ text: userText, effort, advisorLabel, errorMessage });
+	return buildAdvisorResult({ text: userText, effort, advisorLabel, errorMessage, context });
 }
 
 export async function executeAdvisor(
@@ -114,19 +136,51 @@ export async function executeAdvisor(
 		return buildErrorResult(advisorLabel, effort, errNoApiKey(advisorLabel), errNoApiKeyDetail(advisor.provider));
 	}
 
-	// Live-read every call — advisor runs mid-turn so any message_end snapshot
-	// is always one turn stale. buildSessionContext() preserves Pi's resolved
-	// LLM context, including compaction summaries and branch summaries, instead
-	// of replaying raw pre-compaction branch messages. convertToLlm is
-	// pass-through for user/assistant/toolResult (messages.js:111-114), so
-	// element refs are stable across calls via the session store.
-	const { messages: sessionMessages } = buildSessionContext(
-		ctx.sessionManager.getEntries(),
-		ctx.sessionManager.getLeafId(),
-	);
-	const branchMessages = ensureUserTailForAdvisor(stripInflightAdvisorCall(convertToLlm(sessionMessages)));
+	// Read the active branch and resolved context at call time. Native Pi
+	// compaction and branch summaries are retained; the local budget pass below
+	// additionally removes stale tool output and caps the advisor payload.
+	const entries = ctx.sessionManager.getEntries();
+	const { messages: sessionMessages } = buildSessionContext(entries, ctx.sessionManager.getLeafId());
+	const activeBranchEntries = ctx.sessionManager.getBranch();
 	const inventoryMessage = getInventoryMessage(pi.getAllTools());
+	const rawBranchMessages = convertToLlm(sessionMessages);
+	const pruneCoveredIds = getPruneCoveredToolCallIds(activeBranchEntries);
+	const strippedBranchMessages = stripInflightAdvisorCall(rawBranchMessages);
+	const pruneAwareMessages = dropPruneCoveredToolResults(strippedBranchMessages, pruneCoveredIds);
+	const contextBudget = getAdvisorContextBudget();
+	const responseReserveTokens =
+		Number.isFinite(advisor.maxTokens) && advisor.maxTokens > 0
+			? Math.min(contextBudget.responseReserveTokens, advisor.maxTokens)
+			: contextBudget.responseReserveTokens;
+	const fixedPromptTokens =
+		estimateTokens(ADVISOR_SYSTEM_PROMPT) +
+		(inventoryMessage ? estimateMessageTokens(inventoryMessage) : 0) +
+		estimateTokens(MSG_ADVISOR_NUDGE);
+	const maxInputTokens = Math.max(
+		0,
+		deriveAdvisorBudget(advisor.contextWindow, responseReserveTokens) - fixedPromptTokens,
+	);
+	const fittedBranch = contextBudget.enabled
+		? applyContextBudget(pruneAwareMessages, {
+				maxInputTokens,
+				keepFirst: contextBudget.keepFirst,
+				keepLast: contextBudget.keepLast,
+				toolResultMaxChars: contextBudget.toolResultMaxChars,
+			})
+		: {
+				messages: pruneAwareMessages,
+				dropped: 0,
+				estimatedTokens: pruneAwareMessages.reduce((total, message) => total + estimateMessageTokens(message), 0),
+			};
+	const branchMessages = ensureUserTailForAdvisor(repairToolPairing(fittedBranch.messages));
 	const messages: Message[] = inventoryMessage ? [inventoryMessage, ...branchMessages] : branchMessages;
+	const contextDetails: AdvisorContextDetails = {
+		enabled: contextBudget.enabled,
+		dropped: fittedBranch.dropped,
+		estimatedTokens: fittedBranch.estimatedTokens,
+		maxInputTokens,
+		pruneCoveredToolResults: pruneCoveredIds.size,
+	};
 
 	onUpdate?.({
 		content: [{ type: "text", text: msgConsulting(advisorLabel, effort) }],
@@ -165,6 +219,7 @@ export async function executeAdvisor(
 					usage: r.usage,
 					stopReason: r.stopReason,
 					errorMessage: r.errorMessage ?? ERR_ABORTED_DETAIL,
+					context: contextDetails,
 				});
 			}
 			if (r.stopReason === "error") {
@@ -175,6 +230,7 @@ export async function executeAdvisor(
 					usage: r.usage,
 					stopReason: r.stopReason,
 					errorMessage: r.errorMessage,
+					context: contextDetails,
 				});
 			}
 			return undefined;
@@ -209,6 +265,7 @@ export async function executeAdvisor(
 					usage: response.usage,
 					stopReason: response.stopReason,
 					errorMessage: ERR_EMPTY_RESPONSE_DETAIL,
+					context: contextDetails,
 				});
 			}
 		}
@@ -219,9 +276,10 @@ export async function executeAdvisor(
 			advisorLabel,
 			usage: response.usage,
 			stopReason: response.stopReason,
+			context: contextDetails,
 		});
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		return buildErrorResult(advisorLabel, effort, errCallThrew(message), message);
+		return buildErrorResult(advisorLabel, effort, errCallThrew(message), message, contextDetails);
 	}
 }

--- a/packages/rpiv-advisor/advisor/index.ts
+++ b/packages/rpiv-advisor/advisor/index.ts
@@ -15,6 +15,7 @@
  *   policy     — disabledForModels blocklist + blocked predicates
  *   inventory  — globalThis tool-inventory cache + serializer
  *   context    — branch-message massaging
+ *   budget     — token estimation, prune-aware fitting, and tool-pair repair
  *   prompt     — system-prompt loader
  *   execute    — the advisor side-call
  *   register   — advisor tool registration

--- a/packages/rpiv-advisor/docs/configuration.md
+++ b/packages/rpiv-advisor/docs/configuration.md
@@ -43,11 +43,42 @@ previous selection and the active tool list are left untouched.
 | `modelKey` | `string` — `"provider/modelId"` | absent (advisor off) | `/advisor` |
 | `effort` | graded thinking level (`minimal` → `max`) | absent (no `reasoning` sent) | `/advisor` effort picker |
 | `disabledForModels` | `(string \| { model, minEffort? })[]` | `[]` | hand-edited |
+| `contextBudget` | object — `enabled`, `responseReserveTokens`, `keepFirst`, `keepLast`, `toolResultMaxChars` | bounded defaults enabled | hand-edited |
 | `guidance.promptSnippet` | `string` | built-in snippet | hand-edited |
 | `guidance.promptGuidelines` | `string[]` | six built-in guidelines | hand-edited |
 
 `/advisor` only ever writes `modelKey` and `effort`; `guidance` and
 `disabledForModels` are preserved across saves, so hand-edits survive.
+
+### `contextBudget`
+
+Advisor context fitting is enabled by default. It runs on a temporary copy of the resolved branch, so it never changes the session transcript.
+
+| Field | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `enabled` | `boolean` | `true` | Disable local fitting while retaining native compaction and prune-summary filtering. |
+| `responseReserveTokens` | positive integer | `16384` | Output room reserved before the input budget is calculated. |
+| `keepFirst` | non-negative integer | `4` | Number of earliest messages retained when the branch exceeds the budget. |
+| `keepLast` | positive integer | `24` | Number of newest messages preferred when the branch exceeds the budget. |
+| `toolResultMaxChars` | positive integer | `12000` | Maximum text retained from each tool result before window fitting. |
+
+The input budget uses the selected advisor model's `contextWindow`, subtracts the response reserve, and leaves a ten-percent tokenizer margin. Compaction, branch, and `pi-context-prune` summaries are retained verbatim. Dropped messages produce an omission marker, and tool-call/result pairing is repaired before the provider request.
+
+Example:
+
+```json
+{
+  "contextBudget": {
+    "enabled": true,
+    "responseReserveTokens": 16384,
+    "keepFirst": 4,
+    "keepLast": 24,
+    "toolResultMaxChars": 12000
+  }
+}
+```
+
+All fields are optional. An older `advisor.json` without `contextBudget` uses these defaults.
 
 ### `modelKey`
 

--- a/packages/rpiv-advisor/docs/tool-reference.md
+++ b/packages/rpiv-advisor/docs/tool-reference.md
@@ -26,8 +26,8 @@ Each call assembles the request in this order:
    replay of history. Compaction summaries and branch summaries are forwarded as
    the model actually sees them, so a compacted session sends the summary rather
    than the pre-compaction detail.
-3. **Tail massaging** — the in-flight `advisor()` tool call is stripped from the
-   tail, and a user-role message is guaranteed at the end (falling back to
+3. **Context fitting** — if the resolved branch exceeds the selected advisor model's input budget, large tool results are capped and older messages are omitted with a marker. Tool results covered by `pi-context-prune` summaries are dropped while those summaries remain. Compaction, branch, and prune summaries remain verbatim, and tool-call/result pairing is repaired after fitting.
+4. **Tail massaging** — the in-flight `advisor()` tool call is stripped from the tail, and a user-role message is guaranteed at the end (falling back to
    `Please advise on the executor's situation above.`) so providers that reject
    non-user tails accept the payload.
 
@@ -50,6 +50,13 @@ While the call is in flight the executor streams
     advisorModel?: string,   // "<provider>:<modelId>" — colon-joined
     effort?: ThinkingLevel,  // the reasoning level actually sent
     usage?: Usage,           // token usage from the side-call
+    context?: {              // fitted input telemetry
+      enabled: boolean;
+      dropped: number;
+      estimatedTokens: number;
+      maxInputTokens: number;
+      pruneCoveredToolResults: number;
+    },
     stopReason?: StopReason, // pi-ai stop reason
     errorMessage?: string,   // populated on the no-model/auth/abort/error/empty paths
   }


### PR DESCRIPTION
## Summary

- Fit advisor context to the selected reviewer model window.
- Remove tool results covered by persisted `pi-context-prune` summaries.
- Repair tool-call/result pairing after filtering and trimming.
- Expose fit telemetry and optional `contextBudget` settings.

## Why

`rpiv-advisor` builds its side-call directly with `buildSessionContext()` and `completeSimple()`, so Pi extension `context` handlers are bypassed. In particular, `pi-context-prune` can remove raw tool results from the executor context while the advisor still receives them.

## Implementation

- Uses the selected advisor model `contextWindow`.
- Reserves response tokens and a ten-percent tokenizer margin.
- Caps large tool-result text and omits older messages with a constant cache-stable marker.
- Preserves compaction, branch, and prune summaries verbatim.
- Repairs orphan `toolResult` messages and dangling assistant tool calls.
- Keeps the transformation non-mutating and bounded by default for existing configs.

The estimator intentionally uses a conservative chars/3 × 1.15 heuristic because advisor payloads are dense with tool arguments, code, and serialized metadata.

## Validation

- `bun run vitest run`: 260 files, 4948 tests passed.
- `bun run tsc --noEmit -p tsconfig.base.json`: passed.
- Biome checks: passed.
- Synthetic 500k-character transcript: 194,600 estimated tokens before fitting, 1,994 after fitting, 99 messages dropped.
- Recorded pre-change advisor usage reached 29,465 → 440,354 cache-write tokens and an estimated $0.23 → $2.80 per call; one outlier reached 993k cache-write tokens / $6.26. No billed live after-change session was run.

Relates to #134 and #147.