### PR TITLE
fix(rpiv-ask-user-question): overlay stops hanging in esbuild ESM bundles

### DIFF
--- a/packages/rpiv-ask-user-question/CHANGELOG.md
+++ b/packages/rpiv-ask-user-question/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The question overlay no longer hangs when the extension is loaded from an esbuild ESM bundle: `view/dialog-builder.ts` and `view/tab-content-strategy.ts` imported each other at runtime, which jiti tolerates but esbuild turns into two async initializers awaiting each other (#208). The shared dialog copy moved to `view/dialog-copy.ts`; `dialog-builder.ts` re-exports it, so importers are unchanged.
 - Bare carriage returns in model-supplied text (`question`, `header`, `options[].label`, `options[].description`, `options[].preview`) no longer fragment option rows or corrupt the terminal line: line terminators are normalized once at tool entry — `\r\n` becomes `\n`, a lone `\r` is deleted (never a space, never a newline) — before validation, the TUI, the RPC dialog walker, the answer envelope, and the `rpiv:ask-user:prompt` payload see the text (#192). As a consequence, labels that differed from a reserved or duplicate label only by a stray `\r` are now rejected as before the CR slipped in.
 
 ## [2.9.0] - 2026-09-01

--- a/packages/rpiv-ask-user-question/import-graph.test.ts
+++ b/packages/rpiv-ask-user-question/import-graph.test.ts
@@ -1,0 +1,82 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A cycle of static value imports deadlocks esbuild's async `__esm` init; jiti masks it, so only a bundle
+ * shows the hang (#208). Dynamic `import()` defers init instead of awaiting it, so those edges are out of scope.
+ */
+
+const PACKAGE_ROOT = dirname(fileURLToPath(import.meta.url));
+
+/** `import`/`export … from "./x.js"`, statement form only; `[^;]` spans multi-line specifier lists. */
+const STATIC_IMPORT = /^(?:import|export)\s+([^;]*?)\sfrom\s+["'](\.[^"']+)["']/gms;
+
+function productionModules(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...productionModules(path));
+		else if (path.endsWith(".ts") && !path.endsWith(".test.ts") && !path.endsWith(".d.ts")) out.push(path);
+	}
+	return out;
+}
+
+/** `import type {…}`, `export type {…}`, and `import { type A, type B }` are erased; anything else carries a value. */
+function importsValues(clause: string): boolean {
+	if (/^type\s/.test(clause)) return false;
+	const braced = clause.match(/\{([^}]*)\}/);
+	if (!braced) return true;
+	if (clause.replace(braced[0], "").replace(/,/g, "").trim()) return true;
+	return braced[1]
+		.split(",")
+		.map((s) => s.trim())
+		.some((s) => s && !/^type\s/.test(s));
+}
+
+function staticImportGraph(files: string[]): { graph: Map<string, string[]>; unresolved: string[] } {
+	const graph = new Map<string, string[]>();
+	const unresolved: string[] = [];
+	for (const file of files) {
+		const deps: string[] = [];
+		for (const [, clause, specifier] of readFileSync(file, "utf8").matchAll(STATIC_IMPORT)) {
+			if (!importsValues(clause)) continue;
+			const target = resolve(dirname(file), specifier.replace(/\.js$/, ".ts"));
+			if (existsSync(target)) deps.push(target);
+			else unresolved.push(`${relative(PACKAGE_ROOT, file)}: ${specifier}`);
+		}
+		graph.set(file, deps);
+	}
+	return { graph, unresolved };
+}
+
+function findCycles(graph: Map<string, string[]>): string[][] {
+	const cycles: string[][] = [];
+	const visiting = new Set<string>();
+	const done = new Set<string>();
+	const stack: string[] = [];
+	const visit = (node: string): void => {
+		visiting.add(node);
+		stack.push(node);
+		for (const dep of graph.get(node) ?? []) {
+			if (visiting.has(dep)) cycles.push(stack.slice(stack.indexOf(dep)).map((p) => relative(PACKAGE_ROOT, p)));
+			else if (!done.has(dep)) visit(dep);
+		}
+		stack.pop();
+		visiting.delete(node);
+		done.add(node);
+	};
+	for (const node of graph.keys()) if (!done.has(node)) visit(node);
+	return cycles;
+}
+
+describe("static import graph", () => {
+	it("has no cycles among the package's production modules", () => {
+		const { graph, unresolved } = staticImportGraph(productionModules(PACKAGE_ROOT));
+		expect(graph.has(join(PACKAGE_ROOT, "view/dialog-builder.ts"))).toBe(true);
+		expect(unresolved).toEqual([]);
+		expect(findCycles(graph).map((cycle) => cycle.join(" -> "))).toEqual([]);
+	});
+});

