### PR TITLE
fix(rpiv-btw): strip tool traffic from /btw context for Bedrock

### DIFF
--- a/packages/rpiv-btw/CHANGELOG.md
+++ b/packages/rpiv-btw/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Prior tool calls and tool results cloned in from the main conversation are now stripped from the `/btw` request before it's sent. `/btw` always calls with `tools: []`, but Bedrock's Converse API rejects a request that still contains `toolUse`/`toolResult` blocks unless `toolConfig` is also set, so any `/btw` question asked mid-session on a Bedrock-backed model (e.g. Claude via LiteLLM/Bedrock) failed with "The toolConfig field must be defined when using toolUse and toolResult content blocks."
+
 ## [2.7.0] - 2026-08-21
 
 ## [2.6.4] - 2026-08-20

--- a/packages/rpiv-btw/btw-messages.ts
+++ b/packages/rpiv-btw/btw-messages.ts
@@ -16,7 +16,7 @@
  * plan (see plan risk r6).
  */
 
-import type { AssistantMessage, UserMessage } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Message, UserMessage } from "@earendil-works/pi-ai";
 
 // Real messages — no fabrication. userMessage is built at call time; assistantMessage
 // is the unmodified completeSimple response. Stable object references across calls →
@@ -41,4 +41,22 @@ export function assistantMessageText(msg: AssistantMessage): string {
 		.filter((c): c is { type: "text"; text: string } => c.type === "text")
 		.map((c) => c.text)
 		.join("\n");
+}
+
+// /btw always calls completeSimple with tools: [] — the model has no tools to
+// call in a side question. Drop toolResult messages and toolCall content parts
+// from the cloned branch before sending it, so a branch that has real tool use
+// in it (any normal coding session) never puts a toolUse/toolResult block on
+// the wire without a matching toolConfig. Bedrock's Converse API rejects that
+// combination outright ("The toolConfig field must be defined when using
+// toolUse and toolResult content blocks"), and an orphaned toolCall with no
+// toolResult is invalid on most other providers too.
+export function stripToolTraffic(messages: Message[]): Message[] {
+	return messages.flatMap((m): Message[] => {
+		if (m.role === "toolResult") return [];
+		if (m.role !== "assistant") return [m];
+		const content = m.content.filter((c) => c.type !== "toolCall");
+		if (content.length === m.content.length) return [m];
+		return content.length > 0 ? [{ ...m, content }] : [];
+	});
 }

--- a/packages/rpiv-btw/btw.test.ts
+++ b/packages/rpiv-btw/btw.test.ts
@@ -3,6 +3,7 @@ import {
 	createMockCtx,
 	createMockPi,
 	makeAssistantMessage,
+	makeToolResult,
 	makeUserMessage,
 } from "@juicesharp/rpiv-test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -56,6 +57,7 @@ import {
 	registerBtwCommand,
 	registerInvalidationHooks,
 	registerMessageEndSnapshot,
+	stripToolTraffic,
 	userMessageText,
 } from "./btw.js";
 import { loadCompleteSimple, loadIsContextOverflow } from "./pi-compat.js";
@@ -354,6 +356,45 @@ describe("executeBtw — branch threading", () => {
 			return makeCompletionResponse({ text: "ok" });
 		}) as never);
 		await executeBtw("q", ctx, new AbortController());
