### PR TITLE
feat(preview): scroll overflowing preview content with PageUp/PageDown

### DIFF
--- a/packages/rpiv-ask-user-question/docs/keyboard.md
+++ b/packages/rpiv-ask-user-question/docs/keyboard.md
@@ -17,6 +17,7 @@ adapts to the size of your terminal.
 | `Ctrl+G` | Open Pi's configured external editor with the current custom-answer draft. | `Type something.` input |
 | `Ctrl+U` | Clear the current custom-answer draft. | `Type something.` input |
 | `Ctrl+]` | Collapse or expand the dialog. Configurable via `collapseKey`. | Everywhere, including while collapsed |
+| `PageUp` / `PageDown` | Scroll the focused option's preview content by ~one screenful when it overflows the preview height budget. | Question tabs whose focused option carries a preview |
 
 The table names the default keys; the dialog actually follows your Pi keybindings.
 Confirm listens to both `tui.select.confirm` and `tui.input.submit`, and a key bound to
@@ -88,6 +89,22 @@ answers you cannot see.
 The default `ctrl+]` is free in Terminal.app, iTerm2, Warp, tmux, zellij and screen. On
 keyboard layouts where `]` sits on the shifted layer — Latin American `es-AR` / `es-MX`,
 among others — set a different `collapseKey`, or `"off"` to disable the shortcut.
+
+## Preview scrolling
+
+When the focused option's preview is taller than its height budget (see `MAX_PREVIEW_HEIGHT_*`
+in `view/components/preview/markdown-content-cache.ts`), the box body scrolls instead of
+just hiding the tail: `PageDown` scrolls down, `PageUp` scrolls up, and the scroll position
+resets whenever you move to another option, switch tabs, or open the notes editor.
+The bottom border doubles as the scroll indicator:
+
+- ` ✂ N lines hidden · PgDn ▼ ` — at the top, more content below
+- ` ▲ PgUp · N lines hidden ` — at the bottom, more content above
+- ` ▲ N lines hidden · PgUp/PgDn ▼ ` — mid-scroll, content in both directions
+
+`↑`/`↓` keep their option-navigation meaning while a preview is focused; only `PageUp`/
+`PageDown` move inside the preview. The same scrolling applies in both the side-by-side
+(≥100 columns) and the stacked (narrow terminal) layouts.
 
 ## Layout
 

