### PR TITLE
fix(tool): reject undeclared fields in questionnaire schemas (strict Type.Object)

### DIFF
--- a/packages/rpiv-ask-user-question/tool/types.ts
+++ b/packages/rpiv-ask-user-question/tool/types.ts
@@ -52,7 +52,7 @@ export const OptionSchema = Type.Object({
 				"Optional preview content rendered when this option is focused. Use for mockups, code snippets, or visual comparisons that help users compare options. See the tool description for the expected content format.",
 		}),
 	),
-});
+}, { additionalProperties: false });
 
 export const QuestionSchema = Type.Object({
 	question: Type.String({
@@ -76,7 +76,7 @@ export const QuestionSchema = Type.Object({
 				"Set to true to allow the user to select multiple options instead of just one. Use when choices are not mutually exclusive.",
 		}),
 	),
-});
+}, { additionalProperties: false });
 
 export const QuestionsSchema = Type.Array(QuestionSchema, {
 	minItems: 1,
@@ -86,7 +86,7 @@ export const QuestionsSchema = Type.Array(QuestionSchema, {
 
 export const QuestionParamsSchema = Type.Object({
 	questions: QuestionsSchema,
-});
+}, { additionalProperties: false });
 
 export type OptionData = Static<typeof OptionSchema>;
 export type QuestionData = Static<typeof QuestionSchema>;


### PR DESCRIPTION
Closes #212

## Context

This hardening was **discovered while investigating the preview-truncation issue #210** (implemented in #211): an agent placing the `preview` string on the question object instead of on an option passed schema validation silently — the undeclared key was tolerated by the default non-strict `Type.Object` and stripped somewhere in the validation/transport layer, so the questionnaire components received zero previews with **no error anywhere**. The only way to diagnose was auditing the raw tool-call JSON.

## Change

Add `{ additionalProperties: false }` to the three authored object schemas in `tool/types.ts`:

- `OptionSchema`
- `QuestionSchema`
- `QuestionParamsSchema`

Undeclared fields now fail validation loudly and the error bounces back to the model, which retries with the correct shape — turning a ~1-hour silent failure into an automatic retry. Structural violations (missing required, `minItems`, wrong types) already behaved this way; this closes the "extra fields" gap.

## Verification

Locally tested against the real tool after the change:
- preview placed at `questions[0].preview` (wrong level) → `Validation failed ... questions.0: must not have additional properties` ✅ rejected loudly
- preview placed at `questions[0].options[0].preview` (correct) → renders normally ✅ no false positives

No legitimate caller sends undeclared keys, so compatibility risk is minimal.

## Files

`tool/types.ts` (+3 lines)