--- a/packages/rpiv-ask-user-question/package.json
+++ b/packages/rpiv-ask-user-question/package.json
@@ -73,6 +73,7 @@
 		"view/components/tab-bar.ts",
 		"view/components/wrapping-select.ts",
 		"view/dialog-builder.ts",
+		"view/dialog-copy.ts",
 		"view/props-adapter.ts",
 		"view/stateful-view.ts",
 		"view/tab-components.ts",

--- a/packages/rpiv-ask-user-question/view/dialog-builder.ts
+++ b/packages/rpiv-ask-user-question/view/dialog-builder.ts
@@ -1,6 +1,5 @@
 import { DynamicBorder, type Theme } from "@earendil-works/pi-coding-agent";
 import { type Component, Container, type Editor, Spacer } from "@earendil-works/pi-tui";
-import { DEFAULT_COLLAPSE_KEY, formatKeySpecForDisplay } from "../config.js";
 import type { QuestionnaireState } from "../state/state.js";
 import type { QuestionData } from "../tool/types.js";
 import type { PreviewPaneProps } from "./components/preview/preview-pane.js";
@@ -9,53 +8,26 @@ import type { StatefulView } from "./stateful-view.js";
 import type { TabComponents } from "./tab-components.js";
 import { QuestionTabStrategy, SubmitTabStrategy, type TabContentStrategy } from "./tab-content-strategy.js";
 