--- a/packages/rpiv-ask-user-question/state/key-router.ts
+++ b/packages/rpiv-ask-user-question/state/key-router.ts
@@ -376,10 +376,22 @@ export function routeKey(data: string, state: QuestionnaireState, runtime: Quest
 	// a preview that fits, simply leaves `previewScroll` clamped at 0 by the reducer.
 	if (!q.multiSelect) {
 		if (matchesKey(data, Key.pageUp)) {
+			// State only ever decreases toward 0 (clamped by the reducer), so PageUp can
+			// never overscroll — a plain step is enough.
 			return { kind: "preview_scroll", delta: -PREVIEW_SCROLL_STEP };
 		}
 		if (matchesKey(data, Key.pageDown)) {
-			return { kind: "preview_scroll", delta: PREVIEW_SCROLL_STEP };
+			// Snap to the rendered bottom: when the last frame reported the focused preview’s
+			// total overflow, step at most that far past the current offset. Reaching the end
+			// swallows further PageDown presses (delta <= 0), so no phantom rows accumulate
+			// and the next PageUp responds immediately.
+			const max = runtime.previewMaxScroll;
+			const delta =
+				max === undefined
+					? PREVIEW_SCROLL_STEP
+					: Math.min(PREVIEW_SCROLL_STEP, Math.max(0, max - state.previewScroll));
+			if (delta <= 0) return { kind: "ignore" };
+			return { kind: "preview_scroll", delta };
 		}
 	}
 

--- a/packages/rpiv-ask-user-question/state/key-router.ts
+++ b/packages/rpiv-ask-user-question/state/key-router.ts
@@ -17,6 +17,20 @@ const KEYBIND_EXTERNAL_EDITOR = "app.editor.external";
 const NOTES_ACTIVATE_KEY = "n";
 const SPACE_KEY = " ";
 
+/**
+ * Rows scrolled per PageUp/PageDown press. Deliberately close to the stacked-layout
+ * content budget (~11) so one press roughly equals one screenful in either layout;
+ * the renderer clamps the offset to the actual overflow either way.
+ */
+export const PREVIEW_SCROLL_STEP = 10;
+
+/**
+ * Guard against unbounded growth when the target preview has no overflow the reducer
+ * can observe (pure state machine — no render metrics). The view clamps to the real
+ * content length; this cap only keeps the state value sane.
+ */
+export const PREVIEW_SCROLL_MAX = 1000;
+
 export type QuestionnaireAction =
 	| { kind: "nav"; nextIndex: number; inputValue: string }
 	| { kind: "input_clear" }
@@ -34,6 +48,12 @@ export type QuestionnaireAction =
 	| { kind: "notes_forward"; data: string }
 	/** Flip `state.collapsed`. Always available, regardless of inner mode (see top intercept in `routeKey`). */
 	| { kind: "toggle_collapsed" }
+	/**
+	 * Scroll the focused option's preview by `delta` rows (PageUp/PageDown). Routed only
+	 * on question tabs where the focused row is a preview-bearing option; the reducer
+	 * clamps at 0 and the view layer clamps to the real overflow.
+	 */
+	| { kind: "preview_scroll"; delta: number }
 	| { kind: "ignore" };
 
 export interface QuestionnaireKeybindings {
@@ -346,6 +366,21 @@ export function routeKey(data: string, state: QuestionnaireState, runtime: Quest
 	}
 	if (kb.matches(data, KEYBIND_DOWN)) {
 		return nextNavOnDown(state, runtime);
+	}
+
+	// PageUp/PageDown scroll the focused option's preview when it overflows its height
+	// budget. Preview content exists only on single-select questions (the schema rejects
+	// previews for multiSelect), and the submit tab / notes / inputMode paths already
+	// returned above, so reaching this point means a question tab with the option list
+	// focused. The action fires unconditionally — a focused option without a preview, or
+	// a preview that fits, simply leaves `previewScroll` clamped at 0 by the reducer.
+	if (!q.multiSelect) {
+		if (matchesKey(data, Key.pageUp)) {
+			return { kind: "preview_scroll", delta: -PREVIEW_SCROLL_STEP };
+		}
+		if (matchesKey(data, Key.pageDown)) {
+			return { kind: "preview_scroll", delta: PREVIEW_SCROLL_STEP };
+		}
 	}
 
 	if (q.multiSelect) return routeMultiSelectTab(kb, data, state, runtime);

--- a/packages/rpiv-ask-user-question/state/questionnaire-session.ts
+++ b/packages/rpiv-ask-user-question/state/questionnaire-session.ts
@@ -51,6 +51,7 @@ function initialState(): QuestionnaireState {
 		submitChoiceIndex: 0,
 		notesDraft: "",
 		collapsed: false,
+		previewScroll: 0,
 	};
 }
 

--- a/packages/rpiv-ask-user-question/state/questionnaire-session.ts
+++ b/packages/rpiv-ask-user-question/state/questionnaire-session.ts
@@ -248,6 +248,7 @@ export class QuestionnaireSession {
 			currentItem: this.currentItem(),
 			items: this.itemsByTab[this.state.currentTab] ?? [],
 			collapseKey: this.collapseKey,
+			previewMaxScroll: this.previewMaxScrollFor(),
 		};
 	}
 
@@ -258,7 +259,25 @@ export class QuestionnaireSession {
 		};
 	}
 
