### PR TITLE
feat(ask-user-question): programmatic answer channel — submitAskUserAnswer

### DIFF
--- a/packages/rpiv-ask-user-question/ask-answer.test.ts
+++ b/packages/rpiv-ask-user-question/ask-answer.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	clearActiveAsk,
+	getActiveAskParams,
+	hasActiveAsk,
+	registerActiveAsk,
+	submitAskUserAnswer,
+} from "./ask-answer.js";
+import type { QuestionnaireResult } from "./tool/types.js";
+
+const params = {
+	questions: [
+		{
+			question: "Single?",
+			header: "S",
+			options: [
+				{ label: "A", description: "d" },
+				{ label: "B", description: "d" },
+			],
+		},
+		{
+			question: "Multi?",
+			header: "M",
+			multiSelect: true,
+			options: [
+				{ label: "X", description: "d" },
+				{ label: "Y", description: "d" },
+			],
+		},
+	],
+} as Parameters<typeof registerActiveAsk>[0];
+
+const okResult = (overrides: Partial<QuestionnaireResult> = {}): QuestionnaireResult => ({
+	answers: [
+		{ questionIndex: 0, question: "Single?", kind: "option", answer: "A" },
+		{ questionIndex: 1, question: "Multi?", kind: "multi", answer: null, selected: ["X", "Y"] },
+	],
+	cancelled: false,
+	...overrides,
+});
+
+function resetSlot(): void {
+	registerActiveAsk(params, () => {});
+	clearActiveAsk(registerActiveAsk(params, () => {}));
+}
+
+beforeEach(() => {
+	// The slot is process-global (Symbol.for); make each test start from a known state.
+	resetSlot();
+});
+
+describe("submitAskUserAnswer", () => {
+	it("returns false when nothing is registered", () => {
+		resetSlot();
+		expect(submitAskUserAnswer(okResult())).toBe(false);
+	});
+
+	it("submits to the registered done callback and returns true", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		expect(submitAskUserAnswer(okResult())).toBe(true);
+		expect(done).toHaveBeenCalledWith(okResult());
+	});
+
+	it("is idempotent: second submit after answer returns false", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		expect(submitAskUserAnswer(okResult())).toBe(true);
+		expect(submitAskUserAnswer(okResult())).toBe(false);
+		expect(done).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns false after the owning call's clearActiveAsk", () => {
+		const done = vi.fn();
+		const ask = registerActiveAsk(params, done);
+		clearActiveAsk(ask);
+		expect(hasActiveAsk()).toBe(false);
+		expect(submitAskUserAnswer(okResult())).toBe(false);
+		expect(done).not.toHaveBeenCalled();
+	});
+
+	it("accepts cancelled results (Esc-equivalent) with zero answers", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		expect(submitAskUserAnswer({ answers: [], cancelled: true })).toBe(true);
+		expect(done).toHaveBeenCalledTimes(1);
+	});
+
+	it("accepts cancelled results even with malformed answer entries", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const cancelled = { answers: [null], cancelled: true } as unknown as QuestionnaireResult;
+		expect(submitAskUserAnswer(cancelled)).toBe(true);
+		expect(done).toHaveBeenCalledWith(cancelled);
+	});
+
+	it("rejects structurally malformed results without calling done", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		expect(submitAskUserAnswer({} as QuestionnaireResult)).toBe(false);
+		// cancelled:false with zero answers is not a real answer
+		expect(submitAskUserAnswer({ answers: [], cancelled: false })).toBe(false);
+		expect(done).not.toHaveBeenCalled();
+	});
+
+	it("rejects a null answer entry instead of letting buildQuestionnaireResponse throw", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const withNull = { answers: [null], cancelled: false } as unknown as QuestionnaireResult;
+		expect(submitAskUserAnswer(withNull)).toBe(false);
+		expect(done).not.toHaveBeenCalled();
+	});
+
+	it("rejects an out-of-range questionIndex", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const result = okResult({
+			answers: [{ questionIndex: 9, question: "?", kind: "custom", answer: "text" }],
+		});
+		expect(submitAskUserAnswer(result)).toBe(false);
+		expect(done).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-integer questionIndex", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const result = okResult({
+			answers: [{ questionIndex: 0.5, question: "?", kind: "custom", answer: "text" }],
+		});
+		expect(submitAskUserAnswer(result)).toBe(false);
+	});
+
+	it("rejects a fabricated option label", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const result = okResult({
+			answers: [{ questionIndex: 0, question: "Single?", kind: "option", answer: "NOT_A_LABEL" }],
+		});
+		expect(submitAskUserAnswer(result)).toBe(false);
+		expect(done).not.toHaveBeenCalled();
+	});
+
+	it("rejects a fabricated label inside a pipe-joined multi-select option answer", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const result = okResult({
+			answers: [{ questionIndex: 0, question: "Single?", kind: "option", answer: "A|FORGED" }],
+		});
+		expect(submitAskUserAnswer(result)).toBe(false);
+	});
+
+	it("accepts a pipe-joined option answer whose parts are all valid labels", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const result = okResult({
+			answers: [{ questionIndex: 0, question: "Single?", kind: "option", answer: "A|B" }],
+		});
+		expect(submitAskUserAnswer(result)).toBe(true);
+	});
+
+	it("rejects a multi answer with a fabricated selected label", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const result = okResult({
+			answers: [{ questionIndex: 1, question: "Multi?", kind: "multi", answer: null, selected: ["X", "FORGED"] }],
+		});
+		expect(submitAskUserAnswer(result)).toBe(false);
+	});
+
+	it("rejects an unknown kind", () => {
+		const done = vi.fn();
+		registerActiveAsk(params, done);
+		const result = okResult({
+			answers: [{ questionIndex: 0, question: "?", kind: "surprise", answer: "A" } as never],
+		});
+		expect(submitAskUserAnswer(result)).toBe(false);
+	});
+
+	it("leaves no residue: slot empty after a successful submit", () => {
+		registerActiveAsk(params, vi.fn());
+		expect(submitAskUserAnswer(okResult())).toBe(true);
+		expect(hasActiveAsk()).toBe(false);
+		expect(getActiveAskParams()).toBeNull();
+	});
+});
+
+describe("held-identity clear (parallel asks)", () => {
+	it("clears when the slot still holds the given handle", () => {
+		const ask = registerActiveAsk(params, vi.fn());
+		clearActiveAsk(ask);
+		expect(hasActiveAsk()).toBe(false);
+	});
+
+	it("does not clear a different registration (first ask's finally vs second ask)", () => {
+		const first = registerActiveAsk(params, vi.fn());
+		const second = registerActiveAsk(params, vi.fn());
+		clearActiveAsk(first); // first ask's finally — slot holds `second`
+		expect(hasActiveAsk()).toBe(true);
+		expect(getActiveAskParams()).toBe(params);
+		clearActiveAsk(second); // second ask's finally
+		expect(hasActiveAsk()).toBe(false);
+	});
+
+	it("a stale handle clears nothing after its registration was replaced", () => {
+		const first = registerActiveAsk(params, vi.fn());
+		registerActiveAsk(params, vi.fn()); // replaces first in the slot
+		clearActiveAsk(first);
+		expect(hasActiveAsk()).toBe(true);
+	});
+
+	it("an undefined handle (factory never ran) clears nothing", () => {
+		registerActiveAsk(params, vi.fn());
+		clearActiveAsk(undefined);
+		expect(hasActiveAsk()).toBe(true);
+	});
+
+	it("submit answers the newest registration only", () => {
+		const firstDone = vi.fn();
+		const secondDone = vi.fn();
+		registerActiveAsk(params, firstDone);
+		registerActiveAsk(params, secondDone);
+		expect(submitAskUserAnswer(okResult())).toBe(true);
+		expect(firstDone).not.toHaveBeenCalled();
+		expect(secondDone).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("getActiveAskParams", () => {
+	it("returns the registered params while waiting, null after clear", () => {
+		const ask = registerActiveAsk(params, vi.fn());
+		expect(getActiveAskParams()).toBe(params);
+		clearActiveAsk(ask);
+		expect(getActiveAskParams()).toBeNull();
+	});
+});

--- a/packages/rpiv-ask-user-question/ask-answer.ts
+++ b/packages/rpiv-ask-user-question/ask-answer.ts
@@ -1,0 +1,155 @@
+/**
+ * Programmatic answer channel for the ask_user_question tool.
+ *
+ * The events contract (`rpiv:ask-user:prompt` / `rpiv:ask-user:blocked`) is
+ * read-only by design, and the `done` resolve-callback passed to the
+ * `ctx.ui.custom()` factory is trapped inside that closure. This module
+ * bridges the gap so extensions that install this package (e.g. a chat
+ * bridge) can answer a waiting questionnaire programmatically — identical to
+ * the terminal user selecting by hand.
+ *
+ * RPC-path gap: the slot is registered ONLY on the TUI path, as the first
+ * line of the factory `makeSessionFactory` returns (`ask-user-question.ts`).
+ * `runRpcPath` and the `resolveUndefinedResult` backstop never register, so
+ * on RPC hosts (VS Code pendant, Zed/Paseo ACP) a questionnaire can be
+ * waiting while `getActiveAskParams()` returns null — bridge authors must
+ * not assume this channel is available there.
+ *
+ * The pi SDK's `close` implementation carries its own `closed` idempotency
+ * gate, so a late answer after the questionnaire already resolved is a
+ * natural no-op — no double-answer races. `submitAskUserAnswer` is idempotent
+ * for the same reason: once the slot is cleared, late answers return `false`
+ * without side effects.
+ *
+ * State lives on globalThis (Symbol.for key) so multiple module instances of
+ * this package — the host's installed extension vs a consumer resolving its
+ * own copy — share ONE questionnaire slot, the same cross-instance pattern
+ * as `rpiv-advisor/inventory.ts` and `rpiv-workflow/execution-host.ts`.
+ * Without the shared slot, each instance would hold a private null and the
+ * programmatic answer would always miss.
+ */
+
+import { isQuestionnaireResult, type QuestionnaireResult, type QuestionParams } from "./tool/types.js";
+
+type Done = (result: QuestionnaireResult) => void;
+
+/**
+ * Opaque handle to one registered questionnaire — returned by
+ * `registerActiveAsk`, passed back to `clearActiveAsk`, compared by object
+ * identity only ("clear only if still held"), never inspected.
+ */
+export interface ActiveAsk {
+	/** Identity token — opaque, never read. */
+	readonly token: symbol;
+}
+
+type RegisteredAsk = ActiveAsk & { params: QuestionParams; done: Done };
+
+const ACTIVE_ASK = Symbol.for("@juicesharp/rpiv-ask-user-question:activeAsk");
+const store = globalThis as Record<symbol, RegisteredAsk | undefined>;
+
+function get(): RegisteredAsk | undefined {
+	return store[ACTIVE_ASK];
+}
+
+/**
+ * Called by the tool's execute() path — first line of the factory that
+ * `makeSessionFactory` returns. Registers the live questionnaire and returns
+ * its handle; the caller MUST keep the handle and pass it to `clearActiveAsk`
+ * in its `finally`. A later registration replaces an earlier one in the slot
+ * (the newest ask is the one a programmatic answer targets), and each handle
+ * only ever clears itself.
+ */
+export function registerActiveAsk(params: QuestionParams, done: Done): ActiveAsk {
+	const ask: RegisteredAsk = { token: Symbol(), params, done };
+	store[ACTIVE_ASK] = ask;
+	return ask;
+}
+
+/**
+ * Called from execute()'s finally — the questionnaire is over either way.
+ * Clears ONLY when the slot still holds the caller's own handle: pi runs
+ * tool-call batches in parallel, so an overlapping ask registered after this
+ * one must survive the first call's teardown. An undefined handle (the
+ * factory never ran — e.g. `ctx.ui.custom` rejected before rendering) clears
+ * nothing.
+ */
+export function clearActiveAsk(ask: ActiveAsk | undefined): void {
+	if (ask !== undefined && store[ACTIVE_ASK] === ask) {
+		store[ACTIVE_ASK] = undefined;
+	}
+}
+
+/** True when a questionnaire is waiting (registered and not yet resolved). */
+export function hasActiveAsk(): boolean {
+	return get() !== undefined;
+}
+
+/** Read-only snapshot of the waiting questionnaire's params (null if none). */
+export function getActiveAskParams(): QuestionParams | null {
+	return get()?.params ?? null;
+}
+
+/**
+ * Validate submitted answers against the registered params, entry by entry:
+ * - every entry MUST be an object with a known `kind`
+ * - `questionIndex` MUST be an integer within `[0, questions.length)`
+ * - `kind: "option"` — `answer` MUST be a string whose `|`-separated parts
+ *   are all valid labels of that question (multi-select answers arrive as
+ *   pipe-joined label lists)
+ * - `kind: "multi"` — when `selected` is present, every element MUST be a
+ *   valid label of that question
+ * - `kind: "custom"` — free text; only the index is checked
+ *
+ * Answers arrive from remote users through bridges, not just from trusted
+ * code: a fabricated label would be echoed verbatim into the LLM-facing
+ * envelope, and an out-of-range index would throw inside
+ * `buildQuestionnaireResponse`. Reject (return false) instead of throwing.
+ */
+function answersMatchParams(answers: readonly unknown[], params: QuestionParams): boolean {
+	for (const entry of answers) {
+		if (entry === null || typeof entry !== "object") return false;
+		const { kind, questionIndex, answer: answerText, selected } = entry as Record<string, unknown>;
+		if (kind !== "option" && kind !== "custom" && kind !== "multi") return false;
+		if (typeof questionIndex !== "number" || !Number.isInteger(questionIndex)) return false;
+		if (questionIndex < 0 || questionIndex >= params.questions.length) return false;
+		const question = params.questions[questionIndex]!;
+		if (kind === "option") {
+			if (typeof answerText !== "string") return false;
+			const labels = new Set(question.options.map((o) => o.label));
+			for (const part of answerText.split("|")) {
+				if (!labels.has(part)) return false;
+			}
+		} else if (kind === "multi" && selected !== undefined) {
+			if (!Array.isArray(selected)) return false;
+			const labels = new Set(question.options.map((o) => o.label));
+			for (const label of selected) {
+				if (typeof label !== "string" || !labels.has(label)) return false;
+			}
+		}
+	}
+	return true;
+}
+
+/**
+ * Submit an answer to the currently-waiting questionnaire.
+ *
+ * Returns `true` when the result was handed to the still-open questionnaire
+ * (overlay closes, the tool call resolves with the structured result).
+ * Returns `false` — without side effects — when there is no active
+ * questionnaire, it was already answered (idempotent no-op: the answer
+ * arrived too late), or the result fails validation against the registered
+ * params (forged labels, out-of-range question index, malformed entries).
+ * Cancelled requests skip the per-entry validation (a cancel carries no
+ * answers to lie about). Never throws.
+ */
+export function submitAskUserAnswer(result: QuestionnaireResult): boolean {
+	const ask = get();
+	if (!ask) return false;
+	if (!isQuestionnaireResult(result)) return false;
+	if (!result.cancelled && result.answers.length === 0) return false;
+	if (!result.cancelled && !answersMatchParams(result.answers, ask.params)) return false;
+	store[ACTIVE_ASK] = undefined;
+	ask.done(result);
+	return true;
+}

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { isKeyRelease, isKeyRepeat, matchesKey, type OverlayHandle, type TUI } from "@earendil-works/pi-tui";
+import { type ActiveAsk, clearActiveAsk, registerActiveAsk } from "./ask-answer.js";
 import {
 	COLLAPSE_KEY_OFF,
 	formatKeySpecForDisplay,
@@ -190,15 +191,21 @@ function makeSessionFactory(config: {
 	collapseKey: string;
 	canReopenWhileHidden: boolean;
 	sessionRef: SessionRef;
+	/** Captures the activeAsk handle the factory's first line registers (ask-answer.ts). */
+	askRef: { current: ActiveAsk | undefined };
 	Session: SessionModule["QuestionnaireSession"];
 }) {
-	const { ctx, typed, itemsByTab, collapseKey, canReopenWhileHidden, sessionRef, Session } = config;
+	const { ctx, typed, itemsByTab, collapseKey, canReopenWhileHidden, sessionRef, askRef, Session } = config;
 	return (
 		tui: TUI,
 		theme: Theme,
 		keybindings: import("./state/questionnaire-session.js").QuestionnaireSessionConfig["keybindings"],
 		done: (result: QuestionnaireResult) => void,
 	): import("./state/questionnaire-session.js").QuestionnaireSessionComponent => {
+		// First line by design: the questionnaire is answerable from the moment
+		// the overlay starts constructing. The handle lands in askRef so the
+		// caller's finally can clear exactly this registration (ask-answer.ts).
+		askRef.current = registerActiveAsk(typed, done);
 		const session = new Session({
 			tui,
 			theme,
@@ -356,6 +363,10 @@ export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 			// not route input to a hidden overlay's `component.handleInput`).
 			const sessionRef: SessionRef = { current: null };
 			const overlayHandleRef: OverlayHandleRef = { current: undefined };
+			// This call's own activeAsk registration, captured when the factory runs
+			// its first line. Held-identity clearing in the finally keeps a parallel
+			// ask's registration safe from our teardown (ask-answer.ts).
+			const askRef: { current: ActiveAsk | undefined } = { current: undefined };
 			const removeOverlayInputListener = registerCollapseKeyListener(ctx, collapseKey, sessionRef, overlayHandleRef);
 			// Hiding the overlay is only reversible through the raw listener above, so
 			// the session may emit `setHidden` only when it was actually registered;
@@ -373,6 +384,7 @@ export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 						collapseKey,
 						canReopenWhileHidden,
 						sessionRef,
+						askRef,
 						Session: QuestionnaireSession,
 					}),
 					{
@@ -396,6 +408,7 @@ export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 
 				return buildQuestionnaireResponse(result, typed);
 			} finally {
+				clearActiveAsk(askRef.current); // clear only our own registration (ask-answer.ts)
 				removeOverlayInputListener?.();
 				emitAskUserBlockedEvent(pi, false);
 			}

--- a/packages/rpiv-ask-user-question/index.ts
+++ b/packages/rpiv-ask-user-question/index.ts
@@ -39,6 +39,7 @@ try {
 	// SDK absent — extension still loads with English-only UI.
 }
 
+export { getActiveAskParams, hasActiveAsk, submitAskUserAnswer } from "./ask-answer.js";
 export {
 	ASK_USER_BLOCKED_EVENT,
 	ASK_USER_PROMPT_EVENT,

--- a/packages/rpiv-ask-user-question/package.json
+++ b/packages/rpiv-ask-user-question/package.json
@@ -30,6 +30,7 @@
 		"test": "vitest run"
 	},
 	"files": [
+		"ask-answer.ts",
 		"ask-user-question.ts",
 		"rpc-fallback.ts",
 		"config.ts",


### PR DESCRIPTION
## Problem

The questionnaire's resolve-callback (`done`) is only reachable via terminal keyboard. Extensions that monitor `rpiv:ask-user:prompt` (read-only events) can *see* a waiting question but cannot *answer* it — remote front-ends (chat bridges, web UIs) are dead-ends. Real-world case: a Feishu/Lark chat bridge relays the pending question to a group chat, but group members must still walk back to the terminal to select an option.

## Proposal

Purely additive (~110 lines, core diff is +4 lines):

- `execute()` registers the live questionnaire (`params` + `done`) in the `ctx.ui.custom` factory, clears it in `finally`
- `submitAskUserAnswer(result)` resolves a still-open questionnaire; **idempotent** — a late remote answer after the terminal user already replied is a natural no-op (piggybacks the existing `closed` gate in `close()`)
- State lives on `globalThis[Symbol.for(…)]`: multiple module instances of this package (host-managed npm install + a consumer's own node_modules copy) share ONE questionnaire slot — required under pi's jiti/npm install layout

## Usage

```ts
import { getActiveAskParams, submitAskUserAnswer } from "@juicesharp/rpiv-ask-user-question";

const params = getActiveAskParams();  // null when nothing is waiting
submitAskUserAnswer({
  answers: [{ questionIndex: 0, question, kind: "option", answer: label }],
  cancelled: false,
});  // → false if the questionnaire was already answered (too late)
```

## Notes

- Zero changes to existing behavior; unit tests included
- Context: the events contract is append-only and explicitly designed for cross-process bridging — this closes the missing *answer* direction

Alternative naming/API shape is of course open to discussion.