-export const HINT_PART_ENTER = "Enter to select";
-export const HINT_PART_NAV = "↑/↓ to navigate";
-export const HINT_PART_NEW_LINE = "Shift+Enter for newline";
-export const HINT_PART_CLEAR = "Ctrl+U to clear";
-export const HINT_PART_TOGGLE = "Space to toggle";
-export const HINT_PART_NOTES = "n to add notes";
-export const HINT_PART_TAB = "Tab to switch questions";
-export const HINT_PART_CANCEL = "Esc to cancel";
-/**
- * Collapse/expand hint copy is templated on `KEY_PLACEHOLDER` because the
- * shortcut is configurable (`collapseKey`) and `rpiv-i18n`'s `tr` has no
- * interpolation — locale entries carry the same `{key}` placeholder and call
- * sites `.replace()` it with `formatKeySpecForDisplay(collapseKey)` after
- * lookup, so per-locale word order is preserved.
- */
-export const KEY_PLACEHOLDER = "{key}";
-export const HINT_PART_COLLAPSE_TEMPLATE = `${KEY_PLACEHOLDER} to collapse`;
-export const HINT_PART_EXPAND_TEMPLATE = `${KEY_PLACEHOLDER} to expand`;
-/** Default-key (`Ctrl+]`) rendering of the collapse template, for tests and default-config assertions. */
-export const HINT_PART_COLLAPSE = HINT_PART_COLLAPSE_TEMPLATE.replace(
+export {
+	COLLAPSED_HINT_TEMPLATE,
+	HINT_MULTI,
+	HINT_PART_CANCEL,
+	HINT_PART_CLEAR,
+	HINT_PART_COLLAPSE,
+	HINT_PART_COLLAPSE_TEMPLATE,
+	HINT_PART_ENTER,
+	HINT_PART_EXPAND_TEMPLATE,
+	HINT_PART_NAV,
+	HINT_PART_NEW_LINE,
+	HINT_PART_NOTES,
+	HINT_PART_TAB,
+	HINT_PART_TOGGLE,
+	HINT_SINGLE,
+	INCOMPLETE_WARNING_PREFIX,
 	KEY_PLACEHOLDER,
-	formatKeySpecForDisplay(DEFAULT_COLLAPSE_KEY),
-);
-/**
- * `HINT_SINGLE` / `HINT_MULTI` are the resting core hint for NON-multiSelect
- * question tabs only: `buildHintText` drops `NOTES` while the notes editor is
- * open (`state.notesVisible`) or the "Type something." row is capturing text
- * (`state.inputMode`), and on multiSelect tabs it interleaves `TOGGLE` between
- * `NAV` and `NOTES`, so neither composite is a substring there — assert on
- * `HINT_PART_*` constants in those states instead. The collapse affordance is
- * appended AFTER cancel by `buildHintText` so the resting core stays a contiguous
- * prefix substring of the rendered line. On narrow terminals the collapse tail
- * clips with `…` (`OneLineClippedText`); the core is preserved.
- */
-export const HINT_SINGLE = [HINT_PART_ENTER, HINT_PART_NAV, HINT_PART_NOTES, HINT_PART_CANCEL].join(" · ");
-export const HINT_MULTI = [HINT_PART_ENTER, HINT_PART_NAV, HINT_PART_NOTES, HINT_PART_TAB, HINT_PART_CANCEL].join(
-	" · ",
-);
-/**
- * Template for the single-line footer shown by `QuestionnaireSession` when
- * `state.collapsed === true`. Bypasses `buildHintText`; the session replaces
- * `KEY_PLACEHOLDER` with the configured key's display form.
- */
-export const COLLAPSED_HINT_TEMPLATE = [HINT_PART_EXPAND_TEMPLATE, HINT_PART_CANCEL].join(" · ");
-export const REVIEW_HEADING = "Review your answers";
-export const READY_PROMPT = "Ready to submit your answers?";
-export const INCOMPLETE_WARNING_PREFIX = "⚠ Answer remaining questions before submitting:";
+	READY_PROMPT,
+	REVIEW_HEADING,
+} from "./dialog-copy.js";
 
 const OVERFLOW_UP = "↑";
 const OVERFLOW_DOWN = "↓";

