### PR TITLE
feat(rpiv-todo): add /todos clear command

### DIFF
--- a/packages/rpiv-todo/CHANGELOG.md
+++ b/packages/rpiv-todo/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `/todos clear` removes the entire current-session todo list, resets task IDs, updates the overlay immediately, and persists across reloads and branch navigation.
+
 ## [2.9.0] - 2026-09-01
 
 ## [2.8.0] - 2026-08-29

--- a/packages/rpiv-todo/README.md
+++ b/packages/rpiv-todo/README.md
@@ -41,7 +41,7 @@ input box, updating as work moves:
 
 Press `ctrl+shift+t` to collapse the panel to its heading plus a one-line hint,
 and again to expand it. Run `/todos` at any time to print the full list grouped
-by status.
+by status, or `/todos clear` to remove every task and reset task IDs.
 
 ## What you get
 

--- a/packages/rpiv-todo/docs/overlay.md
+++ b/packages/rpiv-todo/docs/overlay.md
@@ -17,10 +17,10 @@ The widget is mounted above the Pi editor under the key `rpiv-todos`.
 | Disposed | On the foreground session's shutdown. A child session shutting down leaves the overlay alone. |
 
 Task state is partitioned by session id, so parallel sessions cannot read or
-overwrite each other's lists. Nothing is written to disk: on session start,
-compaction, and session-tree changes, the list is rebuilt by walking the branch
-and taking the last `todo` tool result's snapshot, which replaces the whole list
-(last-write-wins).
+overwrite each other's lists. Nothing is written outside Pi's session history:
+on session start, compaction, and session-tree changes, the list is rebuilt by
+walking the branch. `todo` tool-result snapshots replace the whole list, while
+`/todos clear` markers reset it; the latest recognized entry wins.
 
 ## Anatomy of a row
 