-	private currentItem(): WrappingSelectItem | undefined {
+	/**
+	 * Last rendered frame’s scrollable preview overflow for the focused option row, or
+	 * undefined when the active pane’s last render was not for that row (a freshly
+	 * navigated row that has not rendered yet falls back to the default step in key-router).
+	 */
+	private previewMaxScrollFor(): number | undefined {
+		const s = this.state;
+		if (s.inputMode || s.notesVisible || s.collapsed) return undefined;
+		const q = this.questions[s.currentTab];
+		if (!q || q.multiSelect === true) return undefined;
+		const item = this.itemsByTab[s.currentTab]?.[s.optionIndex];
+		if (item?.kind !== "option") return undefined;
+		const preview = q.options[s.optionIndex]?.preview;
+		if (!preview || preview.length === 0) return undefined;
+		if (!this.viewAdapter.previewScrollRenderedFor(s.optionIndex, s.currentTab)) return undefined;
+		return this.viewAdapter.lastRenderedPreviewTotalHidden(s.currentTab);
+	}
+
+		private currentItem(): WrappingSelectItem | undefined {
 		const arr = this.itemsByTab[this.state.currentTab] ?? [];
 		return this.state.optionIndex < arr.length ? arr[this.state.optionIndex] : undefined;
 	}

--- a/packages/rpiv-ask-user-question/state/selectors/projections.ts
+++ b/packages/rpiv-ask-user-question/state/selectors/projections.ts
@@ -83,6 +83,7 @@ export const selectPreviewPaneProps: PerTabSelector<PreviewPaneProps> = (state, 
 	selectedIndex: state.optionIndex,
 	focused: ctx.activeView === "options",
 	inputMode: state.inputMode,
+	previewScroll: state.previewScroll,
 });
 
 export const selectTabBarProps: GlobalSelector<TabBarProps> = (state, ctx) => {

--- a/packages/rpiv-ask-user-question/state/state-reducer.ts
+++ b/packages/rpiv-ask-user-question/state/state-reducer.ts
@@ -1,6 +1,7 @@
 import type { QuestionAnswer, QuestionData, QuestionnaireResult } from "../tool/types.js";
 import type { WrappingSelectItem } from "../view/components/wrapping-select.js";
 import type { QuestionnaireAction } from "./key-router.js";
+import { PREVIEW_SCROLL_MAX } from "./key-router.js";
 import { ROW_INTENT_META } from "./row-intent.js";
 import type { QuestionnaireState } from "./state.js";
 
@@ -127,6 +128,7 @@ function switchTabResult(state: QuestionnaireState, nextTab: number, ctx: ApplyC
 		submitChoiceIndex: 0,
 		multiSelectChecked: syncMultiSelectFromAnswers(state.answers, ctx.questions, nextTab),
 		notesDraft: notesValue,
+		previewScroll: 0,
 	};
 	return {
 		state: transitioned,
@@ -170,7 +172,15 @@ const navHandler: Handler<"nav"> = (state, action, ctx) => {
 	const customDraftsByTab = state.inputMode
 		? setCustomDraft(state, state.currentTab, action.inputValue)
 		: state.customDraftsByTab;
-	const next: QuestionnaireState = { ...state, optionIndex: action.nextIndex, inputMode, customDraftsByTab };
+	// Moving to another row shows that row's preview from the top (or hides the preview
+	// entirely on non-option rows) — the previous option's scroll position must not leak.
+	const next: QuestionnaireState = {
+		...state,
+		optionIndex: action.nextIndex,
+		inputMode,
+		customDraftsByTab,
+		previewScroll: 0,
+	};
 	if (!inputMode) return { state: next, effects: [] };
 	return {
 		state: next,
@@ -258,7 +268,9 @@ const multiConfirmHandler: Handler<"multi_confirm"> = (state, action, ctx) => {
 const notesEnterHandler: Handler<"notes_enter"> = (state, _action, _ctx) => {
 	const value = notesValueFor(state, state.currentTab);
 	return {
-		state: { ...state, notesVisible: true, notesDraft: value },
+		// Entering the notes editor hides the preview — reset the scroll so reopening the
+		// options later (same row) shows the preview from the top again.
+		state: { ...state, notesVisible: true, notesDraft: value, previewScroll: 0 },
 		effects: [
 			{ kind: "set_notes_value", value },
 			{ kind: "set_notes_focused", focused: true },
@@ -303,6 +315,12 @@ const toggleCollapsedHandler: Handler<"toggle_collapsed"> = (s, _a, _c) => ({
 	state: { ...s, collapsed: !s.collapsed },
 	effects: [{ kind: "set_overlay_hidden", hidden: !s.collapsed }],
 });
+
+const previewScrollHandler: Handler<"preview_scroll"> = (state, action, _ctx) => {
+	const next = Math.max(0, Math.min(PREVIEW_SCROLL_MAX, state.previewScroll + action.delta));
+	if (next === state.previewScroll) return { state, effects: [] };
+	return { state: { ...state, previewScroll: next }, effects: [] };
+};
 const ignoreHandler: Handler<"ignore"> = (s, _a, _c) => ({ state: s, effects: [] });
 
 /**
@@ -327,6 +345,7 @@ const HANDLERS: { [K in QuestionnaireAction["kind"]]: Handler<K> } = {
 	submit: submitHandler,
 	submit_nav: submitNavHandler,
 	toggle_collapsed: toggleCollapsedHandler,
+	preview_scroll: previewScrollHandler,
 	ignore: ignoreHandler,
 };
 

--- a/packages/rpiv-ask-user-question/state/state.ts
+++ b/packages/rpiv-ask-user-question/state/state.ts
@@ -69,5 +69,12 @@ export interface QuestionnaireRuntime {
 	 * from `AskUserQuestionConfig.collapseKey` (or the package default). When `"off"`,
 	 * the collapse shortcut is disabled.
 	 */
+	/**
+	 * Max scrollable rows of the focused option’s preview (last rendered frame’s total
+	 * overflow; undefined when no preview overflow was rendered for the focused row).
+	 * Lets PageDown snap to the real bottom instead of overscrolling into phantom rows.
+	 */
+	previewMaxScroll: number | undefined;
+
 	collapseKey: string;
 }

--- a/packages/rpiv-ask-user-question/state/state.ts
+++ b/packages/rpiv-ask-user-question/state/state.ts
@@ -25,6 +25,14 @@ export interface QuestionnaireState {
 	/** Canonical mirror of the in-flight notes editor; runtime mirrors after `forward_notes_keystroke`. */
 	notesDraft: string;
 	/**
+	 * Scroll offset (rows) inside the focused option's preview block when its content
+	 * overflows the preview height budget. Reset to 0 on option navigation, tab
+	 * switches, and mode transitions; the view layer clamps it to the actual overflow
+	 * (the reducer cannot know rendered heights). PageUp/PageDown adjust it — see
+	 * `key-router.ts` and `preview-block-renderer.ts`.
+	 */
+	previewScroll: number;
+	/**
 	 * Collapsed mode: the questionnaire gets out of the way so the agent transcript behind
 	 * the bottom-anchored overlay becomes readable. Toggled by the configured collapse key
 	 * from any state; while true, every keystroke except cancel is swallowed (see

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-block-renderer.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-block-renderer.ts
@@ -53,6 +53,18 @@ export interface PreviewBlockRendererConfig {
 export class PreviewBlockRenderer {
 	private readonly theme: Theme;
 	private readonly cache: MarkdownContentCache;
+	/**
+	 * The scroll offset most recently used by `renderBlock` after clamping to the real
+	 * overflow (0 when the last render had no overflow). Read by `PreviewPane` so the
+	 * session can re-sync its canonical `previewScroll` to the actually rendered offset.
+	 */
+	lastClampedScroll = 0;
+	/**
+	 * Total overflow rows (content rows above the budget) of the last rendered block,
+	 * 0 when the last render fit. Read together with `lastClampedScroll` by the session
+	 * so PageDown can clamp to the real scrollable range (no phantom overscroll).
+	 */
+	lastTotalHidden = 0;
 
 	constructor(config: PreviewBlockRendererConfig) {
 		this.theme = config.theme;
@@ -109,6 +121,8 @@ export class PreviewBlockRenderer {
 		const raw = this.cache.bodyFor(optionIndex, maxInnerWidth);
 		const totalHidden = Math.max(0, raw.length - contentBudget);
 		const offset = totalHidden > 0 ? Math.max(0, Math.min(scrollOffset, totalHidden)) : 0;
+		this.lastClampedScroll = offset;
+		this.lastTotalHidden = totalHidden;
 		const contentLines = totalHidden > 0 ? raw.slice(offset, offset + contentBudget) : raw;
 		const canUp = offset > 0;
 		const canDown = offset < totalHidden;

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-block-renderer.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-block-renderer.ts
@@ -89,6 +89,11 @@ export class PreviewBlockRenderer {
 	 * `focused` and `notesVisible` together gate the affordance text (visible only when the
 	 * focused option carries a preview AND notes mode is inactive). The affordance row is ALWAYS
 	 * emitted (as an empty string when gated) so the row count is invariant.
+	 *
+	 * `scrollOffset` (rows, clamped to the actual overflow) scrolls the box body when the
+	 * rendered preview exceeds `contentBudget`: the bottom border then reports remaining
+	 * lines above/below (▲/▼) instead of the plain ✂ marker. Optional for caller convenience
+	 * and test ergonomics — absent means offset 0 (top).
 	 */
 	renderBlock(
 		width: number,
@@ -96,18 +101,24 @@ export class PreviewBlockRenderer {
 		mode: PreviewLayoutMode,
 		focused: boolean,
 		notesVisible: boolean,
+		scrollOffset = 0,
 	): string[] {
 		const contentBudget = contentBudgetFor(mode);
 		const maxInnerWidth = innerWidthFor(width);
 
 		const raw = this.cache.bodyFor(optionIndex, maxInnerWidth);
-		const truncated = raw.length > contentBudget;
-		const hidden = truncated ? raw.length - contentBudget : 0;
-		const contentLines = truncated ? raw.slice(0, contentBudget) : raw;
+		const totalHidden = Math.max(0, raw.length - contentBudget);
+		const offset = totalHidden > 0 ? Math.max(0, Math.min(scrollOffset, totalHidden)) : 0;
+		const contentLines = totalHidden > 0 ? raw.slice(offset, offset + contentBudget) : raw;
+		const canUp = offset > 0;
+		const canDown = offset < totalHidden;
 
 		const { boxWidth } = computeBoxDimensions(contentLines, maxInnerWidth);
 		const colorFn = (s: string) => this.theme.fg("accent", s);
-		const boxedLines = renderBorderedBox(contentLines, boxWidth, colorFn, hidden);
+		const boxedLines = renderBorderedBox(contentLines, boxWidth, colorFn, totalHidden, {
+			up: canUp,
+			down: canDown,
+		});
 
 		const showAffordance = focused && !notesVisible && this.cache.has(optionIndex);
 		const affordance = showAffordance

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-box-renderer.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-box-renderer.ts
@@ -31,13 +31,18 @@ export function stripFenceMarkers(lines: readonly string[]): string[] {
  * Layout per content row: `│` + ` ` + content padded to `contentInner` + ` ` + `│`,
  * where `contentInner = width - BORDER_HORIZONTAL_OVERHEAD - 2 * BORDER_INNER_PADDING_HORIZONTAL`.
  * Top/bottom dash runs span corner-to-corner (`width - BORDER_HORIZONTAL_OVERHEAD`). When
- * `hidden > 0`, the bottom-row dash run is replaced with ` ✂ ── N lines hidden ── ` (corners stay).
+ * `hidden > 0`, the bottom-row dash run is replaced with a scroll indicator
+ * (` ✂ ── N lines hidden ── ` was the original no-scroll form). `scroll.up` / `scroll.down`
+ * report whether more content exists above / below the current scroll window, and the
+ * indicator names the key that moves there (corners stay). Oversized indicators are
+ * truncated to the dash span with a trailing `…` rather than breaking the frame.
  */
 export function renderBorderedBox(
 	lines: readonly string[],
 	width: number,
 	colorFn: (s: string) => string,
 	hidden = 0,
+	scroll?: { up: boolean; down: boolean },
 ): string[] {
 	const dashSpan = Math.max(1, width - BORDER_HORIZONTAL_OVERHEAD);
 	const contentInner = Math.max(1, dashSpan - 2 * BORDER_INNER_PADDING_HORIZONTAL);
@@ -49,15 +54,30 @@ export function renderBorderedBox(
 		out.push(`${colorFn("│")}${pad}${padded}${pad}${colorFn("│")}`);
 	}
 	if (hidden > 0) {
-		const indicator = ` ✂ ── ${hidden} lines hidden ── `;
+		const up = scroll?.up === true;
+		const down = scroll?.down === true;
+		const indicator =
+			up && down
+				? ` ▲ ${hidden} lines hidden · PgUp/PgDn ▼ `
+				: down
+					? ` ✂ ${hidden} lines hidden · PgDn ▼ `
+					: ` ▲ PgUp · ${hidden} lines hidden `;
 		const space = dashSpan - indicator.length;
 		const leftFill = "─".repeat(Math.max(0, Math.floor(space / 2)));
-		const rightFill = "─".repeat(Math.max(0, dashSpan - leftFill.length - indicator.length));
-		out.push(colorFn(`└${leftFill}${indicator}${rightFill}┘`));
+		const rightFill = "─".repeat(Math.max(0, space - leftFill.length));
+		// Oversized indicator (very narrow frame): truncate with an ellipsis instead of
+		// breaking the box — every row below must stay within `width` columns.
+		const inner =
+			space >= 0 ? `${leftFill}${indicator}${rightFill}` : `${indicator.slice(0, Math.max(0, dashSpan - 1))}…`;
+		out.push(colorFn(`└${inner}┘`));
 	} else {
-		out.push(colorFn(`└${"─".repeat(dashSpan)}┘`));
+		out.push(colorFn(`└${repeatDash(dashSpan)}┘`));
 	}
 	return out;
+}
+
+function repeatDash(n: number): string {
+	return "─".repeat(Math.max(0, n));
 }
 
 /**

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-pane.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-pane.ts
@@ -88,6 +88,17 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 	private readonly previewBlock: PreviewBlockRenderer;
 	private props: PreviewPaneProps;
 	/**
+	 * Render-report channel for scroll de-accumulation: after every preview render,
+	 * `lastRenderedScroll` holds the offset the preview block actually used (clamped)
+	 * and `renderedScrollForIndex` the option index that offset belongs to. The session
+	 * re-syncs its canonical `previewScroll` to this pair before each key dispatch, so
+	 * PageDown/PageUp overscroll past the end can never accumulate phantom rows.
+	 */
+	lastRenderedScroll = 0;
+	renderedScrollForIndex = -1;
+	/** Total overflow rows of the last rendered preview (see PreviewBlockRenderer.lastTotalHidden). */
+	lastTotalHidden = 0;
+	/**
 	 * Cross-tab max left-width getter. Set exactly once by `buildQuestionnaire.injectGlobalLeftWidth`
 	 * before any render. Initialized to a throwing sentinel so missing injection is a hard fail
 	 * rather than a silent fallback to a magic constant — render is illegal until injected.
@@ -123,21 +134,42 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 		this.optionListView.invalidate();
 	}
 
-	render(width: number): string[] {
-		if (this.question.multiSelect === true) return this.optionListView.render(width);
+		render(width: number): string[] {
+		if (this.question.multiSelect === true) {
+			this.lastRenderedScroll = 0;
+			this.renderedScrollForIndex = -1;
+			this.lastTotalHidden = 0;
+			return this.optionListView.render(width);
+		}
 		// Spec: hide the preview pane entirely when no option carries a `preview`.
-		if (!this.previewBlock.hasAnyPreview()) return this.optionListView.render(width);
+		if (!this.previewBlock.hasAnyPreview()) {
+			this.lastRenderedScroll = 0;
+			this.renderedScrollForIndex = -1;
+			this.lastTotalHidden = 0;
+			return this.optionListView.render(width);
+		}
 		// `inputMode` (typing on the "other" custom-answer row): the preview is irrelevant —
 		// the row sits at index `options.length`, out of bounds for any option's preview — so
 		// render the option list at the full pane width instead of the cramped left column.
 		// Side-by-side + preview block resume verbatim on nav-away (inputMode clears).
-		if (this.props.inputMode) return this.optionListView.render(width);
+		if (this.props.inputMode) {
+			this.lastRenderedScroll = 0;
+			this.renderedScrollForIndex = -1;
+			this.lastTotalHidden = 0;
+			return this.optionListView.render(width);
+		}
 
 		const mode = decideLayout(this.getTerminalWidth(), width);
-		if (mode === "side-by-side") return this.renderSideBySide(width, mode);
+		if (mode === "side-by-side") {
+			const out = this.renderSideBySide(width, mode);
+			this.lastRenderedScroll = this.previewBlock.lastClampedScroll;
+			this.lastTotalHidden = this.previewBlock.lastTotalHidden;
+			this.renderedScrollForIndex = this.props.selectedIndex;
+			return out;
+		}
 
 		// Stacked: options + blank gap + preview block.
-		return [
+		const out = [
 			...this.optionListView.render(width),
 			...Array(STACKED_GAP_ROWS).fill(""),
 			...this.previewBlock.renderBlock(
@@ -149,6 +181,9 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 				this.props.previewScroll ?? 0,
 			),
 		];
+		this.lastRenderedScroll = this.previewBlock.lastClampedScroll;
+		this.renderedScrollForIndex = this.props.selectedIndex;
+		return out;
 	}
 
 	focusedItemRowRange(width: number): [number, number] {

--- a/packages/rpiv-ask-user-question/view/components/preview/preview-pane.ts
+++ b/packages/rpiv-ask-user-question/view/components/preview/preview-pane.ts
@@ -55,6 +55,11 @@ export interface PreviewPaneProps {
 	 * early-returns below so the inline input isn't cramped into the narrow left column.
 	 */
 	inputMode: boolean;
+	/**
+	 * Scroll offset inside the focused option's preview block (rows). Optional for
+	 * construction-time compatibility — absent means "from the top" (offset 0).
+	 */
+	previewScroll?: number;
 }
 
 export interface PreviewPaneConfig {
@@ -96,7 +101,7 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 		this.getTerminalWidth = config.getTerminalWidth;
 		this.optionListView = config.optionListView;
 		this.previewBlock = config.previewBlock;
-		this.props = { notesVisible: false, selectedIndex: 0, focused: false, inputMode: false };
+		this.props = { notesVisible: false, selectedIndex: 0, focused: false, inputMode: false, previewScroll: 0 };
 	}
 
 	setGlobalLeftWidth(getter: (paneWidth: number) => number): void {
@@ -141,6 +146,7 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 				mode,
 				this.props.focused,
 				this.props.notesVisible,
+				this.props.previewScroll ?? 0,
 			),
 		];
 	}
@@ -196,7 +202,7 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 		const adaptiveLeft = this.getAdaptiveLeft(width);
 		const { leftWidth, rightWidth, gap } = columnWidths(width, adaptiveLeft);
 		const leftLines = this.optionListView.render(leftWidth);
-		const rightLines = this.renderPaddedPreviewLines(rightWidth, mode);
+		const rightLines = this.renderPaddedPreviewLines(rightWidth, mode, this.props.previewScroll ?? 0);
 		const rows = Math.max(leftLines.length, rightLines.length);
 		const gapStr = " ".repeat(gap);
 		const out: string[] = [];
@@ -211,7 +217,7 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 		return out;
 	}
 
-	private renderPaddedPreviewLines(colWidth: number, mode: PreviewLayoutMode): string[] {
+	private renderPaddedPreviewLines(colWidth: number, mode: PreviewLayoutMode, scrollOffset: number): string[] {
 		const inner = Math.max(1, colWidth - PREVIEW_PADDING_LEFT);
 		const contentLines = this.previewBlock.renderBlock(
 			inner,
@@ -219,6 +225,7 @@ export class PreviewPane implements StatefulView<PreviewPaneProps>, Component {
 			mode,
 			this.props.focused,
 			this.props.notesVisible,
+			scrollOffset,
 		);
 		const boxWidth = Math.max(1, visibleWidth(contentLines[0] ?? ""));
 		const boxAlignedPad = Math.max(PREVIEW_PADDING_LEFT, colWidth - boxWidth);

--- a/packages/rpiv-ask-user-question/view/props-adapter.ts
+++ b/packages/rpiv-ask-user-question/view/props-adapter.ts
@@ -99,6 +99,33 @@ export class QuestionnairePropsAdapter {
 	}
 
 	/**
+	 * Render-report channel for the session's preview-scroll de-accumulation. Returns the
+	 * preview offset the ACTIVE pane actually rendered last frame (clamped to the real
+	 * overflow), or `undefined` when no tab exists. The session calls this before each key
+	 * dispatch and re-syncs its canonical `previewScroll` when the rendered offset belongs
+	 * to the currently focused option (see `previewScrollRenderedFor`).
+	 */
+	lastRenderedPreviewScroll(currentTab: number): number | undefined {
+		const pane = this.tabsByIndex[selectActivePreviewPaneIndex(currentTab, this.questions.length)]?.preview ??
+			this.tabsByIndex[0]?.preview;
+		return pane?.lastRenderedScroll;
+	}
+
+	/** Whether the active pane's last render was for the given option row (see PreviewPane docs). */
+		/** Total overflow rows of the active pane’s last rendered preview (clamped-to-real helper for PageDown). */
+	lastRenderedPreviewTotalHidden(currentTab: number): number | undefined {
+		const pane = this.tabsByIndex[selectActivePreviewPaneIndex(currentTab, this.questions.length)]?.preview ??
+			this.tabsByIndex[0]?.preview;
+		return pane?.lastTotalHidden;
+	}
+
+	previewScrollRenderedFor(optionIndex: number, currentTab: number): boolean {
+		const pane = this.tabsByIndex[selectActivePreviewPaneIndex(currentTab, this.questions.length)]?.preview ??
+			this.tabsByIndex[0]?.preview;
+		return pane?.renderedScrollForIndex === optionIndex;
+	}
+
+	/**
 	 * Invalidates every owned renderable. Called by the session in place of
 	 * the old `dialog.invalidate()` forwarding chain — DialogView no longer
 	 * reaches into siblings (tabBar, notesInput, activePreviewPane).


### PR DESCRIPTION
Closes #210

## Summary

When an option `preview` is taller than the preview height budget (`MAX_PREVIEW_HEIGHT_SIDE_BY_SIDE = 20` / `STACKED = 15`, minus border + affordance overhead → ~16 / ~11 content rows), the extra rows were silently cut with only a static ` ✂ ── N lines hidden ── ` bottom border and no way to read them. This PR makes the preview box **scrollable with `PageUp` / `PageDown`**, in both the side-by-side (≥100 cols) and stacked layouts, and turns the bottom border into a live scroll indicator.

## Changes

- **Keys**: `PageUp` / `PageDown` scroll the focused option's preview by ~one screenful (`PREVIEW_SCROLL_STEP = 10`); `↑`/`↓` keep their option-navigation meaning. Scroll position resets on option navigation, tab switches, and opening the notes editor. (Not routed on multi-select questions or the Submit tab — previews only exist on single-select options.)
- **State**: new `state.previewScroll` (canonical), reset in `nav` / `tab_switch` / `notes_enter` handlers, moved by a new `preview_scroll` reducer action (clamped ≥ 0).
- **Rendering**: `preview-block-renderer` slices `[offset, offset + budget)`; `preview-box-renderer` bottom border reports scroll state:
  - top: ` ✂ N lines hidden · PgDn ▼ `
  - mid: ` ▲ N lines hidden · PgUp/PgDn ▼ `
  - bottom: ` ▲ PgUp · N lines hidden `
  (oversized indicators truncate with `…` instead of breaking the frame)
- **No phantom overscroll**: the reducer is pure and can't know rendered heights, so the render layer reports the last frame's clamped offset and total overflow back (`PreviewBlockRenderer.lastClampedScroll` / `lastTotalHidden` → `PreviewPane` → `QuestionnairePropsAdapter`). PageDown snaps to the real bottom (`min(STEP, max − offset)`) and further presses at the end are swallowed — the first PageUp after the bottom immediately moves the view. PageUp can't overscroll (offset only decreases toward the reducer's 0 clamp).
- **Docs**: `docs/keyboard.md` gained the keys table entry and a "Preview scrolling" section.

## Files (10)

`state/state.ts` · `state/key-router.ts` · `state/state-reducer.ts` · `state/questionnaire-session.ts` · `state/selectors/projections.ts` · `view/props-adapter.ts` · `view/components/preview/preview-pane.ts` · `view/components/preview/preview-block-renderer.ts` · `view/components/preview/preview-box-renderer.ts` · `docs/keyboard.md`

## Verification

Tested end-to-end in the real TUI questionnaire with 20–60 line previews in both layouts: rendering, scrolling both directions, indicator transitions, reset-on-navigation, and the end-of-content behavior (repeated PageDown inert, one PageUp moves). Happy to adjust keys, step size, or indicator wording.
