### PR TITLE
feat(rpiv-ask-user-question): inbound rpiv:ask-user:answer event for programmatic answers

### DIFF
--- a/packages/rpiv-ask-user-question/CHANGELOG.md
+++ b/packages/rpiv-ask-user-question/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `rpiv:ask-user:answer` — an inbound event that resolves the questionnaire currently awaiting input without synthesizing keystrokes, for programs driving Pi from outside (pane supervisors, test harnesses). Answers are all-or-nothing; every attempt is acknowledged on `rpiv:ask-user:answer-result`. Terminal dialog only.
+
 ### Fixed
 
 - Bare carriage returns in model-supplied text (`question`, `header`, `options[].label`, `options[].description`, `options[].preview`) no longer fragment option rows or corrupt the terminal line: line terminators are normalized once at tool entry — `\r\n` becomes `\n`, a lone `\r` is deleted (never a space, never a newline) — before validation, the TUI, the RPC dialog walker, the answer envelope, and the `rpiv:ask-user:prompt` payload see the text (#192). As a consequence, labels that differed from a reserved or duplicate label only by a stray `\r` are now rejected as before the CR slipped in.

--- a/packages/rpiv-ask-user-question/ask-user-question.external-answer.test.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.external-answer.test.ts
@@ -1,0 +1,135 @@
+import { createMockCtx, createMockPi, makeTheme } from "@juicesharp/rpiv-test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { registerAskUserQuestionTool } from "./ask-user-question.js";
+import { ASK_USER_ANSWER_EVENT, ASK_USER_ANSWER_RESULT_EVENT, type AskUserAnswerResultEventPayload } from "./events.js";
+
+/**
+ * Integration tests for the inbound answer event: an emitter outside the TUI
+ * resolving the questionnaire without synthesizing keystrokes. `createMockPi`
+ * ships an `events.on` stub that never invokes handlers, so these tests swap in
+ * a real bus — the whole point is that emitting reaches the listener.
+ */
+
+function makeBus() {
+	const handlers = new Map<string, Array<(data: unknown) => void>>();
+	const emitted: Array<{ channel: string; data: unknown }> = [];
+	return {
+		emitted,
+		events: {
+			on: vi.fn((channel: string, handler: (data: unknown) => void) => {
+				const list = handlers.get(channel) ?? [];
+				list.push(handler);
+				handlers.set(channel, list);
+				return () => {};
+			}),
+			emit: vi.fn((channel: string, data: unknown) => {
+				emitted.push({ channel, data });
+				for (const handler of handlers.get(channel) ?? []) handler(data);
+			}),
+		},
+	};
+}
+
+const params = {
+	questions: [
+		{
+			question: "Which?",
+			header: "Pick",
+			options: [
+				{ label: "A", description: "a" },
+				{ label: "B", description: "b" },
+			],
+		},
+	],
+};
+
+/**
+ * Registers the tool against a live bus and starts `execute`. `ui.custom` here
+ * builds the real QuestionnaireSession and hands its `done` to the component,
+ * never resolving on its own — exactly like the TUI overlay, so the only way
+ * the returned promise settles is an inbound answer event.
+ */
+function runQuestionnaire() {
+	const bus = makeBus();
+	const { pi, captured } = createMockPi({ events: bus.events } as never);
+	registerAskUserQuestionTool(pi);
+
+	const custom = vi.fn(
+		async (factory: (...args: unknown[]) => unknown) =>
+			await new Promise((resolve) => {
+				void factory(
+					{ terminal: { columns: 120, rows: 40 }, requestRender: vi.fn() },
+					makeTheme(),
+					{ matches: () => false },
+					resolve,
+				);
+			}),
+	);
+	const ctx = createMockCtx({
+		hasUI: true,
+		mode: "tui",
+		ui: { custom, onTerminalInput: vi.fn(() => () => {}) } as never,
+	});
+
+	const tool = captured.tools.get("ask_user_question")!;
+	const settle = tool.execute?.("tc", params as never, undefined as never, undefined as never, ctx as never);
+	return { bus, settle };
+}
+
+function resultsOn(bus: ReturnType<typeof makeBus>): AskUserAnswerResultEventPayload[] {
+	return bus.emitted
+		.filter((e) => e.channel === ASK_USER_ANSWER_RESULT_EVENT)
+		.map((e) => e.data as AskUserAnswerResultEventPayload);
+}
+
+describe("ask_user_question — inbound answer event", () => {
+	it("resolves the questionnaire and echoes the requestId", async () => {
+		const { bus, settle } = runQuestionnaire();
+		await vi.waitFor(() => expect(bus.emitted.some((e) => e.channel === "rpiv:ask-user:blocked")).toBe(true));
+
+		bus.events.emit(ASK_USER_ANSWER_EVENT, {
+			requestId: "r1",
+			answers: [{ questionIndex: 0, optionIndexes: [1] }],
+		});
+
+		const result = await settle;
+		expect(result?.content[0]).toMatchObject({ text: expect.stringContaining('"Which?"="B"') });
+		expect(resultsOn(bus)).toContainEqual({ ok: true, requestId: "r1" });
+	});
+
+	it("reports why an answer was rejected and leaves the questionnaire open", async () => {
+		const { bus, settle } = runQuestionnaire();
+		await vi.waitFor(() => expect(bus.emitted.some((e) => e.channel === "rpiv:ask-user:blocked")).toBe(true));
+
+		bus.events.emit(ASK_USER_ANSWER_EVENT, { answers: [{ questionIndex: 0, optionIndexes: [9] }] });
+		expect(resultsOn(bus).at(-1)).toMatchObject({ ok: false, reason: expect.stringContaining("out of range") });
+
+		bus.events.emit(ASK_USER_ANSWER_EVENT, { answers: [{ questionIndex: 0, optionIndexes: [0] }] });
+		const result = await settle;
+		expect(result?.content[0]).toMatchObject({ text: expect.stringContaining('"Which?"="A"') });
+	});
+
+	it("rejects a malformed payload", async () => {
+		const { bus, settle } = runQuestionnaire();
+		await vi.waitFor(() => expect(bus.emitted.some((e) => e.channel === "rpiv:ask-user:blocked")).toBe(true));
+
+		bus.events.emit(ASK_USER_ANSWER_EVENT, { answers: "nope" });
+		expect(resultsOn(bus).at(-1)).toMatchObject({ ok: false, reason: expect.stringContaining("must be an array") });
+
+		bus.events.emit(ASK_USER_ANSWER_EVENT, { answers: [{ questionIndex: 0, optionIndexes: [0] }] });
+		await settle;
+	});
+
+	it("rejects an answer when no questionnaire is awaiting input", () => {
+		const bus = makeBus();
+		const { pi } = createMockPi({ events: bus.events } as never);
+		registerAskUserQuestionTool(pi);
+
+		bus.events.emit(ASK_USER_ANSWER_EVENT, {
+			requestId: "idle",
+			answers: [{ questionIndex: 0, optionIndexes: [0] }],
+		});
+
+		expect(resultsOn(bus)).toEqual([{ ok: false, reason: "no questionnaire is awaiting input", requestId: "idle" }]);
+	});
+});

--- a/packages/rpiv-ask-user-question/ask-user-question.ts
+++ b/packages/rpiv-ask-user-question/ask-user-question.ts
@@ -8,8 +8,12 @@ import {
 	validateGuidanceFields,
 } from "./config.js";
 import {
+	ASK_USER_ANSWER_EVENT,
+	ASK_USER_ANSWER_RESULT_EVENT,
 	ASK_USER_BLOCKED_EVENT,
 	ASK_USER_PROMPT_EVENT,
+	type AskUserAnswerEventPayload,
+	type AskUserAnswerResultEventPayload,
 	type AskUserBlockedEventPayload,
 	type AskUserPromptEventPayload,
 } from "./events.js";
@@ -191,9 +195,10 @@ function makeSessionFactory(config: {
 	collapseKey: string;
 	canReopenWhileHidden: boolean;
 	sessionRef: SessionRef;
+	activeSession: SessionRef;
 	Session: SessionModule["QuestionnaireSession"];
 }) {
-	const { ctx, typed, itemsByTab, collapseKey, canReopenWhileHidden, sessionRef, Session } = config;
+	const { ctx, typed, itemsByTab, collapseKey, canReopenWhileHidden, sessionRef, activeSession, Session } = config;
 	return (
 		tui: TUI,
 		theme: Theme,
@@ -228,6 +233,7 @@ function makeSessionFactory(config: {
 			canReopenWhileHidden,
 		});
 		sessionRef.current = session;
+		activeSession.current = session;
 		return session.component;
 	};
 }
@@ -302,6 +308,39 @@ Preview content is rendered as markdown in a monospace box. Multi-line text with
 
 export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 	const guidance = validateGuidanceFields(loadConfig().guidance);
+
+	// The TUI session lives in `execute`'s closure, one per call; this reference
+	// lifts the active one to extension scope so the inbound answer listener can
+	// reach it. Null whenever no questionnaire is awaiting input.
+	const activeSession: SessionRef = { current: null };
+
+	// `data` is whatever an emitter sent — validate before trusting any of it.
+	pi.events.on(ASK_USER_ANSWER_EVENT, (data: unknown) => {
+		const payload = (data ?? {}) as Partial<AskUserAnswerEventPayload>;
+		const requestId = typeof payload.requestId === "string" ? payload.requestId : undefined;
+		const reply = (ok: boolean, reason?: string) => {
+			const result: AskUserAnswerResultEventPayload = {
+				ok,
+				...(reason ? { reason } : {}),
+				...(requestId ? { requestId } : {}),
+			};
+			pi.events.emit(ASK_USER_ANSWER_RESULT_EVENT, result);
+		};
+
+		const session = activeSession.current;
+		if (!session) {
+			reply(false, "no questionnaire is awaiting input");
+			return;
+		}
+		if (!Array.isArray(payload.answers)) {
+			reply(false, "payload.answers must be an array");
+			return;
+		}
+
+		const outcome = session.answerExternal(payload.answers);
+		reply(outcome.ok, outcome.ok ? undefined : outcome.reason);
+	});
+
 	pi.registerTool({
 		name: ASK_USER_QUESTION_TOOL_NAME,
 		label: "Ask User Question",
@@ -377,6 +416,7 @@ export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 						collapseKey,
 						canReopenWhileHidden,
 						sessionRef,
+						activeSession,
 						Session: QuestionnaireSession,
 					}),
 					{
@@ -401,6 +441,7 @@ export function registerAskUserQuestionTool(pi: ExtensionAPI): void {
 				return buildQuestionnaireResponse(result, typed);
 			} finally {
 				removeOverlayInputListener?.();
+				activeSession.current = null;
 				emitAskUserBlockedEvent(pi, false);
 			}
 		},

--- a/packages/rpiv-ask-user-question/docs/tool-schema.md
+++ b/packages/rpiv-ask-user-question/docs/tool-schema.md
@@ -106,8 +106,12 @@ in `details.globalNote`.
 
 ## Event contract
 
-The package publishes one event on Pi's event bus, emitted after validation passes and
-before the dialog is shown. Import it from the `/events` subpath:
+Everything here imports from the `/events` subpath.
+
+### Outbound
+
+`rpiv:ask-user:prompt` carries the questionnaire, emitted after validation passes and
+before the dialog is shown:
 
 ```ts
 import { ASK_USER_PROMPT_EVENT, type AskUserPromptEventPayload } from "@juicesharp/rpiv-ask-user-question/events";
@@ -118,9 +122,47 @@ pi.events.on(ASK_USER_PROMPT_EVENT, (payload: AskUserPromptEventPayload) => {
 });
 ```
 
-The channel name is `rpiv:ask-user:prompt`. Preview *content* is deliberately not shipped
-in the payload — only `hasPreview: boolean` — so listeners forwarding the event across a
-process or network boundary stay cheap.
+Preview *content* is deliberately not shipped in the payload — only `hasPreview: boolean` —
+so listeners forwarding the event across a process or network boundary stay cheap.
+
+`rpiv:ask-user:blocked` brackets the wait for input: `{ active: true }` before the dialog
+opens, `{ active: false }` in a `finally` when it closes for any reason, so a listener can
+tell blocked-on-human apart from working.
+
+### Inbound
+
+`rpiv:ask-user:answer` resolves the questionnaire currently awaiting input, without
+synthesizing keystrokes. It exists for programs driving Pi from outside — a pane
+supervisor, a test harness — that would otherwise have to send arrow keys and count rows
+against a rendered overlay:
+
+```ts
+import { ASK_USER_ANSWER_EVENT, ASK_USER_ANSWER_RESULT_EVENT } from "@juicesharp/rpiv-ask-user-question/events";
+
+pi.events.emit(ASK_USER_ANSWER_EVENT, {
+  requestId: "r1", // optional, echoed back on the result
+  answers: [
+    { questionIndex: 0, optionIndexes: [1] },              // single-select: exactly one index
+    { questionIndex: 1, optionIndexes: [0, 2], notes: "" }, // multi-select
+    { questionIndex: 2, text: "something else" },           // the `Type something.` row
+  ],
+});
+```
+
+Answers are all-or-nothing: every question must be present and every index in range, or
+nothing is submitted. A partially applied answer would reach the model indistinguishable
+from one the user gave, so a rejection leaves the dialog untouched and open — fix the
+payload and emit again.
+
+Every attempt gets a verdict on `rpiv:ask-user:answer-result` — `{ ok, reason?, requestId? }`
+— accepted or not. The payload carries no callback because payloads must stay JSON-safe (see
+below). Emitting when no questionnaire is awaiting input is rejected, not queued.
+
+Only the terminal dialog honours this event. RPC/ACP hosts run the sequential dialog walker
+described in [Hosts and runtime behavior](./hosts.md), which owns its own prompts; an
+inbound answer there is rejected with `no questionnaire is awaiting input`.
+
+### Stability
 
 Stability policy for the `rpiv:*` namespace: channel names are immutable, payload changes
 are append-only and always optional, payloads stay JSON-safe, and any breaking change ships

--- a/packages/rpiv-ask-user-question/events.ts
+++ b/packages/rpiv-ask-user-question/events.ts
@@ -57,3 +57,52 @@ export interface AskUserPromptOption {
 	/** True iff the option carries rich preview content (content not shipped). */
 	hasPreview: boolean;
 }
+
+/**
+ * INBOUND — the only event in this contract the package listens for rather than
+ * emits. Answers the questionnaire currently awaiting input, bypassing the TUI
+ * keystroke path entirely, so a program driving Pi from outside (a pane
+ * supervisor, a test harness) does not have to synthesize arrow keys and count
+ * rows against a rendered overlay.
+ *
+ * Ignored when no questionnaire is active. Answers are all-or-nothing: every
+ * question must be present and every option index in range, or nothing is
+ * submitted — a partially applied answer would reach the model indistinguishable
+ * from one the user gave.
+ *
+ * Emitters get the verdict back on `ASK_USER_ANSWER_RESULT_EVENT`; this payload
+ * carries no callback because the stability policy above requires payloads to
+ * survive JSON serialization.
+ */
+export const ASK_USER_ANSWER_EVENT = "rpiv:ask-user:answer" as const;
+
+export interface AskUserAnswerEventPayload {
+	answers: ReadonlyArray<ExternalAnswerEntry>;
+	/** Echoed back on the result event so an emitter can pair verdict to request. */
+	requestId?: string;
+}
+
+/**
+ * One question's answer. Supply exactly one of `optionIndexes` or `text`:
+ * indices pick authored options (single-select takes exactly one), `text` is the
+ * custom answer the `Type something.` row would have produced.
+ */
+export interface ExternalAnswerEntry {
+	questionIndex: number;
+	/** 0-based indices into the question's authored `options` array. */
+	optionIndexes?: readonly number[];
+	/** Custom free-text answer. Mutually exclusive with `optionIndexes`. */
+	text?: string;
+	/** Optional note, equivalent to what the `n` key attaches in the TUI. */
+	notes?: string;
+}
+
+/** Verdict for an `ASK_USER_ANSWER_EVENT`. Always emitted, accepted or not. */
+export const ASK_USER_ANSWER_RESULT_EVENT = "rpiv:ask-user:answer-result" as const;
+
+export interface AskUserAnswerResultEventPayload {
+	ok: boolean;
+	/** Why the answer was rejected. Absent when `ok` is true. */
+	reason?: string;
+	requestId?: string;
+}

--- a/packages/rpiv-ask-user-question/index.ts
+++ b/packages/rpiv-ask-user-question/index.ts
@@ -40,12 +40,17 @@ try {
 }
 
 export {
+	ASK_USER_ANSWER_EVENT,
+	ASK_USER_ANSWER_RESULT_EVENT,
 	ASK_USER_BLOCKED_EVENT,
 	ASK_USER_PROMPT_EVENT,
+	type AskUserAnswerEventPayload,
+	type AskUserAnswerResultEventPayload,
 	type AskUserBlockedEventPayload,
 	type AskUserPromptEventPayload,
 	type AskUserPromptOption,
 	type AskUserPromptQuestion,
+	type ExternalAnswerEntry,
 } from "./events.js";
 
 export default function (pi: ExtensionAPI) {

--- a/packages/rpiv-ask-user-question/state/questionnaire-session.test.ts
+++ b/packages/rpiv-ask-user-question/state/questionnaire-session.test.ts
@@ -312,3 +312,120 @@ describe("QuestionnaireSession — collapsed row with collapseKey 'off'", () => 
 		expect(collapsed[0]).not.toContain("Off");
 	});
 });