@@ -105,7 +105,10 @@ row budget and auto-hiding:
 ```
 
 The header omits any count that is zero. Sections appear only when they have
-tasks. Tombstoned tasks are never listed.
+tasks. Tombstoned tasks are never listed. Run `/todos clear` to remove the
+entire list, including tombstones, and reset the next task id to `1`. The reset
+is stored in session history, so it survives reloads and follows branch
+navigation.
 
 - With no tasks: `No todos yet. Ask the agent to add some!`
 - In a non-interactive session: `/todos requires interactive mode`

--- a/packages/rpiv-todo/index.ts
+++ b/packages/rpiv-todo/index.ts
@@ -148,7 +148,10 @@ export default function (pi: ExtensionAPI, importOverlay: TodoOverlayImporter = 
 	}
 
 	registerTodoTool(pi);
-	registerTodosCommand(pi);
+	registerTodosCommand(pi, async (ctx) => {
+		if (sid(ctx) !== getActiveRenderSession()) return;
+		await updateTodoOverlay(true);
+	});
 
 	// Collapse/expand hotkey for the todo overlay. The key is resolved once at
 	// factory scope from config (register-once contract: a config change needs

--- a/packages/rpiv-todo/locales/de.json
+++ b/packages/rpiv-todo/locales/de.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "eingeklappt",
 
   "command.no_todos": "Noch keine Todos. Bitte den Agenten, welche hinzuzufügen!",
+  "command.cleared": "{count} Aufgaben gelöscht",
   "command.requires_interactive": "/todos erfordert den interaktiven Modus",
   "command.section.pending": "── Ausstehend ──",
   "command.section.in_progress": "── In Bearbeitung ──",

--- a/packages/rpiv-todo/locales/en.json
+++ b/packages/rpiv-todo/locales/en.json
@@ -10,6 +10,7 @@
   "overlay.collapsed": "collapsed",
 
   "command.no_todos": "No todos yet. Ask the agent to add some!",
+  "command.cleared": "Cleared {count} tasks",
   "command.requires_interactive": "/todos requires interactive mode",
   "command.section.pending": "── Pending ──",
   "command.section.in_progress": "── In Progress ──",

--- a/packages/rpiv-todo/locales/es.json
+++ b/packages/rpiv-todo/locales/es.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "contraído",
 
   "command.no_todos": "Sin tareas aún. ¡Pídele al agente que añada algunas!",
+  "command.cleared": "Se borraron {count} tareas",
   "command.requires_interactive": "/todos requiere modo interactivo",
   "command.section.pending": "── Pendientes ──",
   "command.section.in_progress": "── En curso ──",

--- a/packages/rpiv-todo/locales/fr.json
+++ b/packages/rpiv-todo/locales/fr.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "réduit",
 
   "command.no_todos": "Pas encore de tâches. Demandez à l'agent d'en ajouter !",
+  "command.cleared": "{count} tâches effacées",
   "command.requires_interactive": "/todos nécessite le mode interactif",
   "command.section.pending": "── En attente ──",
   "command.section.in_progress": "── En cours ──",

--- a/packages/rpiv-todo/locales/pt-BR.json
+++ b/packages/rpiv-todo/locales/pt-BR.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "recolhido",
 
   "command.no_todos": "Nenhuma tarefa ainda. Peça ao agente para adicionar algumas!",
+  "command.cleared": "{count} tarefas apagadas",
   "command.requires_interactive": "/todos requer modo interativo",
   "command.section.pending": "── Pendentes ──",
   "command.section.in_progress": "── Em andamento ──",

--- a/packages/rpiv-todo/locales/pt.json
+++ b/packages/rpiv-todo/locales/pt.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "recolhido",
 
   "command.no_todos": "Sem tarefas ainda. Peça ao agente para adicionar algumas!",
+  "command.cleared": "{count} tarefas limpas",
   "command.requires_interactive": "/todos requer modo interativo",
   "command.section.pending": "── Pendentes ──",
   "command.section.in_progress": "── Em curso ──",

--- a/packages/rpiv-todo/locales/ru.json
+++ b/packages/rpiv-todo/locales/ru.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "свёрнуто",
 
   "command.no_todos": "Задач пока нет. Попросите агента добавить!",
+  "command.cleared": "Очищено задач: {count}",
   "command.requires_interactive": "/todos требует интерактивного режима",
   "command.section.pending": "── Ожидание ──",
   "command.section.in_progress": "── В работе ──",

--- a/packages/rpiv-todo/locales/uk.json
+++ b/packages/rpiv-todo/locales/uk.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "згорнуто",
 
   "command.no_todos": "Завдань поки немає. Попросіть агента додати!",
+  "command.cleared": "Очищено завдань: {count}",
   "command.requires_interactive": "/todos потребує інтерактивного режиму",
   "command.section.pending": "── Очікування ──",
   "command.section.in_progress": "── У роботі ──",

--- a/packages/rpiv-todo/locales/zh.json
+++ b/packages/rpiv-todo/locales/zh.json
@@ -12,6 +12,7 @@
   "overlay.collapsed": "已折叠",
 
   "command.no_todos": "暂无任务。可以让 agent 添加一些！",
+  "command.cleared": "已清除 {count} 个任务",
   "command.requires_interactive": "/todos 需要交互模式",
   "command.section.pending": "── 待处理 ──",
   "command.section.in_progress": "── 进行中 ──",

--- a/packages/rpiv-todo/state/replay.test.ts
+++ b/packages/rpiv-todo/state/replay.test.ts
@@ -64,6 +64,16 @@ describe("replayFromBranch", () => {
 		expect(state.nextId).toBe(3);
 	});
 
+	it("treats a slash-command clear marker as an empty state", () => {
+		const ctx = createMockCtx({
+			branch: [
+				...buildBranch([{ action: "create", params: {}, tasks: [taskFixture(1, "old")], nextId: 2 }]),
+				{ type: "custom", customType: "rpiv-todo-clear" } as never,
+			],
+		});
+		expect(replayFromBranch(ctx)).toEqual({ tasks: [], nextId: 1 });
+	});
+
 	it("clones tasks so mutating the fixture does not mutate replayed state", () => {
 		const fixture: Task = taskFixture(1, "original");
 		const ctx = createMockCtx({

--- a/packages/rpiv-todo/state/replay.ts
+++ b/packages/rpiv-todo/state/replay.ts
@@ -1,6 +1,9 @@
 import type { TaskDetails } from "../tool/types.js";
 import { EMPTY_STATE, type TaskState } from "./state.js";
 
+/** Session marker written when `/todos clear` resets state outside a tool call. */
+export const TODO_CLEAR_ENTRY_TYPE = "rpiv-todo-clear";
+
 /**
  * Discriminator for `details` envelopes that match the persisted `TaskDetails`
  * shape. Defensive — branch entries from older or corrupt sessions are
@@ -13,9 +16,9 @@ export function isTaskDetails(value: unknown): value is TaskDetails {
 }
 
 /**
- * Walk the current branch in chronological order; the LAST `toolResult` whose
- * `toolName === "todo"` and whose `details` shape matches `TaskDetails` wins
- * (last-write-wins). When no matching entry exists, returns `EMPTY_STATE`.
+ * Walk the current branch in chronological order. Valid `todo` tool-result
+ * snapshots replace the state, while `/todos clear` markers reset it. The last
+ * recognized state entry wins; when none exists, returns `EMPTY_STATE`.
  *
  * Pure of module state — `index.ts` writes the returned snapshot into the
  * store after this returns. The function explicitly does NOT touch the store
@@ -24,7 +27,15 @@ export function isTaskDetails(value: unknown): value is TaskDetails {
 export function replayFromBranch(ctx: { sessionManager: { getBranch(): Iterable<unknown> } }): TaskState {
 	let result: TaskState = { tasks: [...EMPTY_STATE.tasks], nextId: EMPTY_STATE.nextId };
 	for (const entry of ctx.sessionManager.getBranch()) {
-		const e = entry as { type?: string; message?: { role?: string; toolName?: string; details?: unknown } };
+		const e = entry as {
+			type?: string;
+			customType?: string;
+			message?: { role?: string; toolName?: string; details?: unknown };
+		};
+		if (e.type === "custom" && e.customType === TODO_CLEAR_ENTRY_TYPE) {
+			result = { tasks: [...EMPTY_STATE.tasks], nextId: EMPTY_STATE.nextId };
+			continue;
+		}
 		if (e.type !== "message") continue;
 		const msg = e.message;
 		if (msg?.role !== "toolResult" || msg.toolName !== "todo") continue;

--- a/packages/rpiv-todo/todo.command.test.ts
+++ b/packages/rpiv-todo/todo.command.test.ts
@@ -1,18 +1,20 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
+import { createMockCommandCtx, createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __resetState, registerTodosCommand, registerTodoTool, TOOL_NAME } from "./todo.js";
 
 function setup() {
 	__resetState();
-	const { pi, captured } = createMockPi();
+	const appendEntry = vi.fn();
+	const onStateChanged = vi.fn(async () => {});
+	const { pi, captured } = createMockPi({ appendEntry });
 	registerTodoTool(pi);
-	registerTodosCommand(pi);
+	registerTodosCommand(pi, onStateChanged);
 	const tool = captured.tools.get(TOOL_NAME);
 	if (!tool) throw new Error("tool not registered");
 	const cmd = captured.commands.get("todos");
 	if (!cmd) throw new Error("command not registered");
-	return { tool, cmd };
+	return { tool, cmd, appendEntry, onStateChanged };
 }
 
 async function seed(tool: ReturnType<typeof setup>["tool"], actions: Array<Record<string, unknown>>) {
@@ -65,6 +67,36 @@ describe("/todos command — guard branches", () => {
 		await cmd.handler("", ctx as never);
 		const notify = ctx.ui.notify as ReturnType<typeof vi.fn>;
 		expect(notify).toHaveBeenCalledWith(expect.stringContaining("No todos"), "info");
+	});
+});
+
+describe("/todos clear", () => {
+	it("clears the current session, persists the reset, and refreshes the view", async () => {
+		const { tool, cmd, appendEntry, onStateChanged } = setup();
+		await seed(tool, [
+			{ action: "create", subject: "a" },
+			{ action: "create", subject: "b" },
+		]);
+		const ctx = createMockCommandCtx({ hasUI: true });
+
+		await cmd.handler("  clear  ", ctx as never);
+
+		expect(ctx.waitForIdle).toHaveBeenCalledTimes(1);
+		expect(appendEntry).toHaveBeenCalledWith("rpiv-todo-clear");
+		expect(onStateChanged).toHaveBeenCalledWith(ctx);
+		const notify = ctx.ui.notify as ReturnType<typeof vi.fn>;
+		expect(notify).toHaveBeenCalledWith("Cleared 2 tasks", "info");
+
+		await cmd.handler("", ctx as never);
+		expect(notify).toHaveBeenLastCalledWith(expect.stringContaining("No todos"), "info");
+		const result = await tool.execute?.(
+			"tc",
+			{ action: "create", subject: "after clear" } as never,
+			undefined as never,
+			undefined as never,
+			ctx as never,
+		);
+		expect(result?.content[0]).toMatchObject({ text: expect.stringContaining("Created #1") });
 	});
 });
 

--- a/packages/rpiv-todo/todo.session-isolation.test.ts
+++ b/packages/rpiv-todo/todo.session-isolation.test.ts
@@ -1,5 +1,5 @@
-import { createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
-import { afterEach, beforeEach, describe, expect, it, type vi } from "vitest";
+import { createMockCommandCtx, createMockCtx, createMockPi } from "@juicesharp/rpiv-test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import registerTodo from "./index.js";
 import { EMPTY_STATE } from "./state/state.js";
 import { getActiveRenderSession, getRenderState, getState } from "./state/store.js";
@@ -158,7 +158,7 @@ describe("rpiv-todo — foreground overlay policy (Slice 2)", () => {
 	}
 
 	function setup() {
-		const { pi, captured } = createMockPi();
+		const { pi, captured } = createMockPi({ appendEntry: vi.fn() });
 		registerTodo(pi);
 		const start = captured.events.get("session_start")?.[0] as
 			| ((e: unknown, ctx: unknown) => Promise<void>)
@@ -170,17 +170,17 @@ describe("rpiv-todo — foreground overlay policy (Slice 2)", () => {
 			| ((event: { toolName: string; isError: boolean }) => Promise<void>)
 			| undefined;
 		const tool = captured.tools.get("todo");
-		return { captured, start, shutdown, toolEnd, tool };
+		const cmd = captured.commands.get("todos");
+		return { captured, start, shutdown, toolEnd, tool, cmd };
 	}
 
-	it("first hasUI session_start claims the foreground and renders its slot", async () => {
-		const { start, toolEnd, tool } = setup();
-		const parentCtx = createMockCtx({ hasUI: true, sessionId: PARENT });
+	it("first hasUI session owns the overlay, which /todos clear removes", async () => {
+		const { start, toolEnd, tool, cmd } = setup();
+		const parentCtx = createMockCommandCtx({ hasUI: true, sessionId: PARENT });
 
 		await start?.({}, parentCtx);
 		expect(getActiveRenderSession()).toBe(PARENT);
 
-		// Create a parent task; pump tool_execution_end so the overlay renders it.
 		await tool?.execute?.(
 			"tc",
 			{ action: "create", subject: "parent task" } as never,
@@ -189,10 +189,10 @@ describe("rpiv-todo — foreground overlay policy (Slice 2)", () => {
 			parentCtx as never,
 		);
 		await toolEnd?.({ toolName: "todo", isError: false });
-
-		// Overlay registered a widget on the parent ui and renders the parent slot.
-		expect(widgetSpy(parentCtx)).toHaveBeenCalled();
 		expect(getRenderState().tasks.map((t) => t.subject)).toEqual(["parent task"]);
+
+		await cmd?.handler("clear", parentCtx as never);
+		expect(widgetSpy(parentCtx)).toHaveBeenLastCalledWith(WIDGET_KEY, undefined);
 	});
 
 	it("a child session_start (distinct sid, hasUI) does not claim foreground or rebind the overlay", async () => {

--- a/packages/rpiv-todo/todo.ts
+++ b/packages/rpiv-todo/todo.ts
@@ -12,9 +12,10 @@
  * continue to import from `./todo.js`.
  */
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { loadConfig, validateGuidanceFields } from "./config.js";
 import { formatStatusLabel, t } from "./state/i18n-bridge.js";
+import { TODO_CLEAR_ENTRY_TYPE } from "./state/replay.js";
 import { selectTasksByStatus, selectTodoCounts, selectVisibleTasks } from "./state/selectors.js";
 import { applyTaskMutation } from "./state/state-reducer.js";
 import { commitState, getRenderState, getState, sid } from "./state/store.js";
@@ -103,14 +104,30 @@ export function registerTodoTool(pi: ExtensionAPI): void {
 // /todos slash command
 // ---------------------------------------------------------------------------
 
-export function registerTodosCommand(pi: ExtensionAPI): void {
+type TodosStateChangedHandler = (ctx: ExtensionCommandContext) => Promise<void> | void;
+
+export function registerTodosCommand(pi: ExtensionAPI, onStateChanged?: TodosStateChangedHandler): void {
 	pi.registerCommand(COMMAND_NAME, {
-		description: "Show all todos on the current branch, grouped by status",
-		handler: async (_args, ctx) => {
+		description: "Show all todos on the current branch, grouped by status; pass clear to reset the list",
+		handler: async (args, ctx) => {
 			if (!ctx.hasUI) {
 				ctx.ui.notify(t("command.requires_interactive", ERR_REQUIRES_INTERACTIVE), "error");
 				return;
 			}
+
+			if (args.trim() === "clear") {
+				await ctx.waitForIdle();
+				const id = sid(ctx);
+				const state = getState(id);
+				const result = applyTaskMutation(state, "clear", {});
+				pi.appendEntry(TODO_CLEAR_ENTRY_TYPE);
+				commitState(id, result.state);
+				await onStateChanged?.(ctx);
+				const count = state.tasks.length;
+				ctx.ui.notify(t("command.cleared", "Cleared {count} tasks").replace("{count}", String(count)), "info");
+				return;
+			}
+
 			const state = getState(sid(ctx));
 			const visible = selectVisibleTasks(state);
 			if (visible.length === 0) {


### PR DESCRIPTION
## Summary

Adds `/todos clear` for resetting the todo list in the current Pi session. The clear operation persists with the session and updates the overlay immediately. Existing `/todos` listing behavior remains unchanged.