### PR TITLE
fix(rpiv-todo): stale-todo reminders and compaction resync

### DIFF
--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Stale-todo reminders: when the model goes a configurable number of turns without a successful `todo` call while tasks are `in_progress`, a reminder is injected into a tool result so the model re-reads and reconciles task state (`staleAfterTurns` / `reminderCooldownTurns` in config, both default 12) (#159).
+- Compaction resync: after `session_compact`, the next `before_agent_start` injects a one-shot hint telling the model to re-read the todo list, since the data survives compaction but the model's working memory of it does not (#159).
+
 ## [2.7.1] - 2026-08-24
 
 ## [2.7.0] - 2026-08-21

--- a/packages/rpiv-todo/config.ts
+++ b/packages/rpiv-todo/config.ts
@@ -11,6 +11,18 @@ interface TodoConfig {
 	 * entirely. Validation happens in `resolveCollapseKey`, not at load.
 	 */
 	collapseKey?: string;
+	/**
+	 * Minimum number of turns without a successful `todo` call before a stale
+	 * reminder is injected into a tool result. Must be a positive integer; any
+	 * other value falls back to `DEFAULT_STALE_AFTER_TURNS`. Runtime-only read.
+	 */
+	staleAfterTurns?: number;
+	/**
+	 * Minimum gap (in turns) between two stale reminders for the same session.
+	 * Must be a positive integer; any other value falls back to
+	 * `DEFAULT_REMINDER_COOLDOWN_TURNS`. Runtime-only read.
+	 */
+	reminderCooldownTurns?: number;
 }
 
 /** Default content-row budget when the config is missing/invalid — the prior
@@ -26,8 +38,38 @@ export const DEFAULT_COLLAPSE_KEY: CollapseKeySpec = "ctrl+shift+t";
 /** Sentinel value for `collapseKey` that disables the collapse shortcut entirely. */
 export const COLLAPSE_KEY_OFF: CollapseKeySpec = "off";
 
+/** Default stale threshold — turns without a successful `todo` call before a reminder. */
+export const DEFAULT_STALE_AFTER_TURNS = 12;
+
+/** Default reminder cooldown — minimum gap between two reminders for one session. */
+export const DEFAULT_REMINDER_COOLDOWN_TURNS = 12;
+
 export function loadConfig(): TodoConfig {
 	return loadJsonConfigWithLegacyFallback<TodoConfig>("rpiv-todo");
+}
+
+/**
+ * Stale threshold — turns without a successful `todo` call before a reminder,
+ * read fresh on every call (no `/reload`). A non-number or a value below 1
+ * falls back to the default. Runtime-only; not persisted into the session.
+ */
+export function getStaleAfterTurns(): number {
+	const config = loadConfig();
+	const turns = config.staleAfterTurns;
+	if (typeof turns !== "number" || !Number.isFinite(turns) || turns < 1) return DEFAULT_STALE_AFTER_TURNS;
+	return Math.floor(turns);
+}
+
+/**
+ * Reminder cooldown — minimum gap (in turns) between two reminders for one
+ * session, read fresh on every call (no `/reload`). A non-number or a value
+ * below 1 falls back to the default. Runtime-only; not persisted.
+ */
+export function getReminderCooldownTurns(): number {
+	const config = loadConfig();
+	const turns = config.reminderCooldownTurns;
+	if (typeof turns !== "number" || !Number.isFinite(turns) || turns < 1) return DEFAULT_REMINDER_COOLDOWN_TURNS;
+	return Math.floor(turns);
 }
 
 /** Content-row budget for the overlay, read fresh on every call (per-render —

--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -21,14 +21,16 @@
 
 import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import type { KeyId } from "@earendil-works/pi-tui";
-import { COLLAPSE_KEY_OFF, resolveCollapseKey } from "./config.js";
-import { I18N_NAMESPACE } from "./state/i18n-bridge.js";
+import { COLLAPSE_KEY_OFF, getReminderCooldownTurns, getStaleAfterTurns, resolveCollapseKey } from "./config.js";
+import { getActivity } from "./state/activity-tracker.js";
+import { I18N_NAMESPACE, t } from "./state/i18n-bridge.js";
 import { replayFromBranch } from "./state/replay.js";
 import {
 	clearActiveRenderSession,
 	evictSession,
 	getActiveRenderSession,
 	getRenderState,
+	getState,
 	replaceState,
 	setActiveRenderSession,
 	sid,
@@ -217,7 +219,44 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 	});
 
 	pi.on("session_compact", async (_event, ctx) => {
+		// Remember the session needs one resync hint on its next agent start (the
+		// model lost its working memory of the todo list across compaction; the
+		// data itself survived via replay). Best-effort sid — a stale ctx (same
+		// race as replayAndRefresh) just skips the flag; the replacement
+		// session's session_start replays the store anyway.
+		try {
+			const id = sid(ctx);
+			if (id) getActivity(id).compactionResyncPending = true;
+		} catch (e) {
+			if (!isStaleCtxError(e)) throw e;
+		}
 		await replayAndRefresh(ctx);
+	});
+
+	// `session_compact_failed` exists at runtime (Pi 0.84+) but is absent from the
+	// package's pinned 0.80.6 ExtensionAPI overloads, so we register through a
+	// narrow local port that accepts the extra event name, staying compile-compatible
+	// with the pinned peer while still wiring the runtime handler. See
+	// docs/extensions.md → session_compact_failed.
+	(
+		pi as unknown as {
+			on(
+				event: "session_compact_failed",
+				handler: (event: unknown, ctx: { sessionManager: { getSessionId(): string } }) => Promise<void> | void,
+			): void;
+		}
+	).on("session_compact_failed", async (_event, ctx) => {
+		// A failed/aborted compaction means the session was NOT rewritten, so the
+		// model's working memory was not lost — a "your todo list survived, call
+		// list" resync hint would be a false claim. Clear the pending flag (if a
+		// later compaction succeeds it sets it again). Best-effort sid, same stale
+		// ctx handling as session_compact.
+		try {
+			const id = sid(ctx);
+			if (id) delete getActivity(id).compactionResyncPending;
+		} catch (e) {
+			if (!isStaleCtxError(e)) throw e;
+		}
 	});
 
 	pi.on("session_tree", async (_event, ctx) => {
@@ -286,5 +325,121 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 
 	pi.on("agent_start", async () => {
 		todoOverlay?.hideCompletedTasksFromPreviousTurn();
+	});
+
+	// -------------------------------------------------------------------------
+	// Stale-todo activity tracking + reminders (Issue #159). The tracker is
+	// runtime-only, per-session, and never persisted — see state/activity-tracker.ts.
+	// A stale reminder is injected into an arbitrary tool result so the model
+	// sees it WHILE busy (bash/edit gaps are exactly when todo updates drop),
+	// not only on the next todo call.
+	//
+	// Turn-index scoping: Pi resets turnIndex to 0 on every agent_start, so the
+	// "N turns without a todo call" count is only meaningful within ONE agent
+	// run. Cross-run staleness (follow-up prompt / compaction retry / queued
+	// continuation) is intentionally NOT tracked here: the human operator sees
+	// the todo list in the TUI at all times, so reminding them adds no
+	// information. Only the model's own in-run drift needs this tracker.
+	// -------------------------------------------------------------------------
+
+	pi.on("turn_start", (event, ctx) => {
+		let id: string;
+		try {
+			id = sid(ctx);
+		} catch (e) {
+			if (!isStaleCtxError(e)) throw e;
+			return;
+		}
+		const activity = getActivity(id);
+		activity.currentTurn = event.turnIndex;
+	});
+
+	pi.on("turn_end", (_event, ctx) => {
+		let id: string;
+		try {
+			id = sid(ctx);
+		} catch (e) {
+			if (!isStaleCtxError(e)) throw e;
+			return;
+		}
+		const activity = getActivity(id);
+		// A successful todo call during this turn advances the baseline. Only
+		// commit on turn_end so a mid-turn failure (isError) never resets it.
+		if (activity.todoSyncedThisTurn) {
+			activity.lastTodoTurn = activity.currentTurn;
+			activity.todoSyncedThisTurn = false;
+		}
+	});
+
+	pi.on("tool_result", (event, ctx) => {
+		let id: string;
+		try {
+			id = sid(ctx);
+		} catch (e) {
+			if (!isStaleCtxError(e)) throw e;
+			return;
+		}
+		const activity = getActivity(id);
+
+		// A successful todo call marks this turn as synced (committed on turn_end)
+		// AND short-circuits the stale check entirely: this turn already synced, so
+		// injecting a "please call todo list" reminder onto the todo result itself
+		// would be contradictory. A failed todo call must NOT reset the baseline.
+		if (event.toolName === TOOL_NAME && !event.isError) {
+			activity.todoSyncedThisTurn = true;
+			return;
+		}
+
+		const state = getState(id);
+		const hasInProgress = state.tasks.some((task) => task.status === "in_progress");
+		// lastTodoTurn undefined = no successful todo call this run yet → no baseline,
+		// so no staleness can be measured. (Must not use a numeric sentinel: a real
+		// successful call in turn 0 legitimately stores 0.)
+		if (!hasInProgress || activity.lastTodoTurn === undefined) return;
+
+		const staleAfter = getStaleAfterTurns();
+		const turnsSinceTodo = activity.currentTurn - activity.lastTodoTurn;
+		if (turnsSinceTodo < staleAfter) return;
+
+		// Cooldown: never remind twice in the same turn, and keep the minimum
+		// gap between reminders for this session.
+		const cooldown = getReminderCooldownTurns();
+		if (activity.lastReminderTurn !== undefined && activity.currentTurn - activity.lastReminderTurn < cooldown) {
+			return;
+		}
+		activity.lastReminderTurn = activity.currentTurn;
+
+		const reminder = t(
+			"reminder.stale",
+			"Tasks have gone {n} turns without a todo sync. Call `todo list` to check whether they are still in progress, then update their status based on the actual result.",
+		).replace("{n}", String(turnsSinceTodo));
+		return { content: [...event.content, { type: "text", text: reminder }] };
+	});
+
+	// After compaction the todo DATA survives (replayed from the branch), but the
+	// model's working memory of the list is gone. Inject one resync hint into the
+	// first agent start after a compaction. We append to the system prompt for
+	// this turn (no extra LLM call, no agent_end→sendMessage loop); the pending
+	// flag is cleared here so it fires exactly once.
+	pi.on("before_agent_start", (event, ctx) => {
+		let id: string;
+		try {
+			id = sid(ctx);
+		} catch (e) {
+			if (!isStaleCtxError(e)) throw e;
+			return;
+		}
+		const activity = getActivity(id);
+		if (!activity.compactionResyncPending) return;
+		activity.compactionResyncPending = false;
+		return {
+			systemPrompt:
+				event.systemPrompt +
+				"\n\n" +
+				t(
+					"resync.after_compact",
+					"Todo state has been restored from session history. Call `todo list` to re-read the current tasks; do not assume the pre-compaction task state is still in context.",
+				),
+		};
 	});
 }

--- a/packages/rpiv-todo/locales/de.json
+++ b/packages/rpiv-todo/locales/de.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. Unicode box-drawing characters (──) stay untranslated. Note: 'overlay.more' renders as '+5 weitere' which is grammatically loose for plural agreement — accepted for badge brevity.",
-
   "status.pending": "ausstehend",
   "status.in_progress": "in Bearbeitung",
   "status.completed": "erledigt",
   "status.deleted": "gelöscht",
-
   "overlay.heading": "Todos",
   "overlay.more": "weitere",
   "overlay.expandHint": "{key} zum Ausklappen",
   "overlay.collapsed": "eingeklappt",
-
   "command.no_todos": "Noch keine Todos. Bitte den Agenten, welche hinzuzufügen!",
   "command.requires_interactive": "/todos erfordert den interaktiven Modus",
   "command.section.pending": "── Ausstehend ──",
   "command.section.in_progress": "── In Bearbeitung ──",
-  "command.section.completed": "── Erledigt ──"
+  "command.section.completed": "── Erledigt ──",
+  "reminder.stale": "Aufgaben sind {n} Runden lang ohne Todo-Synchronisierung geblieben. Rufen Sie `todo list` auf, um zu prüfen, ob sie noch in Arbeit sind, und aktualisieren Sie dann ihren Status anhand des tatsächlichen Ergebnisses.",
+  "resync.after_compact": "Der Aufgabenstatus wurde aus dem Sitzungsverlauf wiederhergestellt. Rufen Sie `todo list` auf, um die aktuellen Aufgaben neu zu lesen; gehen Sie nicht davon aus, dass der Aufgabenstatus vor der Komprimierung noch im Kontext steht."
 }

--- a/packages/rpiv-todo/locales/en.json
+++ b/packages/rpiv-todo/locales/en.json
@@ -3,15 +3,15 @@
   "status.in_progress": "in progress",
   "status.completed": "completed",
   "status.deleted": "deleted",
-
   "overlay.heading": "Todos",
   "overlay.more": "more",
   "overlay.expandHint": "{key} to expand",
   "overlay.collapsed": "collapsed",
-
   "command.no_todos": "No todos yet. Ask the agent to add some!",
   "command.requires_interactive": "/todos requires interactive mode",
   "command.section.pending": "── Pending ──",
   "command.section.in_progress": "── In Progress ──",
-  "command.section.completed": "── Completed ──"
+  "command.section.completed": "── Completed ──",
+  "reminder.stale": "Tasks have gone {n} turns without a todo sync. Call `todo list` to check whether they are still in progress, then update their status based on the actual result.",
+  "resync.after_compact": "Todo state has been restored from session history. Call `todo list` to re-read the current tasks; do not assume the pre-compaction task state is still in context."
 }

--- a/packages/rpiv-todo/locales/es.json
+++ b/packages/rpiv-todo/locales/es.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. Unicode box-drawing characters (──) stay untranslated.",
-
   "status.pending": "pendientes",
   "status.in_progress": "en curso",
   "status.completed": "completadas",
   "status.deleted": "eliminada",
-
   "overlay.heading": "Tareas",
   "overlay.more": "más",
   "overlay.expandHint": "{key} para expandir",
   "overlay.collapsed": "contraído",
-
   "command.no_todos": "Sin tareas aún. ¡Pídele al agente que añada algunas!",
   "command.requires_interactive": "/todos requiere modo interactivo",
   "command.section.pending": "── Pendientes ──",
   "command.section.in_progress": "── En curso ──",
-  "command.section.completed": "── Completadas ──"
+  "command.section.completed": "── Completadas ──",
+  "reminder.stale": "Las tareas llevan {n} turnos sin sincronizarse con el todo. Llama a `todo list` para comprobar si siguen en curso y actualiza su estado según el resultado real.",
+  "resync.after_compact": "El estado de las tareas se ha restaurado desde el historial de la sesión. Llama a `todo list` para volver a leer las tareas actuales; no asumas que el estado previo a la compactación sigue en el contexto."
 }

--- a/packages/rpiv-todo/locales/fr.json
+++ b/packages/rpiv-todo/locales/fr.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. Unicode box-drawing characters (──) stay untranslated.",
-
   "status.pending": "en attente",
   "status.in_progress": "en cours",
   "status.completed": "terminées",
   "status.deleted": "supprimée",
-
   "overlay.heading": "Tâches",
   "overlay.more": "autres",
   "overlay.expandHint": "{key} pour développer",
   "overlay.collapsed": "réduit",
-
   "command.no_todos": "Pas encore de tâches. Demandez à l'agent d'en ajouter !",
   "command.requires_interactive": "/todos nécessite le mode interactif",
   "command.section.pending": "── En attente ──",
   "command.section.in_progress": "── En cours ──",
-  "command.section.completed": "── Terminées ──"
+  "command.section.completed": "── Terminées ──",
+  "reminder.stale": "Des tâches n'ont pas été synchronisées avec todo depuis {n} tours. Appelez `todo list` pour vérifier si elles sont toujours en cours, puis mettez à jour leur statut selon le résultat réel.",
+  "resync.after_compact": "L'état des tâches a été restauré depuis l'historique de la session. Appelez `todo list` pour relire les tâches actuelles ; ne supposez pas que l'état antérieur à la compaction est encore dans le contexte."
 }

--- a/packages/rpiv-todo/locales/pt-BR.json
+++ b/packages/rpiv-todo/locales/pt-BR.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. Unicode box-drawing characters (──) stay untranslated.",
-
   "status.pending": "pendentes",
   "status.in_progress": "em andamento",
   "status.completed": "concluídas",
   "status.deleted": "excluída",
-
   "overlay.heading": "Tarefas",
   "overlay.more": "mais",
   "overlay.expandHint": "{key} para expandir",
   "overlay.collapsed": "recolhido",
-
   "command.no_todos": "Nenhuma tarefa ainda. Peça ao agente para adicionar algumas!",
   "command.requires_interactive": "/todos requer modo interativo",
   "command.section.pending": "── Pendentes ──",
   "command.section.in_progress": "── Em andamento ──",
-  "command.section.completed": "── Concluídas ──"
+  "command.section.completed": "── Concluídas ──",
+  "reminder.stale": "Tarefas ficaram {n} turnos sem sincronização com todo. Chame `todo list` para verificar se ainda estão em andamento e atualize o status com base no resultado real.",
+  "resync.after_compact": "O estado das tarefas foi restaurado do histórico da sessão. Chame `todo list` para reler as tarefas atuais; não presuma que o estado anterior à compactação ainda está no contexto."
 }

--- a/packages/rpiv-todo/locales/pt.json
+++ b/packages/rpiv-todo/locales/pt.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "Auto-translated draft. Native-speaker review welcome via PR. Unicode box-drawing characters (──) stay untranslated.",
-
   "status.pending": "pendentes",
   "status.in_progress": "em curso",
   "status.completed": "concluídas",
   "status.deleted": "eliminada",
-
   "overlay.heading": "Tarefas",
   "overlay.more": "mais",
   "overlay.expandHint": "{key} para expandir",
   "overlay.collapsed": "recolhido",
-
   "command.no_todos": "Sem tarefas ainda. Peça ao agente para adicionar algumas!",
   "command.requires_interactive": "/todos requer modo interativo",
   "command.section.pending": "── Pendentes ──",
   "command.section.in_progress": "── Em curso ──",
-  "command.section.completed": "── Concluídas ──"
+  "command.section.completed": "── Concluídas ──",
+  "reminder.stale": "Tarefas ficaram {n} turnos sem sincronização com o todo. Chame `todo list` para verificar se ainda estão em curso e atualize o estado com base no resultado real.",
+  "resync.after_compact": "O estado das tarefas foi restaurado a partir do histórico da sessão. Chame `todo list` para reler as tarefas atuais; não assuma que o estado anterior à compactação ainda está no contexto."
 }

--- a/packages/rpiv-todo/locales/ru.json
+++ b/packages/rpiv-todo/locales/ru.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "Автоперевод. Приветствуется проверка носителем языка через PR. Символы юникода (──) не переводятся.",
-
   "status.pending": "ожидание",
   "status.in_progress": "в работе",
   "status.completed": "выполнено",
   "status.deleted": "удалена",
-
   "overlay.heading": "Задачи",
   "overlay.more": "ещё",
   "overlay.expandHint": "{key} — развернуть",
   "overlay.collapsed": "свёрнуто",
-
   "command.no_todos": "Задач пока нет. Попросите агента добавить!",
   "command.requires_interactive": "/todos требует интерактивного режима",
   "command.section.pending": "── Ожидание ──",
   "command.section.in_progress": "── В работе ──",
-  "command.section.completed": "── Выполнено ──"
+  "command.section.completed": "── Выполнено ──",
+  "reminder.stale": "Задачи не синхронизировались с todo уже {n} ходов. Вызовите `todo list`, чтобы проверить, выполняются ли они ещё, и обновите их статус по фактическому результату.",
+  "resync.after_compact": "Состояние задач восстановлено из истории сеанса. Вызовите `todo list`, чтобы заново прочитать текущие задачи; не считайте, что состояние до сжатия всё ещё в контексте."
 }

--- a/packages/rpiv-todo/locales/uk.json
+++ b/packages/rpiv-todo/locales/uk.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "Автопереклад. Привітна перевірка носієм мови через PR. Символи юнікоду (──) не перекладаються.",
-
   "status.pending": "очікування",
   "status.in_progress": "у роботі",
   "status.completed": "виконано",
   "status.deleted": "видалено",
-
   "overlay.heading": "Завдання",
   "overlay.more": "ще",
   "overlay.expandHint": "{key} — розгорнути",
   "overlay.collapsed": "згорнуто",
-
   "command.no_todos": "Завдань поки немає. Попросіть агента додати!",
   "command.requires_interactive": "/todos потребує інтерактивного режиму",
   "command.section.pending": "── Очікування ──",
   "command.section.in_progress": "── У роботі ──",
-  "command.section.completed": "── Виконано ──"
+  "command.section.completed": "── Виконано ──",
+  "reminder.stale": "Завдання не синхронізувалися з todo вже {n} ходів. Викличте `todo list`, щоб перевірити, чи вони ще виконуються, і оновіть їхній статус за фактичним результатом.",
+  "resync.after_compact": "Стан завдань відновлено з історії сеансу. Викличте `todo list`, щоб повторно прочитати поточні завдання; не вважайте, що стан до стиснення все ще в контексті."
 }

--- a/packages/rpiv-todo/locales/zh.json
+++ b/packages/rpiv-todo/locales/zh.json
@@ -1,19 +1,18 @@
 {
   "_meta.notes": "中文翻译。欢迎中文母语者通过 PR 审校。",
-
   "status.pending": "待处理",
   "status.in_progress": "进行中",
   "status.completed": "已完成",
   "status.deleted": "已删除",
-
   "overlay.heading": "任务清单",
   "overlay.more": "更多",
   "overlay.expandHint": "按 {key} 展开",
   "overlay.collapsed": "已折叠",
-
   "command.no_todos": "暂无任务。可以让 agent 添加一些！",
   "command.requires_interactive": "/todos 需要交互模式",
   "command.section.pending": "── 待处理 ──",
   "command.section.in_progress": "── 进行中 ──",
-  "command.section.completed": "── 已完成 ──"
+  "command.section.completed": "── 已完成 ──",
+  "reminder.stale": "有任务已连续 {n} 轮未同步 Todo。请先调用 todo list，确认任务是否仍在进行，再根据实际结果更新状态。",
+  "resync.after_compact": "Todo 状态已从 session history 恢复。请调用 todo list 重新读取当前任务，不要假设 compaction 前的任务状态已经在上下文中。"
 }

--- a/packages/rpiv-todo/package.json
+++ b/packages/rpiv-todo/package.json
@@ -39,6 +39,7 @@
 		"!docs/*.svg",
 		"README.md",
 		"state/invariants.ts",
+		"state/activity-tracker.ts",
 		"state/i18n-bridge.ts",
 		"state/replay.ts",
 		"state/selectors.ts",

--- a/packages/rpiv-todo/state/activity-tracker.ts
+++ b/packages/rpiv-todo/state/activity-tracker.ts
@@ -1,0 +1,70 @@
+/**
+ * Per-session runtime activity for stale-todo reminders. This is RUNTIME-ONLY
+ * bookkeeping — it is deliberately NOT persisted, NOT replayed, and never
+ * written into the `Task` shape or the `TaskDetails` snapshot. The live store
+ * (`state/store.ts`) stays the single source of truth for task data; this
+ * module only answers "how many turns has the model gone without touching
+ * `todo`" for each session, which cannot be derived from persisted data.
+ *
+ * The map is keyed by session id so a detached/child session (distinct sid)
+ * can never read or clobber another session's counters — same isolation
+ * contract as `state/store.ts`.
+ *
+ * IMPORTANT — turn-index scoping: Pi resets `turnIndex` to 0 on every
+ * `agent_start` (`_turnIndex = 0` in agent-session.js). So the counters here
+ * are only meaningful WITHIN one low-level agent run. Across runs (a
+ * follow-up prompt, a compaction retry, a queued continuation) the
+ * "N turns without a todo call" count restarts from 0, and a fresh agent run
+ * starts with `lastTodoTurn === undefined` (no baseline yet). This is
+ * intentional: cross-run staleness is deliberately NOT tracked. The human
+ * operator sees the todo list in the TUI at all times, so a reminder adds no
+ * information for them; only the model's own in-run drift matters, and a
+ * fresh agent run always starts from a clean todo state it re-reads on
+ * demand. Do not try to make `currentTurn` monotonically grow across agent
+ * runs — the runtime provides no stable per-session turn counter, and
+ * inventing one would couple this module to Pi internals.
+ */
+
+export interface TodoActivity {
+	/** The most recent `turn_end` turn index observed for this session. */
+	currentTurn: number;
+	/**
+	 * The turn index of the last SUCCESSFUL `todo` call for this agent run.
+	 * `undefined` = no successful `todo` call yet this run — no baseline, so
+	 * no stale reminder may fire. IMPORTANT: this must be `undefined` (not a
+	 * numeric sentinel), because a real successful call in turn 0 legitimately
+	 * stores 0 and must not collide with the "no baseline" marker.
+	 */
+	lastTodoTurn?: number;
+	/** The turn index of the last stale reminder injected (undefined = none yet). */
+	lastReminderTurn?: number;
+	/** Set on `session_compact`; consumed by the next `before_agent_start` to inject one resync hint. */
+	compactionResyncPending?: boolean;
+	/** Set by `tool_result` on a successful `todo` call; consumed by `turn_end` to advance `lastTodoTurn`. */
+	todoSyncedThisTurn?: boolean;
+}
+
+/**
+ * Per-session runtime activity. The Map is the single mutation seam — only
+ * `getActivity` (get-or-create) and `resetActivityState` write it.
+ */
+const activities = new Map<string, TodoActivity>();
+
+/** Get-or-create a session's activity slot. Returns the live object; callers
+ *  mutate its fields in place (matches `state/store.ts`'s `commitState` spirit
+ *  but keeps the activity row tiny and side-channel-free). */
+export function getActivity(sessionId: string): TodoActivity {
+	let activity = activities.get(sessionId);
+	if (!activity) {
+		activity = { currentTurn: 0 };
+		activities.set(sessionId, activity);
+	}
+	return activity;
+}
+
+/** Test-setup reset. Wired into `state/store.ts` `__resetState` (see its comment)
+ *  so the existing `__resetState` import path clears BOTH task state and activity
+ *  counters. */
+export function resetActivityState(): void {
+	activities.clear();
+}

--- a/packages/rpiv-todo/state/store.ts
+++ b/packages/rpiv-todo/state/store.ts
@@ -1,4 +1,5 @@
 import type { Task } from "../tool/types.js";
+import { resetActivityState } from "./activity-tracker.js";
 import { EMPTY_STATE, type TaskState } from "./state.js";
 
 /**
@@ -117,10 +118,12 @@ export function clearActiveRenderSession(): void {
 /**
  * Test-setup reset. Wired into the global `test/setup.ts` `beforeEach` via
  * the existing `__resetState` import path. Signature unchanged ⇒ no
- * `test/setup.ts` edit needed. Clears BOTH the session Map and the render
- * pointer so filesystem/detect resets start from a clean state.
+ * `test/setup.ts` edit needed. Clears the session Map, the render pointer,
+ * AND the per-session runtime activity counters so filesystem/detect resets
+ * start from a clean state.
  */
 export function __resetState(): void {
 	sessions.clear();
 	activeRenderSession = "";
+	resetActivityState();
 }

--- a/packages/rpiv-todo/todo.activity.test.ts
+++ b/packages/rpiv-todo/todo.activity.test.ts
@@ -1,0 +1,426 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_REMINDER_COOLDOWN_TURNS,
+	DEFAULT_STALE_AFTER_TURNS,
+	getReminderCooldownTurns,
+	getStaleAfterTurns,
+} from "./config.js";
+import registerTodo from "./index.js";
+import { getActivity } from "./state/activity-tracker.js";
+import { __resetState } from "./todo.js";
+
+// All tests run against a private XDG_CONFIG_HOME so the stale/cooldown
+// thresholds can be controlled without touching the user's real config and
+// without racing config.test.ts on the same ~/.config path.
+const CONFIG_DIR = join(tmpdir(), "rpiv-todo-activity-test");
+const CONFIG_PATH = join(CONFIG_DIR, "rpiv-todo", "config.json");
+
+function writeConfig(partial: Record<string, unknown>): void {
+	mkdirSync(join(CONFIG_DIR, "rpiv-todo"), { recursive: true });
+	writeFileSync(CONFIG_PATH, JSON.stringify(partial), "utf-8");
+}
+function removeConfig(): void {
+	rmSync(CONFIG_DIR, { recursive: true, force: true });
+}
+
+beforeEach(() => {
+	vi.stubEnv("XDG_CONFIG_HOME", CONFIG_DIR);
+	removeConfig();
+	__resetState();
+	// Default thresholds for the event tests: remind after 2 silent turns,
+	// cooldown of 2 turns between reminders.
+	writeConfig({ staleAfterTurns: 2, reminderCooldownTurns: 2 });
+});
+afterEach(() => {
+	removeConfig();
+	__resetState();
+	vi.unstubAllEnvs();
+});
+
+function setup() {
+	__resetState();
+	const { pi, captured } = createMockPi();
+	registerTodo(pi);
+	const get = (name: string) => captured.events.get(name)?.[0];
+	const sessionStart = get("session_start");
+	const sessionCompact = get("session_compact");
+	const sessionCompactFailed = get("session_compact_failed");
+	const turnStart = get("turn_start");
+	const turnEnd = get("turn_end");
+	const toolResult = get("tool_result");
+	const beforeAgentStart = get("before_agent_start");
+	const tool = captured.tools.get("todo");
+	if (!tool) throw new Error("todo tool not registered");
+	if (!sessionStart) throw new Error("session_start handler not registered");
+	if (!sessionCompact) throw new Error("session_compact handler not registered");
+	if (!sessionCompactFailed) throw new Error("session_compact_failed handler not registered");
+	if (!turnStart) throw new Error("turn_start handler not registered");
+	if (!turnEnd) throw new Error("turn_end handler not registered");
+	if (!toolResult) throw new Error("tool_result handler not registered");
+	if (!beforeAgentStart) throw new Error("before_agent_start handler not registered");
+	return {
+		sessionStart,
+		sessionCompact,
+		sessionCompactFailed,
+		turnStart,
+		turnEnd,
+		toolResult,
+		beforeAgentStart,
+		tool,
+	};
+}
+
+const textContent = (text: string) => [{ type: "text", text }] as never;
+
+function toolResultEvent(toolName: string, text: string, isError = false) {
+	return {
+		type: "tool_result",
+		toolName,
+		toolCallId: "tc",
+		input: {},
+		content: textContent(text),
+		isError,
+	} as never;
+}
+
+/** Create one task and mark it in_progress. */
+async function seedInProgress(
+	tool: NonNullable<ReturnType<typeof setup>["tool"]>,
+	ctx: ReturnType<typeof createMockCtx>,
+) {
+	await tool.execute?.(
+		"tc",
+		{ action: "create", subject: "t1" } as never,
+		undefined as never,
+		undefined as never,
+		ctx as never,
+	);
+	await tool.execute?.(
+		"tc",
+		{ action: "update", id: 1, status: "in_progress" } as never,
+		undefined as never,
+		undefined as never,
+		ctx as never,
+	);
+}
+
+function reminderText(result: unknown): string | undefined {
+	const r = result as { content?: Array<{ type: string; text: string }> } | undefined;
+	return r?.content
+		?.filter((c) => c.type === "text")
+		.map((c) => c.text)
+		.join(" ");
+}
+
+describe("rpiv-todo — stale-todo reminders (turn tracker)", () => {
+	it("injects ONE reminder when an in_progress task goes staleAfterTurns without a todo call", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+		await seedInProgress(tool, ctx);
+
+		// Turn 1: successful todo call establishes the baseline.
+		turnStart({ turnIndex: 1 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "created"), ctx as never);
+		turnEnd({ turnIndex: 1 } as never, ctx as never);
+
+		// Turn 2: no todo → 2-1 = 1 < staleAfter(2), no reminder.
+		turnStart({ turnIndex: 2 } as never, ctx as never);
+		const r2 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		turnEnd({ turnIndex: 2 } as never, ctx as never);
+		expect(reminderText(r2)).toBeUndefined();
+
+		// Turn 3: no todo → 3-1 = 2 >= staleAfter(2), reminder injected.
+		turnStart({ turnIndex: 3 } as never, ctx as never);
+		const r3 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		expect(reminderText(r3)).toContain("todo list");
+
+		// Same turn, second tool result → cooldown suppresses a duplicate.
+		const r3b = toolResult(toolResultEvent("read", "out"), ctx as never);
+		expect(reminderText(r3b)).toBeUndefined();
+	});
+
+	it("resets the baseline after a successful todo call", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+		await seedInProgress(tool, ctx);
+
+		// Turn 1: baseline = 1.
+		turnStart({ turnIndex: 1 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "created"), ctx as never);
+		turnEnd({ turnIndex: 1 } as never, ctx as never);
+
+		// Turn 3: stale → reminder (lastTodoTurn still 1).
+		for (let t = 2; t <= 3; t++) {
+			turnStart({ turnIndex: t } as never, ctx as never);
+			turnEnd({ turnIndex: t } as never, ctx as never);
+		}
+		const r3 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		expect(reminderText(r3)).toContain("todo list");
+
+		// Turn 4: successful todo call resets baseline to 4.
+		turnStart({ turnIndex: 4 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "updated"), ctx as never);
+		turnEnd({ turnIndex: 4 } as never, ctx as never);
+
+		// Turn 5: 5-4 = 1 < 2 → no reminder.
+		turnStart({ turnIndex: 5 } as never, ctx as never);
+		const r5 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		expect(reminderText(r5)).toBeUndefined();
+	});
+
+	it("does NOT reset the baseline when a todo call fails", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+		await seedInProgress(tool, ctx);
+
+		turnStart({ turnIndex: 1 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "created"), ctx as never);
+		turnEnd({ turnIndex: 1 } as never, ctx as never);
+
+		// Turn 2: a FAILED todo call must not advance the baseline.
+		turnStart({ turnIndex: 2 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "boom", true), ctx as never);
+		turnEnd({ turnIndex: 2 } as never, ctx as never);
+
+		// Turn 3: still stale (3-1 = 2) → reminder fires.
+		turnStart({ turnIndex: 3 } as never, ctx as never);
+		const r3 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		expect(reminderText(r3)).toContain("todo list");
+	});
+
+	it("does not remind when no task is in_progress", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+		await tool.execute?.(
+			"tc",
+			{ action: "create", subject: "done" } as never,
+			undefined as never,
+			undefined as never,
+			ctx as never,
+		);
+		await tool.execute?.(
+			"tc",
+			{ action: "update", id: 1, status: "completed" } as never,
+			undefined as never,
+			undefined as never,
+			ctx as never,
+		);
+
+		turnStart({ turnIndex: 1 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "done"), ctx as never);
+		turnEnd({ turnIndex: 1 } as never, ctx as never);
+
+		// 10 silent turns — nothing in_progress, so never a reminder.
+		for (let t = 2; t <= 11; t++) {
+			turnStart({ turnIndex: t } as never, ctx as never);
+			const r = toolResult(toolResultEvent("bash", "out"), ctx as never);
+			expect(reminderText(r)).toBeUndefined();
+			turnEnd({ turnIndex: t } as never, ctx as never);
+		}
+	});
+
+	it("keeps parent and child turn counters isolated", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const parent = createMockCtx({ sessionId: "parent" });
+		const child = createMockCtx({ sessionId: "child" });
+		await sessionStart({} as never, parent as never);
+		await sessionStart({} as never, child as never);
+
+		// Parent has an in_progress task and a baseline at turn 1.
+		await seedInProgress(tool, parent);
+		turnStart({ turnIndex: 1 } as never, parent as never);
+		toolResult(toolResultEvent("todo", "created"), parent as never);
+		turnEnd({ turnIndex: 1 } as never, parent as never);
+
+		// Child churns 10 turns doing bash; it has no in_progress tasks, so its
+		// activity must not influence the parent's counters.
+		for (let t = 1; t <= 10; t++) {
+			turnStart({ turnIndex: t } as never, child as never);
+			toolResult(toolResultEvent("bash", "out"), child as never);
+			turnEnd({ turnIndex: t } as never, child as never);
+		}
+
+		// Parent is now stale (3-1 = 2) → reminder fires.
+		for (let t = 2; t <= 3; t++) {
+			turnStart({ turnIndex: t } as never, parent as never);
+			turnEnd({ turnIndex: t } as never, parent as never);
+		}
+		const r = toolResult(toolResultEvent("bash", "out"), parent as never);
+		expect(reminderText(r)).toContain("todo list");
+
+		// The child's own tool results never carried a reminder.
+		expect(getActivity("child").lastTodoTurn).toBeUndefined();
+		expect(getActivity("parent").lastTodoTurn).toBe(1);
+	});
+});
+
+describe("rpiv-todo — compaction resync hint", () => {
+	it("injects one resync hint on the next before_agent_start and clears the flag", async () => {
+		const { sessionStart, sessionCompact, beforeAgentStart } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+
+		await sessionCompact({} as never, ctx as never);
+
+		const first = beforeAgentStart(
+			{ type: "before_agent_start", prompt: "do it", systemPrompt: "base", systemPromptOptions: {} } as never,
+			ctx as never,
+		) as { systemPrompt?: string } | undefined;
+		expect(first?.systemPrompt).toContain("todo list");
+
+		// Flag cleared → second start carries no hint.
+		const second = beforeAgentStart(
+			{ type: "before_agent_start", prompt: "do it", systemPrompt: "base", systemPromptOptions: {} } as never,
+			ctx as never,
+		);
+		expect(second).toBeUndefined();
+	});
+
+	it("injects no hint without a preceding compaction", async () => {
+		const { sessionStart, beforeAgentStart } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+
+		const result = beforeAgentStart(
+			{ type: "before_agent_start", prompt: "do it", systemPrompt: "base", systemPromptOptions: {} } as never,
+			ctx as never,
+		);
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("rpiv-todo — stale/cooldown config getters", () => {
+	it("returns the defaults when no config is present", () => {
+		removeConfig();
+		expect(getStaleAfterTurns()).toBe(DEFAULT_STALE_AFTER_TURNS);
+		expect(getReminderCooldownTurns()).toBe(DEFAULT_REMINDER_COOLDOWN_TURNS);
+	});
+
+	it("returns configured positive integers", () => {
+		writeConfig({ staleAfterTurns: 3, reminderCooldownTurns: 5 });
+		expect(getStaleAfterTurns()).toBe(3);
+		expect(getReminderCooldownTurns()).toBe(5);
+	});
+
+	it("falls back to the default for invalid values (0, negative, non-number)", () => {
+		writeConfig({ staleAfterTurns: 0, reminderCooldownTurns: -2 });
+		expect(getStaleAfterTurns()).toBe(DEFAULT_STALE_AFTER_TURNS);
+		expect(getReminderCooldownTurns()).toBe(DEFAULT_REMINDER_COOLDOWN_TURNS);
+
+		writeConfig({ staleAfterTurns: "twelve", reminderCooldownTurns: 2.5 });
+		expect(getStaleAfterTurns()).toBe(DEFAULT_STALE_AFTER_TURNS);
+		expect(getReminderCooldownTurns()).toBe(2);
+	});
+});
+
+describe("rpiv-todo — reviewer fix regressions", () => {
+	it("turn-0 baseline works: a successful todo call in turn 0 still enables stale reminders", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+		await seedInProgress(tool, ctx);
+
+		// Pi resets turnIndex to 0 on agent_start, so the FIRST successful todo
+		// call may legitimately happen in turn 0 → lastTodoTurn = 0. This must
+		// NOT be confused with "no baseline yet" (the old `=== 0` sentinel would
+		// have permanently disabled reminders for this run).
+		turnStart({ turnIndex: 0 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "created"), ctx as never);
+		turnEnd({ turnIndex: 0 } as never, ctx as never);
+		expect(getActivity("parent").lastTodoTurn).toBe(0);
+
+		// Turn 1: 1-0 = 1 < staleAfter(2) → no reminder.
+		turnStart({ turnIndex: 1 } as never, ctx as never);
+		const r1 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		turnEnd({ turnIndex: 1 } as never, ctx as never);
+		expect(reminderText(r1)).toBeUndefined();
+
+		// Turn 2: 2-0 = 2 >= staleAfter(2) → reminder fires.
+		turnStart({ turnIndex: 2 } as never, ctx as never);
+		const r2 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		expect(reminderText(r2)).toContain("todo list");
+	});
+
+	it("a successful todo call in an already-stale turn injects NO reminder on that todo result", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+		await seedInProgress(tool, ctx);
+
+		// Baseline at turn 0.
+		turnStart({ turnIndex: 0 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "created"), ctx as never);
+		turnEnd({ turnIndex: 0 } as never, ctx as never);
+
+		// Turn 2 is already stale (2-0 >= 2), but this turn SYNCES via a todo
+		// call. The todo result itself must carry no "please call todo list".
+		turnStart({ turnIndex: 2 } as never, ctx as never);
+		const syncResult = toolResult(toolResultEvent("todo", "updated"), ctx as never);
+		expect(reminderText(syncResult)).toBeUndefined();
+		turnEnd({ turnIndex: 2 } as never, ctx as never);
+		expect(getActivity("parent").lastTodoTurn).toBe(2);
+
+		// Turn 3: 3-2 = 1 < staleAfter(2) → still no reminder after the sync.
+		turnStart({ turnIndex: 3 } as never, ctx as never);
+		const r3 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		expect(reminderText(r3)).toBeUndefined();
+	});
+
+	it("a failed compaction clears the resync hint so no false 'restored' claim is injected", async () => {
+		const { sessionStart, sessionCompact, sessionCompactFailed, beforeAgentStart } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+
+		// Compaction sets the pending resync flag…
+		await sessionCompact({} as never, ctx as never);
+		expect(getActivity("parent").compactionResyncPending).toBe(true);
+
+		// …but it FAILS/aborts → the flag must be cleared, and the next
+		// before_agent_start must NOT inject a "state restored" hint (the session
+		// was never rewritten, so the model's working memory was not lost).
+		await sessionCompactFailed({} as never, ctx as never);
+		expect(getActivity("parent").compactionResyncPending).toBeUndefined();
+
+		const result = beforeAgentStart(
+			{ type: "before_agent_start", prompt: "do it", systemPrompt: "base", systemPromptOptions: {} } as never,
+			ctx as never,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("a successful todo call resets the baseline across an otherwise-stale gap", async () => {
+		const { sessionStart, turnStart, turnEnd, toolResult, tool } = setup();
+		const ctx = createMockCtx({ sessionId: "parent" });
+		await sessionStart({} as never, ctx as never);
+		await seedInProgress(tool, ctx);
+
+		turnStart({ turnIndex: 0 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "created"), ctx as never);
+		turnEnd({ turnIndex: 0 } as never, ctx as never);
+
+		// Turn 2 stale → reminder, and lastReminderTurn = 2.
+		turnStart({ turnIndex: 2 } as never, ctx as never);
+		toolResult(toolResultEvent("bash", "out"), ctx as never);
+		turnEnd({ turnIndex: 2 } as never, ctx as never);
+
+		// Turn 4 syncs (todo success) → baseline advances to 4, so turn 5 (5-4=1)
+		// is not stale even though cooldown (2) would also have suppressed a
+		// reminder.
+		turnStart({ turnIndex: 4 } as never, ctx as never);
+		toolResult(toolResultEvent("todo", "updated"), ctx as never);
+		turnEnd({ turnIndex: 4 } as never, ctx as never);
+		expect(getActivity("parent").lastTodoTurn).toBe(4);
+
+		turnStart({ turnIndex: 5 } as never, ctx as never);
+		const r5 = toolResult(toolResultEvent("bash", "out"), ctx as never);
+		expect(reminderText(r5)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
fix(rpiv-todo): stale-todo reminders and compaction resync

## Summary

Closes #159.

- **Stale-todo reminders**: a per-session runtime tracker records how many turns the model has gone without a successful `todo` call. Past `staleAfterTurns` (default 12) with tasks still `in_progress`, a reminder is injected into an arbitrary tool result so the model sees it while busy — bash/edit gaps are exactly when todo updates drop — not only on the next `todo` call. A successful `todo` call resets the baseline; `reminderCooldownTurns` (default 12) sets the minimum gap between reminders.
- **Compaction resync**: after `session_compact`, the todo data survives (it is replayed from the branch) but the model's working memory of the list is gone. `before_agent_start` now injects a one-shot hint — re-read the tasks, don't assume the pre-compaction state — appended to the system prompt (no extra LLM call, no `agent_end → sendMessage` loop).
- Both thresholds are configurable via `config.json` and read fresh on every call; no `/reload` needed.

## Root cause

- `Task` carries no timestamp or turn counter, so the plugin could not detect a stale task. A reminder only on the next `todo` call is insufficient: the model drifts during long gaps with no todo traffic (#159).
- After compaction the list is replayed into the store, but the model's context no longer contains it, so it may invent task states or forget tasks are open.

## Design constraints

- Runtime-only: nothing is persisted, the `Task` shape and replay format are untouched, preserving cross-version replay compatibility.
- Turn counting is scoped to one agent run (Pi resets `turnIndex` to 0 on each `agent_start`). Cross-run staleness is deliberately not tracked: the human operator sees the todo list in the TUI at all times, so a reminder aimed at them adds no information; only the model's own in-run drift matters.
- No auto-completion: `in_progress` status is only ever changed by an explicit `todo` call. A stale reminder never marks a task done.
- `session_compact_failed` clears the pending resync flag: a failed compaction never rewrote the session, so claiming "state restored" would be a false hint.

## Files changed

- `state/activity-tracker.ts` (new) — per-session runtime turn tracker, never persisted, never replayed
- `index.ts` — `turn_start` / `turn_end` / `tool_result` handlers; `session_compact` / `session_compact_failed` / `before_agent_start` handlers
- `config.ts` — `getStaleAfterTurns` / `getReminderCooldownTurns` (defaults 12, validation + fallback)
- `state/store.ts` — `__resetState` also clears runtime activity (test setup)
- `package.json` — ship `state/activity-tracker.ts`
- `locales/{en,de,es,fr,pt,pt-BR,ru,uk,zh}.json` — `reminder.stale` (with `{n}` interpolation) and `resync.after_compact`; English fallbacks at every call site
- `todo.activity.test.ts` (new) — 14 tests
- `CHANGELOG.md` — entry under `[Unreleased]`

## Validation

- `npx vitest run packages/rpiv-todo/todo.activity.test.ts` — 14 passed
- `npx tsc --noEmit -p tsconfig.base.json` — clean
- `npx biome check packages/rpiv-todo` — clean
- `npm test` — 261 files, 5,035 tests passed
- Live in a real Pi session: reminder fired after the configured threshold with cooldown honored; a successful `todo list` reset the baseline; no reminder without `in_progress` tasks; the todo list survived `/compact` intact.

## Notes

- Non-English locale strings are generated translations — native-speaker review welcome before merge.