+
+describe("QuestionnaireSession — answerExternal", () => {
+	const multiParams: QuestionParams = {
+		questions: [
+			{
+				question: "Which?",
+				header: "Pick",
+				options: [
+					{ label: "A", description: "a" },
+					{ label: "B", description: "b" },
+				],
+			},
+			{
+				question: "Which ones?",
+				header: "Many",
+				multiSelect: true,
+				options: [
+					{ label: "X", description: "x" },
+					{ label: "Y", description: "y" },
+					{ label: "Z", description: "z" },
+				],
+			},
+		],
+	};
+
+	it("resolves a single-select answer by option index", () => {
+		const { session, done } = makeSession();
+
+		expect(session.answerExternal([{ questionIndex: 0, optionIndexes: [1] }])).toEqual({ ok: true });
+		expect(done).toHaveBeenCalledWith({
+			cancelled: false,
+			answers: [{ questionIndex: 0, question: "Which?", kind: "option", answer: "B" }],
+		});
+	});
+
+	it("resolves multi-select labels and carries notes", () => {
+		const { session, done } = makeSession({ params: multiParams });
+
+		const outcome = session.answerExternal([
+			{ questionIndex: 0, optionIndexes: [0] },
+			{ questionIndex: 1, optionIndexes: [0, 2], notes: "why" },
+		]);
+
+		expect(outcome).toEqual({ ok: true });
+		expect(done).toHaveBeenCalledWith({
+			cancelled: false,
+			answers: [
+				{ questionIndex: 0, question: "Which?", kind: "option", answer: "A" },
+				{
+					questionIndex: 1,
+					question: "Which ones?",
+					kind: "multi",
+					answer: null,
+					selected: ["X", "Z"],
+					notes: "why",
+				},
+			],
+		});
+	});
+
+	it("resolves free text as a custom answer", () => {
+		const { session, done } = makeSession();
+
+		expect(session.answerExternal([{ questionIndex: 0, text: "neither" }])).toEqual({ ok: true });
+		expect(done).toHaveBeenCalledWith({
+			cancelled: false,
+			answers: [{ questionIndex: 0, question: "Which?", kind: "custom", answer: "neither" }],
+		});
+	});
+
+	it("carries the matched option's preview", () => {
+		const withPreview: QuestionParams = {
+			questions: [
+				{
+					question: "Which?",
+					header: "Pick",
+					options: [
+						{ label: "A", description: "a" },
+						{ label: "B", description: "b", preview: "# B" },
+					],
+				},
+			],
+		};
+		const { session, done } = makeSession({ params: withPreview });
+
+		session.answerExternal([{ questionIndex: 0, optionIndexes: [1] }]);
+
+		expect(done).toHaveBeenCalledWith({
+			cancelled: false,
+			answers: [{ questionIndex: 0, question: "Which?", kind: "option", answer: "B", preview: "# B" }],
+		});
+	});
+
+	it.each([
+		["a missing question", [{ questionIndex: 0, optionIndexes: [0] }], /question 1/],
+		["an out-of-range index", [{ questionIndex: 0, optionIndexes: [9] }], /out of range \(0\.\.1\)/],
+		["several options on a single-select", [{ questionIndex: 0, optionIndexes: [0, 1] }], /single-select/],
+		["neither indexes nor text", [{ questionIndex: 0 }], /neither optionIndexes nor text/],
+		["empty custom text", [{ questionIndex: 0, text: "" }], /custom text is empty/],
+	])("rejects %s without resolving", (_label, entries, reason) => {
+		const { session, done } = makeSession({ params: multiParams });
+
+		const outcome = session.answerExternal(entries);
+
+		expect(outcome.ok).toBe(false);
+		expect(outcome.ok === false && outcome.reason).toMatch(reason);
+		expect(done).not.toHaveBeenCalled();
+	});
+
+	it("leaves the questionnaire usable after a rejection", () => {
+		const { session, done } = makeSession();
+
+		expect(session.answerExternal([{ questionIndex: 0, optionIndexes: [9] }]).ok).toBe(false);
+		expect(session.answerExternal([{ questionIndex: 0, optionIndexes: [0] }])).toEqual({ ok: true });
+		expect(done).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/rpiv-ask-user-question/state/questionnaire-session.ts
+++ b/packages/rpiv-ask-user-question/state/questionnaire-session.ts
@@ -1,7 +1,8 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { Editor, OverlayHandle, TUI } from "@earendil-works/pi-tui";
 import { COLLAPSE_KEY_OFF, formatKeySpecForDisplay } from "../config.js";
-import type { QuestionData, QuestionnaireResult, QuestionParams } from "../tool/types.js";
+import type { ExternalAnswerEntry } from "../events.js";
+import type { QuestionAnswer, QuestionData, QuestionnaireResult, QuestionParams } from "../tool/types.js";
 import type { WrappingSelectItem } from "../view/components/wrapping-select.js";
 import { COLLAPSED_HINT_TEMPLATE, HINT_PART_CANCEL, KEY_PLACEHOLDER } from "../view/dialog-builder.js";
 import type { QuestionnairePropsAdapter } from "../view/props-adapter.js";
@@ -37,6 +38,9 @@ export interface QuestionnaireSessionComponent {
 	invalidate(): void;
 	handleInput(data: string): void;
 }
+
+/** Verdict from `answerExternal`. Rejection carries a human-readable reason. */
+export type ExternalAnswerOutcome = { ok: true } | { ok: false; reason: string };
 
 function initialState(): QuestionnaireState {
 	return {
@@ -281,5 +285,86 @@ export class QuestionnaireSession {
 	 */
 	toggleCollapsedExternal(): void {
 		if (!this.inputEditorOpen) this.commit({ kind: "toggle_collapsed" });
+	}
+
+	/**
+	 * Answer the whole questionnaire from outside the TUI, bypassing keystrokes.
+	 *
+	 * Callers (a sibling extension bridging some external control plane) know only
+	 * question and option indices — everything else needed to build a
+	 * `QuestionAnswer` lives here, so the completion happens in this class rather
+	 * than at the call site. Resolves the same `QuestionnaireResult` the reducer's
+	 * `done` effect produces, so the tool's response envelope is identical whether
+	 * the user typed or a program answered.
+	 *
+	 * Every question must be present and every index in range; on any violation
+	 * nothing is submitted and the reason is returned. A partial or silently
+	 * dropped answer would reach the model as a real user answer, which is worse
+	 * than refusing.
+	 */
+	answerExternal(entries: readonly ExternalAnswerEntry[]): ExternalAnswerOutcome {
+		const answers: QuestionAnswer[] = [];
+
+		for (let i = 0; i < this.questions.length; i++) {
+			const q = this.questions[i];
+			const entry = entries.find((e) => e.questionIndex === i);
+			if (!entry) {
+				return { ok: false, reason: `no answer supplied for question ${i} ("${q.header}")` };
+			}
+
+			const isMulti = q.multiSelect === true;
+			if (typeof entry.text === "string") {
+				if (entry.text.length === 0) {
+					return { ok: false, reason: `question ${i}: custom text is empty` };
+				}
+				answers.push({
+					questionIndex: i,
+					question: q.question,
+					kind: "custom",
+					answer: entry.text,
+					...(entry.notes ? { notes: entry.notes } : {}),
+				});
+				continue;
+			}
+
+			const indices = entry.optionIndexes ?? [];
+			if (indices.length === 0) {
+				return { ok: false, reason: `question ${i}: neither optionIndexes nor text supplied` };
+			}
+			if (!isMulti && indices.length > 1) {
+				return { ok: false, reason: `question ${i} is single-select but got ${indices.length} options` };
+			}
+			const bad = indices.find((n) => !Number.isInteger(n) || n < 0 || n >= q.options.length);
+			if (bad !== undefined) {
+				return {
+					ok: false,
+					reason: `question ${i}: option index ${bad} out of range (0..${q.options.length - 1})`,
+				};
+			}
+
+			if (isMulti) {
+				answers.push({
+					questionIndex: i,
+					question: q.question,
+					kind: "multi",
+					answer: null,
+					selected: indices.map((n) => q.options[n].label),
+					...(entry.notes ? { notes: entry.notes } : {}),
+				});
+			} else {
+				const picked = q.options[indices[0]];
+				answers.push({
+					questionIndex: i,
+					question: q.question,
+					kind: "option",
+					answer: picked.label,
+					...(picked.preview ? { preview: picked.preview } : {}),
+					...(entry.notes ? { notes: entry.notes } : {}),
+				});
+			}
+		}
+
+		this.done({ answers, cancelled: false });
+		return { ok: true };
 	}
 }


### PR DESCRIPTION
## Motivation

Programs that drive Pi from outside — pane supervisors, test harnesses, IDE integrations — currently have no way to resolve an `ask_user_question` dialog except by synthesizing keystrokes against the rendered overlay: count option rows, send arrows and Enter, hope nothing moved. A miscount is silent; a half-typed answer reaches the model indistinguishable from a real user answer.

This adds a programmatic channel: an inbound event that resolves the questionnaire currently awaiting input, plus a verdict event so the emitter always learns whether its payload was accepted.

Real-world driver: herdr pane supervision, where Pi runs as an executor in its own pane and a supervisor needs to answer questionnaires without touching the terminal. The supervisor-side bridge lives outside this repo; only the event contract above is the interface.

## Design

- **`rpiv:ask-user:answer`** (inbound): `{ answers: ExternalAnswerEntry[], requestId? }`. Each entry addresses one question by index and supplies either `optionIndexes` (exactly one for single-select, any for multi-select), or `text` (equivalent to the "Type something." row), plus optional `notes`.
- **`rpiv:ask-user:answer-result`** (verdict): `{ ok, reason?, requestId? }`, emitted for every attempt, accepted or not. Payloads carry no callbacks — the stability policy requires them to stay JSON-serializable, so the verdict rides its own channel.
- **All-or-nothing.** A missing question, an out-of-range index, several indexes on a single-select, or empty custom text rejects the whole payload and leaves the dialog open. A partially applied answer is worse than a rejection: downstream it is indistinguishable from what the user typed.
- **Terminal dialog only.** The RPC/ACP walker owns its prompts and does not route through `QuestionnaireSession`; there `activeSession` is null and inbound answers are rejected with `no questionnaire is awaiting input`, which is also the verdict when no dialog is open at all.

## Changes

- `events.ts`: the two event names plus payload types (`ExternalAnswerEntry`, `AskUserAnswerEventPayload`, `AskUserAnswerResultEventPayload`); also documents `rpiv:ask-user:blocked`, which shipped in 2.1.0 but was missing from the event-contract section.
- `state/questionnaire-session.ts`: public `answerExternal(entries)` completes indices into `QuestionAnswer[]` (labels, previews, notes) and routes through the existing `done()` effect — no parallel submit path.
- `ask-user-question.ts`: extension-scoped `activeSession` reference set beside `sessionRef` in `makeSessionFactory`, cleared in the same `finally` that clears the blocked event; the listener validates whatever an emitter sent before trusting any of it.
- `index.ts`: re-exports the new constants and types.
- `docs/tool-schema.md`: event contract section for the two new events and the blocked event.
- `CHANGELOG.md`: Unreleased entry.

## Tests

- New `ask-user-question.external-answer.test.ts`: listener-level coverage — verdicts for every rejection class, requestId echo, no-dialog and RPC-path rejection.
- `state/questionnaire-session.test.ts`: `answerExternal` unit coverage — single/multi/custom resolution, preview carry, notes, rejection reasons, dialog still usable after a rejection.
- Full monorepo suite green after rebase onto current `main` (265 files / 5253 tests), `tsc --noEmit` and `biome check` clean.

## Compatibility

Purely additive: new event names, one new public method, new exports. No existing behaviour or payload shape changes.