--- a/packages/rpiv-ask-user-question/view/dialog-copy.ts
+++ b/packages/rpiv-ask-user-question/view/dialog-copy.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_COLLAPSE_KEY, formatKeySpecForDisplay } from "../config.js";
+
+/** Leaf: imports nothing from `view/`, so `dialog-builder` and `tab-content-strategy` never form a runtime cycle (#208). */
+
+export const HINT_PART_ENTER = "Enter to select";
+export const HINT_PART_NAV = "↑/↓ to navigate";
+export const HINT_PART_NEW_LINE = "Shift+Enter for newline";
+export const HINT_PART_CLEAR = "Ctrl+U to clear";
+export const HINT_PART_TOGGLE = "Space to toggle";
+export const HINT_PART_NOTES = "n to add notes";
+export const HINT_PART_TAB = "Tab to switch questions";
+export const HINT_PART_CANCEL = "Esc to cancel";
+/**
+ * Collapse/expand hint copy is templated on `KEY_PLACEHOLDER` because the
+ * shortcut is configurable (`collapseKey`) and `rpiv-i18n`'s `tr` has no
+ * interpolation — locale entries carry the same `{key}` placeholder and call
+ * sites `.replace()` it with `formatKeySpecForDisplay(collapseKey)` after
+ * lookup, so per-locale word order is preserved.
+ */
+export const KEY_PLACEHOLDER = "{key}";
+export const HINT_PART_COLLAPSE_TEMPLATE = `${KEY_PLACEHOLDER} to collapse`;
+export const HINT_PART_EXPAND_TEMPLATE = `${KEY_PLACEHOLDER} to expand`;
+/** Default-key (`Ctrl+]`) rendering of the collapse template, for tests and default-config assertions. */
+export const HINT_PART_COLLAPSE = HINT_PART_COLLAPSE_TEMPLATE.replace(
+	KEY_PLACEHOLDER,
+	formatKeySpecForDisplay(DEFAULT_COLLAPSE_KEY),
+);
+/**
+ * `HINT_SINGLE` / `HINT_MULTI` are the resting core hint for NON-multiSelect
+ * question tabs only: `buildHintText` drops `NOTES` while the notes editor is
+ * open (`state.notesVisible`) or the "Type something." row is capturing text
+ * (`state.inputMode`), and on multiSelect tabs it interleaves `TOGGLE` between
+ * `NAV` and `NOTES`, so neither composite is a substring there — assert on
+ * `HINT_PART_*` constants in those states instead. The collapse affordance is
+ * appended AFTER cancel by `buildHintText` so the resting core stays a contiguous
+ * prefix substring of the rendered line. On narrow terminals the collapse tail
+ * clips with `…` (`OneLineClippedText`); the core is preserved.
+ */
+export const HINT_SINGLE = [HINT_PART_ENTER, HINT_PART_NAV, HINT_PART_NOTES, HINT_PART_CANCEL].join(" · ");
+export const HINT_MULTI = [HINT_PART_ENTER, HINT_PART_NAV, HINT_PART_NOTES, HINT_PART_TAB, HINT_PART_CANCEL].join(
+	" · ",
+);
+/**
+ * Template for the single-line footer shown by `QuestionnaireSession` when
+ * `state.collapsed === true`. Bypasses `buildHintText`; the session replaces
+ * `KEY_PLACEHOLDER` with the configured key's display form.
+ */
+export const COLLAPSED_HINT_TEMPLATE = [HINT_PART_EXPAND_TEMPLATE, HINT_PART_CANCEL].join(" · ");
+export const REVIEW_HEADING = "Review your answers";
+export const READY_PROMPT = "Ready to submit your answers?";
+export const INCOMPLETE_WARNING_PREFIX = "⚠ Answer remaining questions before submitting:";

--- a/packages/rpiv-ask-user-question/view/tab-content-strategy.ts
+++ b/packages/rpiv-ask-user-question/view/tab-content-strategy.ts
@@ -5,8 +5,8 @@ import { t } from "../state/i18n-bridge.js";
 import { formatAnswerScalar } from "../tool/format-answer.js";
 import type { QuestionData } from "../tool/types.js";
 import type { PreviewPane, PreviewPaneProps } from "./components/preview/preview-pane.js";
+import type { DialogState } from "./dialog-builder.js";
 import {
-	type DialogState,
 	HINT_PART_CANCEL,
 	HINT_PART_CLEAR,
 	HINT_PART_COLLAPSE_TEMPLATE,
@@ -20,7 +20,7 @@ import {
 	KEY_PLACEHOLDER,
 	READY_PROMPT,
 	REVIEW_HEADING,
-} from "./dialog-builder.js";
+} from "./dialog-copy.js";
 import type { StatefulView } from "./stateful-view.js";
 import type { TabComponents } from "./tab-components.js";
 


### PR DESCRIPTION
Closes #208.

The hint and Submit-tab copy that both `view/dialog-builder.ts` and `view/tab-content-strategy.ts` need moves to `view/dialog-copy.ts`, a leaf that imports nothing from the view layer. `dialog-builder.ts` re-exports it by name, so the state-layer importers and tests don't change. `tab-content-strategy.ts` keeps a type import from the builder and nothing else. The bundle's init blocks stay async, but with no cycle they resolve in order.

`import-graph.test.ts` builds the package's static value-import graph and fails on any cycle, naming it. It also fails on a relative import it cannot resolve, so the graph cannot shrink silently. Dynamic `import()` edges are out of scope since they defer init rather than await it. On `main` the test fails with `view/dialog-builder.ts -> view/tab-content-strategy.ts`.

Also adds the CHANGELOG entry and lists `view/dialog-copy.ts` in `files` for the ship-manifest test.

The reproduction from #208 resolves in under a second on this branch. `npm run check` and `npm run coverage` pass.