+	});
+
+	it("strips prior toolCall/toolResult blocks from the branch before sending (Bedrock rejects them without a toolConfig)", async () => {
+		const ctx = createMockCtx({
+			branch: buildSessionEntries([
+				makeUserMessage("read that file"),
+				makeAssistantMessage({ toolCalls: [{ id: "c1", name: "read", arguments: {} }] }),
+				makeToolResult({ toolCallId: "c1", toolName: "read", text: "file contents" }),
+			]),
+		});
+		ctx.model = { provider: "a", id: "m" } as never;
+		vi.mocked(completeSimple).mockImplementationOnce((async (_m: unknown, req: { messages: unknown[] }) => {
+			const text = JSON.stringify(req.messages);
+			expect(text).not.toContain("toolCall");
+			expect(text).not.toContain("toolResult");
+			return makeCompletionResponse({ text: "ok" });
+		}) as never);
+		await executeBtw("q", ctx, new AbortController());
+	});
+});
+
+describe("stripToolTraffic", () => {
+	it("drops toolResult messages", () => {
+		const user = makeUserMessage("hi");
+		const toolResult = makeToolResult({ toolCallId: "c1", toolName: "read", text: "x" });
+		expect(stripToolTraffic([user, toolResult])).toEqual([user]);
+	});
+	it("drops toolCall content parts from an assistant message, keeping any text parts", () => {
+		const msg = makeAssistantMessage({ text: "looking", toolCalls: [{ id: "c1", name: "read", arguments: {} }] });
+		const [out] = stripToolTraffic([msg]);
+		expect(out).toMatchObject({ role: "assistant", content: [{ type: "text", text: "looking" }] });
+	});
+	it("drops an assistant message entirely when its only content was a toolCall", () => {
+		const msg = makeAssistantMessage({ toolCalls: [{ id: "c1", name: "read", arguments: {} }] });
+		expect(stripToolTraffic([msg])).toEqual([]);
+	});
+	it("leaves user/assistant text-only messages untouched", () => {
+		const messages = [makeUserMessage("hi"), makeAssistantMessage({ text: "hello" })];
+		expect(stripToolTraffic(messages)).toEqual(messages);
 	});
 });
 

--- a/packages/rpiv-btw/btw.ts
+++ b/packages/rpiv-btw/btw.ts
@@ -18,7 +18,7 @@ import {
 	type SessionEntry,
 } from "@earendil-works/pi-coding-agent";
 import { type CappedHistory, capHistory, type FitBranchResult, fitBranch } from "./btw-budget.js";
-import { assistantMessageText, type BtwTurn, userMessageText } from "./btw-messages.js";
+import { assistantMessageText, type BtwTurn, stripToolTraffic, userMessageText } from "./btw-messages.js";
 import { showBtwOverlay } from "./btw-ui.js";
 import { getRuntimeCompleteSimple, loadCompleteSimple, loadIsContextOverflow } from "./pi-compat.js";
 
@@ -60,7 +60,7 @@ export { BTW_CONTEXT_RESERVE, BTW_HISTORY_TOKEN_BUDGET, BTW_NO_ANCHOR_SAFETY_FAC
 // import them from "./btw.js"). Import-then-re-export (not `export … from`) because
 // btw.ts consumes all three internally (userMessageText at :166,
 // assistantMessageText at :341, BtwTurn in BtwState/getSessionHistory/pushSessionTurn).
-export { assistantMessageText, type BtwTurn, userMessageText };
+export { assistantMessageText, type BtwTurn, stripToolTraffic, userMessageText };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -225,11 +225,11 @@ export function buildBtwMessages(
 		capped = capHistory(history);
 		fit = fitBranch({ ...fitInput, admittedEstimate: capped.estimate, keepBudget });
 	}
-	const assembled: Message[] = [
+	const assembled: Message[] = stripToolTraffic([
 		...fit.messages,
 		...capped.admitted.flatMap((t) => [t.userMessage, t.assistantMessage]),
 		userMessage,
-	];
+	]);
 	return {
 		messages: assembled,
 		systemPrompt,


### PR DESCRIPTION
## Why

`/btw` calls `completeSimple` with `tools: []`, but it still clones in prior messages from the main conversation branch. If that branch has any real tool use in it (which almost every coding session does), the cloned context still contains `toolCall`/`toolResult` blocks.

On Bedrock (Converse API), sending a request with `toolUse`/`toolResult` content but no `toolConfig` gets rejected outright:

```
The toolConfig field must be defined when using toolUse and toolResult content blocks.
```

So `/btw` is currently broken on Bedrock-backed models any time you ask it mid-session, once a tool has actually run.

## Fix

Strip tool traffic from the assembled `/btw` messages before they're sent: drop `toolResult` messages outright, and drop `toolCall` content parts from assistant messages (dropping the whole message if that was its only content). This matches what `rpiv-advisor` already does in spirit — it never sends tools either — just applied on the branch-clone path instead of only the in-flight tail.

Added `stripToolTraffic` in `btw-messages.ts` and wired it into `buildBtwMessages`, plus tests covering the unit behavior and an end-to-end check that a branch with tool calls/results never leaks a toolCall/toolResult block into the request sent to `completeSimple`.

## Testing

- `npx vitest run packages/rpiv-btw` — 120 passing
- `npx tsc --noEmit -p tsconfig.base.json` — clean
- `npx biome check` — clean
- `npm run coverage` (full suite, pre-push hook) — 5014 passing, thresholds met