### PR TITLE
feat(rpiv-todo): batch create via tasks[]

### DIFF
--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `create` accepts `tasks[]` as a one-of with `subject`, so a plan can land in one call. The batch is all-or-nothing; items cannot `blockedBy` each other (#44).
+
 ## [2.7.1] - 2026-08-24
 
 ## [2.7.0] - 2026-08-21

--- a/packages/rpiv-todo/docs/tool-schema.md
+++ b/packages/rpiv-todo/docs/tool-schema.md
@@ -8,7 +8,7 @@ for the `todo` tool registered by
 
 | Action | Required params | What it does |
 | --- | --- | --- |
-| `create` | `subject` | Adds a task in `pending`, assigns the next id. |
+| `create` | `subject` or `tasks[]` (one-of) | Adds one task, or several independent tasks, in `pending`. |
 | `update` | `id` + at least one mutable field | Changes status, fields, or dependencies. |
 | `list` | — | Returns all tasks, optionally filtered by `status`. |
 | `get` | `id` | Returns one task with its `blockedBy` and reverse `blocks` edges. |
@@ -21,9 +21,17 @@ for the `todo` tool registered by
 todo({
   action: "create" | "update" | "list" | "get" | "delete" | "clear",
 
-  // create-only
-  subject?: string,                   // required for create
-  blockedBy?: number[],               // initial dependency ids
+  // create-only (one-of: subject or tasks[])
+  subject?: string,                   // required for single create
+  blockedBy?: number[],               // initial dependency ids (single create)
+  tasks?: Array<{                     // batch create; independent items only
+    subject: string,
+    description?: string,
+    activeForm?: string,
+    blockedBy?: number[],             // existing ids only; no sibling refs
+    owner?: string,
+    metadata?: Record<string, unknown>,
+  }>,
 
   // create + update
   description?: string,               // long-form detail
@@ -45,6 +53,13 @@ todo({
   includeDeleted?: boolean,           // default false — hides tombstones
 })
 ```
+
+`create` takes either `subject` (one task) or `tasks[]` (several independent
+tasks). Passing both is rejected. The batch is validated first and committed
+together: one bad item fails the whole call and leaves the list unchanged.
+Items in `tasks[]` cannot `blockedBy` each other; those ids do not exist until
+the call commits. Create the prerequisite first, then the dependent with
+`blockedBy`. `blockedBy` on a batch item may name a task that already exists.
 
 `update` merges `metadata` key by key into the existing record; passing `null`
 for a key removes it, and emptying the record drops the field entirely.
@@ -111,6 +126,7 @@ survive `/reload` and compaction without any disk writes.
 | Situation | `content[0].text` |
 | --- | --- |
 | Created | `Created #3: Write the parser (pending)` |
+| Created a batch | one `Created #N: … (pending)` line per task, joined by newlines |
 | Updated with a status change | `Updated #3 (pending → in_progress)` |
 | Updated without a status change | `Updated #3` |
 | Update that changed nothing | `No change: #3 already matches the requested values (status: in_progress)` |
@@ -127,9 +143,13 @@ that it was a no-op instead of a fresh `Updated #N`.
 
 | Message | Cause |
 | --- | --- |
-| `subject required for create` | `create` without a non-blank `subject`. |
+| `subject required for create` | `create` without a non-blank `subject` and without `tasks[]`. |
+| `create requires subject or tasks[], not both` | `create` with both `subject` and `tasks[]`. |
+| `tasks[] must be non-empty` | `create` with `tasks: []`. |
+| `tasks[N]: subject required for create` | A batch item with a blank or missing subject. |
 | `blockedBy: #N not found` | `create` naming an unknown dependency. |
 | `blockedBy: #N is deleted` | `create` naming a tombstoned dependency. |
+| `blockedBy: #N is another item in this batch; create the prerequisite first, then the dependent with blockedBy` | A `tasks[]` item naming a sibling that this call would assign. |
 | `id required for update` / `get` / `delete` | `id` omitted. |
 | `#N not found` | No task with that id. |
 | `update requires at least one mutable field: subject, description, activeForm, status, owner, metadata, addBlockedBy, or removeBlockedBy` | `update` with only an `id`. |
@@ -144,9 +164,10 @@ carries the bare message. Task state is unchanged.
 
 ## Prompt guidance
 
-The tool ships a `promptSnippet` and eight `promptGuidelines` bullets telling the
-model when to open a list, to keep exactly one task `in_progress`, to mark work
-completed immediately rather than in batches, never to complete a task with
-failing tests, and the literal `update {id, status}` call shape for changing a
-task's status. Both are overridable — see
+The tool ships a `promptSnippet` and nine `promptGuidelines` bullets telling the
+model when to open a list, to create independent tasks in one `tasks[]` call,
+to keep exactly one task `in_progress`, to mark work completed immediately
+rather than in batches, never to complete a task with failing tests, and the
+literal `update {id, status}` call shape for changing a task's status. Both are
+overridable — see
 [configuration.md](./configuration.md#guidance).

--- a/packages/rpiv-todo/state/state-reducer.test.ts
+++ b/packages/rpiv-todo/state/state-reducer.test.ts
@@ -43,7 +43,98 @@ describe("applyTaskMutation — create", () => {
 		expect(result.state.tasks[0]).toMatchObject({ id: 1, subject: "write tests", status: "pending" });
 		expect(result.state.nextId).toBe(2);
 		expect(result.state.tasks).not.toBe(state.tasks);
-		expect(result.op).toEqual({ kind: "create", taskId: 1 });
+		expect(result.op).toEqual({ kind: "create", taskIds: [1] });
+	});
+
+	it("rejects subject and tasks[] together", () => {
+		const result = applyTaskMutation(emptyState(), "create", {
+			subject: "one",
+			tasks: [{ subject: "two" }],
+		});
+		expect(result.op).toEqual({ kind: "error", message: "create requires subject or tasks[], not both" });
+		expect(result.state.tasks).toHaveLength(0);
+		expect(result.state.nextId).toBe(1);
+	});
+
+	it("rejects an empty tasks[] batch", () => {
+		const result = applyTaskMutation(emptyState(), "create", { tasks: [] });
+		expect(result.op).toEqual({ kind: "error", message: "tasks[] must be non-empty" });
+		expect(result.state.nextId).toBe(1);
+	});
+
+	it("rejects a blank subject inside tasks[] and creates nothing", () => {
+		const result = applyTaskMutation(emptyState(), "create", {
+			tasks: [{ subject: "ok" }, { subject: "  " }],
+		});
+		expect(result.op).toEqual({ kind: "error", message: "tasks[1]: subject required for create" });
+		expect(result.state.tasks).toHaveLength(0);
+		expect(result.state.nextId).toBe(1);
+	});
+
+	it("creates consecutive ids and preserves per-item fields", () => {
+		const result = applyTaskMutation(emptyState(), "create", {
+			tasks: [
+				{ subject: "Inspect existing implementation" },
+				{
+					subject: "Add tests for batch create",
+					description: "reducer + envelope",
+					owner: "rpiv-todo",
+				},
+			],
+		});
+		expect(result.op).toEqual({ kind: "create", taskIds: [1, 2] });
+		expect(result.state.nextId).toBe(3);
+		expect(result.state.tasks).toEqual([
+			{ id: 1, subject: "Inspect existing implementation", status: "pending" },
+			{
+				id: 2,
+				subject: "Add tests for batch create",
+				status: "pending",
+				description: "reducer + envelope",
+				owner: "rpiv-todo",
+			},
+		]);
+	});
+
+	it("allows batch blockedBy on a task that already exists", () => {
+		const state = stateWith(task({ id: 1, subject: "root" }));
+		const result = applyTaskMutation(state, "create", {
+			tasks: [{ subject: "leaf", blockedBy: [1] }],
+		});
+		expect(result.op).toEqual({ kind: "create", taskIds: [2] });
+		expect(result.state.tasks[1]).toMatchObject({ id: 2, subject: "leaf", blockedBy: [1] });
+	});
+
+	it("rejects sibling blockedBy and leaves state unchanged", () => {
+		const result = applyTaskMutation(emptyState(), "create", {
+			tasks: [{ subject: "first" }, { subject: "second", blockedBy: [1] }],
+		});
+		expect(result.op).toEqual({
+			kind: "error",
+			message:
+				"blockedBy: #1 is another item in this batch; create the prerequisite first, then the dependent with blockedBy",
+		});
+		expect(result.state.tasks).toHaveLength(0);
+		expect(result.state.nextId).toBe(1);
+	});
+
+	it("rejects a dangling blockedBy in a batch and creates nothing", () => {
+		const result = applyTaskMutation(emptyState(), "create", {
+			tasks: [{ subject: "ok" }, { subject: "bad", blockedBy: [99] }],
+		});
+		expect(result.op).toEqual({ kind: "error", message: "blockedBy: #99 not found" });
+		expect(result.state.tasks).toHaveLength(0);
+		expect(result.state.nextId).toBe(1);
+	});
+
+	it("rejects a deleted blockedBy in a batch and creates nothing", () => {
+		const state = stateWith(task({ id: 1, subject: "done", status: "deleted" }));
+		const result = applyTaskMutation(state, "create", {
+			tasks: [{ subject: "ok" }, { subject: "bad", blockedBy: [1] }],
+		});
+		expect(result.op).toEqual({ kind: "error", message: "blockedBy: #1 is deleted" });
+		expect(result.state.tasks).toHaveLength(1);
+		expect(result.state.nextId).toBe(2);
 	});
 });
 

--- a/packages/rpiv-todo/state/state-reducer.ts
+++ b/packages/rpiv-todo/state/state-reducer.ts
@@ -13,7 +13,7 @@ import { detectCycle } from "./task-graph.js";
  * `op.kind === "error"` without a side-channel boolean.
  */
 export type Op =
-	| { kind: "create"; taskId: number }
+	| { kind: "create"; taskIds: number[] }
 	| { kind: "update"; id: number; fromStatus: TaskStatus; toStatus: TaskStatus; changed: boolean }
 	| { kind: "delete"; id: number; subject: string }
 	| { kind: "list"; statusFilter?: TaskStatus; includeDeleted: boolean }
@@ -28,6 +28,42 @@ export interface ApplyResult {
 
 function errorResult(state: TaskState, message: string): ApplyResult {
 	return { state, op: { kind: "error", message } };
+}
+
+function asCreateItem(value: unknown): TaskMutationParams | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+	return value as TaskMutationParams;
+}
+
+function buildCreatedTask(id: number, spec: TaskMutationParams, subject: string): Task {
+	const newTask: Task = {
+		id,
+		subject,
+		status: "pending",
+	};
+	if (spec.description) newTask.description = spec.description;
+	if (spec.activeForm) newTask.activeForm = spec.activeForm;
+	if (spec.blockedBy?.length) newTask.blockedBy = [...spec.blockedBy];
+	if (spec.owner) newTask.owner = spec.owner;
+	if (spec.metadata) newTask.metadata = { ...spec.metadata };
+	return newTask;
+}
+
+function validateCreateBlockedBy(
+	state: TaskState,
+	blockedBy: number[] | undefined,
+	siblingIds: ReadonlySet<number>,
+): string | undefined {
+	if (!blockedBy?.length) return undefined;
+	for (const dep of blockedBy) {
+		if (siblingIds.has(dep)) {
+			return `blockedBy: #${dep} is another item in this batch; create the prerequisite first, then the dependent with blockedBy`;
+		}
+		const depTask = state.tasks.find((t) => t.id === dep);
+		if (!depTask) return `blockedBy: #${dep} not found`;
+		if (depTask.status === "deleted") return `blockedBy: #${dep} is deleted`;
+	}
+	return undefined;
 }
 
 function sameNumberList(a: number[] | undefined, b: number[] | undefined): boolean {
@@ -78,31 +114,47 @@ function taskChanged(before: Task, after: Task): boolean {
 export function applyTaskMutation(state: TaskState, action: TaskAction, params: TaskMutationParams): ApplyResult {
 	switch (action) {
 		case "create": {
+			const hasSubject = Boolean(params.subject?.trim());
+			const batch = params.tasks;
+
+			if (Array.isArray(batch) && hasSubject) {
+				return errorResult(state, "create requires subject or tasks[], not both");
+			}
+
+			if (Array.isArray(batch)) {
+				if (batch.length === 0) {
+					return errorResult(state, "tasks[] must be non-empty");
+				}
+				const items: Array<{ spec: TaskMutationParams; subject: string }> = [];
+				for (let i = 0; i < batch.length; i++) {
+					const spec = asCreateItem(batch[i]);
+					const subject = spec?.subject;
+					if (!spec || !subject?.trim()) {
+						return errorResult(state, `tasks[${i}]: subject required for create`);
+					}
+					items.push({ spec, subject });
+				}
+				const siblingIds = new Set(items.map((_, i) => state.nextId + i));
+				for (const item of items) {
+					const blockedError = validateCreateBlockedBy(state, item.spec.blockedBy, siblingIds);
+					if (blockedError) return errorResult(state, blockedError);
+				}
+				const created = items.map((item, i) => buildCreatedTask(state.nextId + i, item.spec, item.subject));
+				return {
+					state: { tasks: [...state.tasks, ...created], nextId: state.nextId + created.length },
+					op: { kind: "create", taskIds: created.map((t) => t.id) },
+				};
+			}
+
 			if (!params.subject?.trim()) {
 				return errorResult(state, "subject required for create");
 			}
-			if (params.blockedBy?.length) {
-				for (const dep of params.blockedBy) {
-					const depTask = state.tasks.find((t) => t.id === dep);
-					if (!depTask) return errorResult(state, `blockedBy: #${dep} not found`);
-					if (depTask.status === "deleted") return errorResult(state, `blockedBy: #${dep} is deleted`);
-				}
-			}
-			const newTask: Task = {
-				id: state.nextId,
-				subject: params.subject,
-				status: "pending",
-			};
-			if (params.description) newTask.description = params.description;
-			if (params.activeForm) newTask.activeForm = params.activeForm;
-			if (params.blockedBy?.length) newTask.blockedBy = [...params.blockedBy];
-			if (params.owner) newTask.owner = params.owner;
-			if (params.metadata) newTask.metadata = { ...params.metadata };
-
-			const newTasks = [...state.tasks, newTask];
+			const blockedError = validateCreateBlockedBy(state, params.blockedBy, new Set());
+			if (blockedError) return errorResult(state, blockedError);
+			const newTask = buildCreatedTask(state.nextId, params, params.subject);
 			return {
-				state: { tasks: newTasks, nextId: state.nextId + 1 },
-				op: { kind: "create", taskId: newTask.id },
+				state: { tasks: [...state.tasks, newTask], nextId: state.nextId + 1 },
+				op: { kind: "create", taskIds: [newTask.id] },
 			};
 		}
 

--- a/packages/rpiv-todo/todo.register.test.ts
+++ b/packages/rpiv-todo/todo.register.test.ts
@@ -44,6 +44,7 @@ describe("registerTodoTool — registration shape", () => {
 		for (const action of ["create", "update", "list", "get", "delete", "clear"]) {
 			expect(raw).toContain(action);
 		}
+		expect(raw).toContain("tasks");
 	});
 });
 
@@ -54,6 +55,20 @@ describe("registerTodoTool — execute mutates module state", () => {
 		expect((r1!.details as TaskDetails).action).toBe("create");
 		const r2 = await call(tool, { action: "list" });
 		expect(r2?.content[0]).toMatchObject({ text: expect.stringContaining("first") });
+	});
+
+	it("create with tasks[] seeds every row in one call", async () => {
+		const { tool } = setup();
+		const r = await call(tool, {
+			action: "create",
+			tasks: [{ subject: "Inspect existing implementation" }, { subject: "Add tests for batch create" }],
+		});
+		expect(r?.content[0]).toMatchObject({
+			text: "Created #1: Inspect existing implementation (pending)\nCreated #2: Add tests for batch create (pending)",
+		});
+		const d = r?.details as TaskDetails;
+		expect(d.tasks.map((t) => t.subject)).toEqual(["Inspect existing implementation", "Add tests for batch create"]);
+		expect(d.nextId).toBe(3);
 	});
 
 	it("clear resets module state and nextId", async () => {
@@ -80,6 +95,16 @@ describe("registerTodoTool — renderCall", () => {
 		expect(text).toContain("todo ");
 		expect(text).toContain("+");
 		expect(text).toContain("hello");
+	});
+
+	it("create action with tasks[] renders the batch size", () => {
+		const { tool } = setup();
+		const node = tool.renderCall?.(
+			{ action: "create", tasks: [{ subject: "a" }, { subject: "b" }] } as never,
+			theme,
+			undefined as never,
+		) as unknown as Text;
+		expect((node as unknown as { text: string }).text).toContain("2 tasks");
 	});
 
 	it("update action renders '#id' when the task has not been registered yet", () => {

--- a/packages/rpiv-todo/todo.ts
+++ b/packages/rpiv-todo/todo.ts
@@ -60,6 +60,7 @@ export const DEFAULT_PROMPT_GUIDELINES: string[] = [
 	"Task status is a 4-state machine: pending → in_progress → completed, plus deleted as a tombstone. Pass activeForm (present-continuous label, e.g. 'researching existing tool') when marking in_progress.",
 	'To change a task\'s status, call update with the task id and the target status, e.g. {"action":"update","id":3,"status":"completed"} or {"action":"update","id":3,"status":"in_progress","activeForm":"writing tests"}. status is the field that changes the task; an update without a mutable field (status or another) is rejected.',
 	"Use blockedBy to express dependencies (A is blocked by B). On create, pass blockedBy as the initial set. On update, use addBlockedBy / removeBlockedBy (additive merge — do not resend the full array). Cycles are rejected.",
+	"To create several independent tasks at once, pass create with tasks: [{subject}, ...]. Do not also pass subject. tasks[] cannot blockedBy each other (ids do not exist until the call commits); create the prerequisite first, then the dependent with blockedBy. Dependency chains stay single-create.",
 	"list hides tombstoned (deleted) tasks by default; pass includeDeleted:true to see them. Pass status to filter by a single status.",
 	"Subject must be short and imperative (e.g. 'Research existing tool'); description is for long-form detail. activeForm is a present-continuous label shown while in_progress.",
 ];

--- a/packages/rpiv-todo/tool/response-envelope.test.ts
+++ b/packages/rpiv-todo/tool/response-envelope.test.ts
@@ -14,7 +14,7 @@ const t = (over: Partial<Task> & { id: number; subject: string }): Task => ({ st
 describe("formatContent", () => {
 	it("create — 'Created #id: subject (pending)'", () => {
 		const state = stateWith(t({ id: 1, subject: "alpha" }));
-		expect(formatContent({ kind: "create", taskId: 1 }, state)).toBe("Created #1: alpha (pending)");
+		expect(formatContent({ kind: "create", taskIds: [1] }, state)).toBe("Created #1: alpha (pending)");
 	});
 
 	it("update — emits transition tuple when statuses differ", () => {
@@ -111,9 +111,16 @@ describe("formatContent", () => {
 		);
 	});
 
-	it("create — defensive fallback when op.taskId is unknown to state", () => {
+	it("create — defensive fallback when an op.taskIds entry is unknown to state", () => {
 		// Defensive branch — exercises the early-return when find() returns undefined.
-		expect(formatContent({ kind: "create", taskId: 999 }, stateWith())).toBe("Created #999");
+		expect(formatContent({ kind: "create", taskIds: [999] }, stateWith())).toBe("Created #999");
+	});
+
+	it("create — one Created line per taskIds entry", () => {
+		const state = stateWith(t({ id: 1, subject: "alpha" }), t({ id: 2, subject: "beta" }));
+		expect(formatContent({ kind: "create", taskIds: [1, 2] }, state)).toBe(
+			"Created #1: alpha (pending)\nCreated #2: beta (pending)",
+		);
 	});
 
 	it("error — 'Error: <message>'", () => {
@@ -126,7 +133,7 @@ describe("formatContent", () => {
 describe("buildToolResult", () => {
 	it("envelope.details mirrors the canonical TaskDetails shape on success", () => {
 		const state = stateWith(t({ id: 1, subject: "alpha" }));
-		const env = buildToolResult("create", { subject: "alpha" }, state, { kind: "create", taskId: 1 });
+		const env = buildToolResult("create", { subject: "alpha" }, state, { kind: "create", taskIds: [1] });
 		expect(env).toEqual({
 			content: [{ type: "text", text: "Created #1: alpha (pending)" }],
 			details: { action: "create", params: { subject: "alpha" }, tasks: state.tasks, nextId: state.nextId },
@@ -156,7 +163,7 @@ describe("formatContent — control characters in model-controlled fields", () =
 		const state = stateWith(
 			t({ id: 1, subject: "evil\u001b[31m", status: "in_progress", activeForm: "clear\u001b[2Jing" }),
 		);
-		expect(formatContent({ kind: "create", taskId: 1 }, state)).toBe("Created #1: evil (pending)");
+		expect(formatContent({ kind: "create", taskIds: [1] }, state)).toBe("Created #1: evil (pending)");
 		expect(formatContent({ kind: "list", includeDeleted: false }, state)).toBe("[in_progress] #1 evil (clearing)");
 	});
 });

--- a/packages/rpiv-todo/tool/response-envelope.ts
+++ b/packages/rpiv-todo/tool/response-envelope.ts
@@ -44,10 +44,14 @@ function formatGetLines(task: Task, state: TaskState): string {
 export function formatContent(op: Op, state: TaskState): string {
 	switch (op.kind) {
 		case "create": {
-			const t = state.tasks.find((x) => x.id === op.taskId);
-			// Defensive — `op.taskId` always resolves on success path.
-			if (!t) return `Created #${op.taskId}`;
-			return `Created #${t.id}: ${sanitizeTerminalText(t.subject)} (pending)`;
+			// Defensive — each `op.taskIds` entry resolves on the success path.
+			return op.taskIds
+				.map((id) => {
+					const created = state.tasks.find((x) => x.id === id);
+					if (!created) return `Created #${id}`;
+					return `Created #${created.id}: ${sanitizeTerminalText(created.subject)} (pending)`;
+				})
+				.join("\n");
 		}
 		case "update": {
 			if (!op.changed) {

--- a/packages/rpiv-todo/tool/types.ts
+++ b/packages/rpiv-todo/tool/types.ts
@@ -57,6 +57,16 @@ export interface TaskDetails {
  * signature (`[key: string]: unknown`) lets the runtime pass through TypeBox
  * `Static<typeof TodoParamsSchema>` without `as` casts.
  */
+/** One item in a batch `create` `tasks[]` payload. Same create-shaped fields as a single create, minus nested `tasks`. */
+export interface CreateTaskInput {
+	subject?: string;
+	description?: string;
+	activeForm?: string;
+	blockedBy?: number[];
+	owner?: string;
+	metadata?: Record<string, unknown>;
+}
+
 export interface TaskMutationParams {
 	[key: string]: unknown;
 	subject?: string;
@@ -70,6 +80,8 @@ export interface TaskMutationParams {
 	metadata?: Record<string, unknown>;
 	id?: number;
 	includeDeleted?: boolean;
+	/** Batch create items. One-of with `subject` on `create`. */
+	tasks?: CreateTaskInput[];
 }
 
 // ---------------------------------------------------------------------------
@@ -78,9 +90,35 @@ export interface TaskMutationParams {
 // pre-refactor schema at `packages/rpiv-todo/todo.ts:512-573`.
 // ---------------------------------------------------------------------------
 
+const CreateTaskInputSchema = Type.Object({
+	subject: Type.Optional(Type.String({ description: "Task subject line (required)" })),
+	description: Type.Optional(Type.String({ description: "Long-form task description" })),
+	activeForm: Type.Optional(
+		Type.String({
+			description: "Present-continuous spinner label shown while status is in_progress (e.g. 'writing tests')",
+		}),
+	),
+	blockedBy: Type.Optional(
+		Type.Array(Type.Number(), {
+			description:
+				"Existing task ids this item waits on. Cannot name another item in this same batch; create the prerequisite first, then the dependent with blockedBy.",
+		}),
+	),
+	owner: Type.Optional(Type.String({ description: "Agent/owner assigned to this task" })),
+	metadata: Type.Optional(
+		Type.Record(Type.String(), Type.Unknown(), {
+			description: "Arbitrary metadata",
+		}),
+	),
+});
+
 export const TodoParamsSchema = Type.Object({
 	action: StringEnum(["create", "update", "list", "get", "delete", "clear"] as const),
-	subject: Type.Optional(Type.String({ description: "Task subject line (required for create)" })),
+	subject: Type.Optional(
+		Type.String({
+			description: "Task subject line (required for create unless tasks[] is set)",
+		}),
+	),
 	description: Type.Optional(Type.String({ description: "Long-form task description" })),
 	activeForm: Type.Optional(
 		Type.String({
@@ -122,6 +160,12 @@ export const TodoParamsSchema = Type.Object({
 	includeDeleted: Type.Optional(
 		Type.Boolean({
 			description: "If true, list action returns deleted (tombstoned) tasks as well. Default: false.",
+		}),
+	),
+	tasks: Type.Optional(
+		Type.Array(CreateTaskInputSchema, {
+			description:
+				"Batch create: independent tasks in one call, one-of with subject. The whole list is validated then committed together. Items cannot blockedBy each other; create the prerequisite first, then the dependent with blockedBy.",
 		}),
 	),
 });

--- a/packages/rpiv-todo/view/format.ts
+++ b/packages/rpiv-todo/view/format.ts
@@ -118,6 +118,8 @@ export function renderTodoCall(
 
 	if (args.action === "create" && args.subject) {
 		text += ` ${theme.fg("dim", sanitizeTerminalText(args.subject))}`;
+	} else if (args.action === "create" && Array.isArray(args.tasks)) {
+		text += ` ${theme.fg("dim", `${args.tasks.length} tasks`)}`;
 	} else if (
 		(args.action === "update" || args.action === "get" || args.action === "delete") &&
 		args.id !== undefined


### PR DESCRIPTION
Implements batch `create` from #44, following the maintainer reply: Option B (`tasks[]` one-of with `subject`), all-or-nothing commit, no sibling `blockedBy`.

```diff
 create
-  subject required → one pending task
+  subject XOR tasks[]
+  validate the whole list, then commit together
+  sibling blockedBy rejected (existing ids still allowed)
+  single-create output unchanged: Created #N: … (pending)
```

```text
create
  subject only        → one task, same content line as today
  tasks[]             → all-or-nothing batch, consecutive ids
  both / empty / blank item / dangling or deleted blockedBy
                      → error, tasks and nextId unchanged
  blockedBy: sibling  → "another item in this batch…"
  blockedBy: existing → allowed
```
